### PR TITLE
bench: surface in-stream error frames and reject buffered flushes

### DIFF
--- a/bench/atlas_bench/client.py
+++ b/bench/atlas_bench/client.py
@@ -38,7 +38,8 @@ _OOM_PATTERNS = re.compile(
 _CONTEXT_PATTERNS = re.compile(
     r"maximum context length|context length exceeded|longer than the maximum|"
     r"exceeds the maximum|reduce the length|too many tokens|context window|"
-    r"n_ctx|prompt is too long",
+    r"n_ctx|prompt is too long|greater than the context length|"
+    r"provide a shorter input",
     re.IGNORECASE,
 )
 _REFUSAL_PATTERNS = re.compile(
@@ -47,6 +48,10 @@ _REFUSAL_PATTERNS = re.compile(
     re.IGNORECASE,
 )
 _TIMEOUT_PATTERNS = re.compile(r"timed out|timeout", re.IGNORECASE)
+
+#: Shortest span between the first and last streamed delta that counts as an observed decode
+#: interval. Anything faster is a buffered flush, not decoding (see ``measured_decode``).
+MIN_DECODE_WINDOW_S = 0.001
 
 
 def utc_now() -> str:
@@ -146,8 +151,16 @@ class RequestResult:
         rate was observed, and dividing by that near-zero window produces a four-digit tok/s
         that is pure artifact. Two content deltas is the minimum for the question to mean
         anything.
+
+        Counting deltas is not enough on its own. A server that buffers a short answer and
+        flushes it whole emits several deltas microseconds apart after a long time to first
+        token — six deltas inside half a millisecond, which reads as 9,000 tok/s. No engine
+        decodes tokens that fast, so a sub-millisecond window is the same non-measurement as
+        a single delta, however many deltas it contains.
         """
-        return len(self.chunk_times) >= 2
+        if len(self.chunk_times) < 2:
+            return False
+        return self.chunk_times[-1] - self.chunk_times[0] >= MIN_DECODE_WINDOW_S
 
     @property
     def tpot_s(self) -> float | None:
@@ -357,6 +370,14 @@ class ChatClient:
                         chunk = json.loads(payload)
                     except json.JSONDecodeError as exc:
                         return self._fail(result, response.status_code, f"malformed chunk: {exc}")
+                    # Not every engine reports a failure with a failing status. LM Studio
+                    # answers 200 and then writes the error into the stream as an `event:
+                    # error` frame, so a prompt that overflows the context window arrives
+                    # here rather than in the status branch above. Dropping it would leave
+                    # the request looking like an empty answer instead of the refusal it is.
+                    if error := chunk.get("error"):
+                        message = error.get("message") if isinstance(error, dict) else str(error)
+                        return self._fail(result, response.status_code, message or "stream error")
                     if chunk.get("usage"):
                         usage = chunk["usage"]
                     for choice in chunk.get("choices") or []:

--- a/bench/tests/conftest.py
+++ b/bench/tests/conftest.py
@@ -58,6 +58,7 @@ class FakeOpenAIServer:
         fail_body: str = "internal error",
         report_usage: bool = True,
         reject_stream_options: bool = False,
+        stream_error: str | None = None,
     ) -> None:
         self.model = model
         self.chunks = chunks
@@ -72,6 +73,8 @@ class FakeOpenAIServer:
         self.report_usage = report_usage
         #: LM Studio-style: reject the request outright, without naming the field.
         self.reject_stream_options = reject_stream_options
+        #: LM Studio-style: answer 200, then report the failure inside the stream.
+        self.stream_error = stream_error
         self.requests: list[dict[str, Any]] = []
 
     # ------------------------------------------------------------------ wiring
@@ -115,6 +118,16 @@ class FakeOpenAIServer:
         return [w + (" " if i < len(words) - 1 else "") for i, w in enumerate(words)]
 
     def _stream(self, body: dict[str, Any], text: str | None) -> httpx.Response:
+        if self.stream_error is not None:
+            frames = [
+                b"event: error\n" + _frame({"error": {"message": self.stream_error}}),
+                b"data: [DONE]\n\n",
+            ]
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                stream=_SSEStream(frames, self.chunk_delay_s),
+            )
         pieces = self._pieces(text)
         frames: list[bytes] = []
         for piece in pieces:

--- a/bench/tests/test_client.py
+++ b/bench/tests/test_client.py
@@ -20,6 +20,14 @@ MESSAGES = [{"role": "user", "content": "hello"}]
         (400, "No available memory for the cache blocks", None, "oom"),
         (400, "This model's maximum context length is 8192 tokens", None, "context-overflow"),
         (400, "Please reduce the length of the messages", None, "context-overflow"),
+        (
+            200,
+            "The number of tokens to keep from the initial prompt is greater than the "
+            "context length. Try to load the model with a larger context length, or "
+            "provide a shorter input",
+            None,
+            "context-overflow",
+        ),
         (500, "internal server error", None, "http-5xx"),
         (404, "model not found", None, "http-4xx"),
         (429, "rate limited", None, "http-4xx"),
@@ -96,6 +104,37 @@ async def test_a_single_chunk_response_reports_no_decode_rate() -> None:
     assert result.e2e_s is not None
 
 
+async def test_a_buffered_flush_is_not_a_decode_measurement() -> None:
+    """Several deltas arriving at once is a flush, not a decode interval.
+
+    LM Studio buffers short answers behind a long prefill: at a 65k-token context the six
+    tokens of the answer landed inside half a millisecond after a 40s time to first token,
+    which the delta count alone accepted as 9,197 tok/s — past what the memory bandwidth of
+    the machine allows, and enough to fail plausibility on an otherwise good run.
+    """
+    server = FakeOpenAIServer(chunks=6, chunk_delay_s=0)
+    async with ChatClient("http://fake", "fake-model", transport=server.transport) as client:
+        result = await client.chat_stream(MESSAGES, request_id="r1", max_tokens=16)
+
+    assert result.ok
+    assert len(result.chunk_times) == 6, "the deltas are still counted as tokens"
+    assert result.measured_decode is False
+    assert result.decode_tok_s is None
+    assert result.tpot_s is None
+    assert result.ttft_s is not None
+
+
+async def test_a_real_decode_interval_is_still_measured() -> None:
+    """Deltas spread over a real interval keep producing a decode rate."""
+    server = FakeOpenAIServer(chunks=6, chunk_delay_s=0.004)
+    async with ChatClient("http://fake", "fake-model", transport=server.transport) as client:
+        result = await client.chat_stream(MESSAGES, request_id="r1", max_tokens=16)
+
+    assert result.measured_decode is True
+    assert result.decode_tok_s is not None
+    assert result.tpot_s is not None
+
+
 async def test_stream_without_usage_falls_back_to_counting_deltas() -> None:
     """An engine that never reports usage still produces a token count, marked as such."""
     server = FakeOpenAIServer(report_usage=False, chunks=5)
@@ -140,6 +179,27 @@ async def test_a_real_400_is_not_retried_forever() -> None:
     assert not result.ok
     assert result.error_category == "context-overflow"
     assert len(server.requests) == 2, "exactly one retry, then the real error"
+
+
+async def test_an_error_frame_inside_a_200_stream_is_surfaced() -> None:
+    """LM Studio answers 200 and puts the failure in the stream; it is still a failure.
+
+    An overlong prompt comes back as `event: error` with the reason in the payload. Ignoring
+    frames without `choices` used to reduce this to "stream produced no content deltas",
+    which reads as a model that answered nothing rather than a request that was refused, and
+    threw away the one sentence saying why.
+    """
+    overflow = (
+        "The number of tokens to keep from the initial prompt is greater than the context "
+        "length. Try to load the model with a larger context length, or provide a shorter input"
+    )
+    server = FakeOpenAIServer(stream_error=overflow)
+    async with ChatClient("http://fake", "fake-model", transport=server.transport) as client:
+        result = await client.chat_stream(MESSAGES, request_id="r1")
+
+    assert not result.ok
+    assert result.error_category == "context-overflow"
+    assert result.error_message == overflow
 
 
 async def test_http_error_is_captured_not_raised() -> None:


### PR DESCRIPTION
Two harness blind spots, both found while running the 128k long-context workloads against LM Studio for the `lmstudio@0.4.21/google/gemma-4-E2B-it/mlx-4bit/apple-m2-max-32gb` cell.

### An error inside a 200 stream was silently dropped

LM Studio answers an overlong prompt with HTTP 200 and writes the failure into the stream:

```
event: error
data: {"error":{"message":"The number of tokens to keep from the initial prompt is greater than the context length. …"}}
```

The stream loop parsed that frame, found no `choices`, and moved on — so all 16 requests of `prefill-128k-v1` and `longctx-needle-128k-v1` were recorded as `malformed-output` / "stream produced no content deltas" with `error: null`. That reads as a model that answered nothing, when in fact the request was refused, and the one sentence explaining why was thrown away.

The frame is now surfaced as a failure carrying the server's own message, and `_CONTEXT_PATTERNS` learned LM Studio's phrasing so it classifies as `context-overflow` rather than a generic error. Same three workloads, after the fix:

| before | after |
|---|---|
| `malformed-output` · "stream produced no content deltas" | `context-overflow` · "The number of tokens to keep from the initial prompt is greater than the context length…" |

The harness then emits its own "requests exceeded the model's context window" gotcha, which it could only reach with the category right.

### A buffered flush counted as a decode interval

`measured_decode` required two content deltas, which a buffered short answer passes. At the 65536 step of `longctx-depth-sweep-v1` the six answer tokens all landed within half a millisecond of each other after a 40 s prefill, giving a per-request decode rate of **9,197 tok/s** — about 30× the 306.6 tok/s the machine's memory bandwidth allows for these weights, and a `bandwidth-ceiling-exceeded` plausibility **error** on an otherwise clean run.

A sub-millisecond window is the same non-measurement as a single delta no matter how many deltas it contains, so `measured_decode` now also requires the span between first and last delta to clear 1 ms. That level reports a null decode rate instead. Token counts, TTFT and e2e are untouched — they were real measurements either way.

### Verification

`uv run pytest` — 421 passed, 3 skipped. Three new tests: the error-frame path, the buffered flush, and a real decode interval still being measured (so the new guard cannot quietly null out good data).

Re-running the affected workloads against the live server turns 27 result files from `2 error(s)` to **`0 error(s)`** under `atlas-bench validate`.