### PR TITLE
registry: sparkinfer engine, the REAP-216 DeepSeek derivative, and corrected V4-Flash figures

### DIFF
--- a/engines/sparkinfer/meta.json
+++ b/engines/sparkinfer/meta.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "id": "sparkinfer",
+  "name": "SparkInfer",
+  "repo": "https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-One-DGX-Spark",
+  "docs": "https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-One-DGX-Spark#readme",
+  "description": "A vLLM-derived stack purpose-built to run DeepSeek-V4-Flash on a single 128 GB DGX Spark: EXL3 trellis expert kernels, a rewritten MLA prefill, and the dspark speculative path. Shipped as a pinned container plus a repository of patch files, so the git commit \u2014 not a released version number \u2014 identifies the build.",
+  "api": "openai",
+  "default_port": 8888,
+  "platforms": [
+    "linux-cuda"
+  ],
+  "quant_formats": [
+    "exl3",
+    "nvfp4",
+    "fp8"
+  ],
+  "install": [
+    {
+      "method": "docker",
+      "image": "ghcr.io/0xsero/deepseek-v4-flash-0731-spark-sparkinfer",
+      "arch": [
+        "aarch64"
+      ],
+      "notes": "compose.yml pins the image by digest and bind-mounts the repository's patch files over it, so the image alone does not define the stack. Check out the commit named by the engine version and run ./start.sh."
+    }
+  ],
+  "serve": {
+    "command_template": "./start.sh",
+    "model_ref": "hf_id",
+    "flag_style": "{NAME}={value}",
+    "bool_style": "{NAME}=1",
+    "bool_false_style": "{NAME}=0",
+    "env_style": "{NAME}={value}",
+    "notes": "Every knob is an environment variable read by start.sh, which composes the docker run. Registry parameter names are lower-case and hyphenated; {NAME} renders them as the upper-case underscored environment variable."
+  },
+  "health": {
+    "path": "/health",
+    "models_path": "/v1/models",
+    "ready_timeout_s": 7200
+  },
+  "bench_harness": "atlas-bench",
+  "drop_params": [
+    "model-repo",
+    "model-revision",
+    "served-model-name",
+    "serving-host",
+    "serving-port",
+    "hf-cache",
+    "hf-token",
+    "remote-host",
+    "remote-user",
+    "remote-share-dir",
+    "mia-mount",
+    "startup-wait",
+    "poll-interval",
+    "local-min-free-gib",
+    "share-min-free-gib",
+    "verify-model-checksums"
+  ],
+  "param_aliases": {},
+  "version_source": {
+    "kind": "manual",
+    "repo": "MiaAI-Lab/DeepSeek-v4-Flash-One-DGX-Spark",
+    "version_scheme": "opaque"
+  },
+  "versions_available": [
+    "960652b"
+  ],
+  "links": {
+    "image": "https://ghcr.io/0xsero/deepseek-v4-flash-0731-spark-sparkinfer"
+  },
+  "notes": "There are no releases or tags: the stack is a pinned image plus a working tree of patches, so a version here is the short git commit of the configuration repository that produced the run. A fork's commit is a valid version as long as it is public and reachable \u2014 record the exact repository in the run's provenance, because forks diverge in their defaults."
+}

--- a/engines/sparkinfer/versions/960652b.json
+++ b/engines/sparkinfer/versions/960652b.json
@@ -1,0 +1,236 @@
+{
+  "schema_version": 1,
+  "engine_id": "sparkinfer",
+  "version": "960652b",
+  "released": "2026-08-24",
+  "extraction_method": "hand-seeded",
+  "extracted_at": "2026-08-24T18:00:00Z",
+  "source": "start.sh of MiaAI-Lab/DeepSeek-v4-Flash-One-DGX-Spark at the commit this version names",
+  "notes": "Defaults are the upstream repository's, not any operator's fork. That is deliberate: canonicalization drops a value that equals the default, so if a fork's local override were seeded here the override would vanish from the fingerprint. ABLATE in particular defaults to 0 upstream, so a run with refusal-direction ablation on carries ABLATE=1 explicitly. Parameter names are recorded lower-case and hyphenated to satisfy the registry id pattern; each help string names the upper-case environment variable start.sh actually reads.",
+  "params": [
+    {
+      "name": "max-model-len",
+      "type": "int",
+      "default": 384000,
+      "help": "Context window the KV pool is sized for. Environment variable: MAX_MODEL_LEN.",
+      "group": "memory",
+      "impact": "high"
+    },
+    {
+      "name": "max-num-seqs",
+      "type": "int",
+      "default": 1,
+      "help": "Concurrent sequences admitted. 1 is a single-deep-context profile; raise it for serving. Environment variable: MAX_NUM_SEQS.",
+      "group": "batching",
+      "impact": "high"
+    },
+    {
+      "name": "max-num-batched-tokens",
+      "type": "int",
+      "default": 8224,
+      "help": "Also sizes and locks the b12x MLA workspace after warmup; lowering it to recover KV crashes later on a wide attend. Environment variable: MAX_NUM_BATCHED_TOKENS.",
+      "group": "batching",
+      "impact": "high"
+    },
+    {
+      "name": "gpu-memory-utilization",
+      "type": "float",
+      "default": 0.94,
+      "help": "Fraction of the unified 128 GB the engine may claim. Environment variable: GPU_MEMORY_UTILIZATION.",
+      "group": "memory",
+      "impact": "high"
+    },
+    {
+      "name": "mode",
+      "type": "str",
+      "default": "dspark",
+      "help": "Inference path: dspark enables the speculative draft-expert route. Environment variable: MODE.",
+      "group": "model",
+      "impact": "high"
+    },
+    {
+      "name": "ablate",
+      "type": "bool",
+      "default": false,
+      "help": "Runtime refusal-direction ablation. Changes what the model will answer, so it changes eval scores; it is not a performance knob. Environment variable: ABLATE.",
+      "group": "model",
+      "impact": "high"
+    },
+    {
+      "name": "dsv4-ablate-lambda",
+      "type": "float",
+      "default": 3.5,
+      "help": "Strength of the ablation direction. Only read when ABLATE=1. Environment variable: DSV4_ABLATE_LAMBDA.",
+      "group": "model",
+      "impact": "high"
+    },
+    {
+      "name": "dsv4-ablate-layers",
+      "type": "str",
+      "default": "10-42",
+      "help": "Layer range the ablation direction is applied to. Only read when ABLATE=1. Environment variable: DSV4_ABLATE_LAYERS.",
+      "group": "model",
+      "impact": "high"
+    },
+    {
+      "name": "dspark-tokens",
+      "type": "int",
+      "default": 5,
+      "help": "Speculative tokens proposed per step. Environment variable: DSPARK_TOKENS.",
+      "group": "speculative",
+      "impact": "high"
+    },
+    {
+      "name": "dspark-draft-experts",
+      "type": "int",
+      "default": 64,
+      "help": "Experts the draft pass may route to. Environment variable: DSPARK_DRAFT_EXPERTS.",
+      "group": "speculative",
+      "impact": "high"
+    },
+    {
+      "name": "dspark-dynamic-draft-depth",
+      "type": "bool",
+      "default": false,
+      "help": "Vary draft depth with acceptance rate. Environment variable: DSPARK_DYNAMIC_DRAFT_DEPTH.",
+      "group": "speculative",
+      "impact": "medium"
+    },
+    {
+      "name": "dspark-dynamic-draft-depth-window",
+      "type": "int",
+      "default": 8,
+      "help": "Window over which acceptance is measured for dynamic draft depth. Environment variable: DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW.",
+      "group": "speculative",
+      "impact": "low"
+    },
+    {
+      "name": "dspark-structured-experts-per-category",
+      "type": "int",
+      "default": 32,
+      "help": "Experts held per output category by the structured router. Environment variable: DSPARK_STRUCTURED_EXPERTS_PER_CATEGORY.",
+      "group": "speculative",
+      "impact": "medium"
+    },
+    {
+      "name": "dspark-capacity",
+      "type": "int",
+      "default": 0,
+      "help": "Draft capacity override; 0 lets the engine choose. Environment variable: DSPARK_CAPACITY.",
+      "group": "speculative",
+      "impact": "low"
+    },
+    {
+      "name": "long-prefill-token-threshold",
+      "type": "int",
+      "default": 1024,
+      "help": "Chunk size above which a prefill is split for fairness; 0 disables. Caps prefill throughput when set below MAX_NUM_BATCHED_TOKENS. Environment variable: LONG_PREFILL_TOKEN_THRESHOLD.",
+      "group": "batching",
+      "impact": "high"
+    },
+    {
+      "name": "max-num-partial-prefills",
+      "type": "int",
+      "default": 0,
+      "help": "Partial prefills allowed in flight; 0 disables. Environment variable: MAX_NUM_PARTIAL_PREFILLS.",
+      "group": "batching",
+      "impact": "medium"
+    },
+    {
+      "name": "kv-offload-gb",
+      "type": "int",
+      "default": 0,
+      "help": "KV cache offloaded to host memory. Environment variable: KV_OFFLOAD_GB.",
+      "group": "memory",
+      "impact": "high"
+    },
+    {
+      "name": "kv-fp8-rope",
+      "type": "bool",
+      "default": false,
+      "help": "Store RoPE-applied keys in fp8. Environment variable: KV_FP8_ROPE.",
+      "group": "memory",
+      "impact": "medium"
+    },
+    {
+      "name": "kv-record",
+      "type": "str",
+      "default": "stock432",
+      "help": "KV layout record the pool is built from. Environment variable: KV_RECORD.",
+      "group": "memory",
+      "impact": "medium"
+    },
+    {
+      "name": "vllm-use-simple-kv-offload",
+      "type": "bool",
+      "default": false,
+      "help": "Use the simple offload path rather than the paged one. Environment variable: VLLM_USE_SIMPLE_KV_OFFLOAD.",
+      "group": "memory",
+      "impact": "medium"
+    },
+    {
+      "name": "vllm-use-b12x-wo-projection",
+      "type": "bool",
+      "default": true,
+      "help": "b12x MLA output projection kernel. Environment variable: VLLM_USE_B12X_WO_PROJECTION.",
+      "group": "kernels",
+      "impact": "medium"
+    },
+    {
+      "name": "vllm-dsv4-padded-nvfp4",
+      "type": "bool",
+      "default": false,
+      "help": "Pad NVFP4 tensors for the fused kernel. Environment variable: VLLM_DSV4_PADDED_NVFP4.",
+      "group": "kernels",
+      "impact": "medium"
+    },
+    {
+      "name": "max-cudagraph-capture-size",
+      "type": "int",
+      "default": 24,
+      "help": "Largest batch captured into a CUDA graph. Environment variable: MAX_CUDAGRAPH_CAPTURE_SIZE.",
+      "group": "kernels",
+      "impact": "medium"
+    },
+    {
+      "name": "cudagraph-capture-sizes",
+      "type": "str",
+      "default": "6,12,24",
+      "help": "Batch sizes captured into CUDA graphs. Environment variable: CUDAGRAPH_CAPTURE_SIZES.",
+      "group": "kernels",
+      "impact": "medium"
+    },
+    {
+      "name": "vllm-memory-profiler-estimate-cudagraphs",
+      "type": "bool",
+      "default": false,
+      "help": "Let the memory profiler estimate CUDA graph cost instead of measuring it. Environment variable: VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS.",
+      "group": "memory",
+      "impact": "low"
+    },
+    {
+      "name": "default-chat-template-kwargs-thinking",
+      "type": "bool",
+      "default": true,
+      "help": "Thinking on by default in the chat template. Changes output token counts by a large factor. Environment variable: DEFAULT_CHAT_TEMPLATE_KWARGS_THINKING.",
+      "group": "template",
+      "impact": "high"
+    },
+    {
+      "name": "default-chat-template-kwargs-effort",
+      "type": "str",
+      "default": "max",
+      "help": "Reasoning effort passed to the chat template. Environment variable: DEFAULT_CHAT_TEMPLATE_KWARGS_EFFORT.",
+      "group": "template",
+      "impact": "high"
+    },
+    {
+      "name": "extra-vllm-args",
+      "type": "str",
+      "default": null,
+      "help": "Raw arguments appended to the server command. Environment variable: EXTRA_VLLM_ARGS.",
+      "group": "model",
+      "impact": "high"
+    }
+  ]
+}

--- a/models/0xSero/deepseek-v4-flash-0731-spark/model.json
+++ b/models/0xSero/deepseek-v4-flash-0731-spark/model.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "id": "0xSero/deepseek-v4-flash-0731-spark",
+  "name": "DeepSeek-V4-Flash 0731 Spark (REAP-216)",
+  "hf_id": "0xSero/deepseek-v4-flash-0731-spark",
+  "family": "deepseek-v4",
+  "vendor": "community",
+  "params_b": 247.7,
+  "active_params_b": 20.4,
+  "architecture": "DeepseekV4ForCausalLM",
+  "moe": true,
+  "experts": 216,
+  "experts_active": 6,
+  "attention": "mla",
+  "modalities": [
+    "text"
+  ],
+  "context_length": 1048576,
+  "licence": "MIT",
+  "released": "2026-07-31",
+  "tags": [
+    "chat",
+    "reasoning",
+    "moe",
+    "pruned",
+    "derivative"
+  ],
+  "links": {
+    "hf": "https://huggingface.co/0xSero/deepseek-v4-flash-0731-spark",
+    "base": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash"
+  },
+  "notes": "A derivative of deepseek-ai/DeepSeek-V4-Flash, not a quantization of it, which is why it has its own record. config.json carries a reap_pruning block: structured-output-constrained REAP expert pruning keeps 216 of 256 routed experts per layer, with 32 mandatory top experts per output category, observed over 21,289 rows spanning code generation, reasoning and agentic tool trajectories. Quality on those categories is the base model's; anywhere else it is the derivative's own and should not be read as DeepSeek-V4-Flash. Read from config.json: 43 layers, hidden 4096, moe_intermediate 2048, 6 routed experts per token plus 1 shared, vocab 129,280, max_position_embeddings 1,048,576. params_b and active_params_b are DERIVED, not read: expert parameters are layers x experts x 3 x 2048 x 4096, and the dense remainder (12.84B) is the base model's measured 290.94B safetensors total minus its 278.11B of experts. Pruning removes capacity, not work: active parameters per token are unchanged at 20.4B, so the decode bandwidth bound is the same as the base model's and only the memory footprint falls."
+}

--- a/models/0xSero/deepseek-v4-flash-0731-spark/quants/exl3-3.0bpw.json
+++ b/models/0xSero/deepseek-v4-flash-0731-spark/quants/exl3-3.0bpw.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "exl3-3.0bpw",
+  "model_id": "0xSero/deepseek-v4-flash-0731-spark",
+  "format": "exl3",
+  "bits": 3.0,
+  "hf_id": "0xSero/deepseek-v4-flash-0731-spark",
+  "revision": "22f28d32b9b29b4352eaa380ff8c2c170b2847ab",
+  "size_gb": 99.5,
+  "engines": [
+    "sparkinfer"
+  ],
+  "source": "community",
+  "calibration": "Quantized from a source checkpoint in packed_e2m1_fp4 with ue8m0 scales; the base quantization config records fp8 e4m3 with dynamic activation scaling and 128x128 weight blocks.",
+  "links": {
+    "hf": "https://huggingface.co/0xSero/deepseek-v4-flash-0731-spark"
+  },
+  "notes": "EXL3 trellis at 3.0 bits, mcg codebook, format version rank-sliced-deepseek-v4-v1. Published rank-sliced for tp=4 as exl3-layer-NNN-tp4-rankN.safetensors; running it on one GPU means coalescing the rank slices first, which the SparkInfer image does at boot into a single tp1 directory. size_gb is the repository payload on disk (106,863,050,743 bytes); the coalesced tp1 form is the same size. Only sparkinfer is listed because the rank-sliced layout and the trellis kernels are not interchangeable with stock exllamav3."
+}

--- a/models/deepseek-ai/DeepSeek-V4-Flash/model.json
+++ b/models/deepseek-ai/DeepSeek-V4-Flash/model.json
@@ -5,17 +5,17 @@
   "hf_id": "deepseek-ai/DeepSeek-V4-Flash",
   "family": "deepseek-v4",
   "vendor": "deepseek",
-  "params_b": 96,
-  "active_params_b": 9,
+  "params_b": 290.9,
+  "active_params_b": 20.4,
   "architecture": "DeepseekV4ForCausalLM",
   "moe": true,
   "experts": 256,
-  "experts_active": 8,
+  "experts_active": 6,
   "attention": "mla",
   "modalities": [
     "text"
   ],
-  "context_length": 163840,
+  "context_length": 1048576,
   "licence": "MIT",
   "released": "2026-08-05",
   "tags": [
@@ -23,5 +23,5 @@
     "reasoning",
     "moe"
   ],
-  "notes": "Placeholder record for a very recent release: params_b, active_params_b, architecture and context_length are NOT verified against config.json. Anyone running this model should verify them and correct this file in the same PR, because the plausibility bound is derived from active_params_b."
+  "notes": "Verified against config.json and the Hugging Face safetensors index on 2026-08-24, replacing the placeholder figures. params_b is measured: the safetensors total is 290,944,616,402 parameters (283.5B I8, 6.0B F8_E4M3, 1.4B BF16), not the 96 previously recorded. active_params_b is DERIVED: 43 layers x (6 routed + 1 shared) experts x 3 x 2048 x 4096 = 7.57B of experts, plus a 12.84B dense remainder (total minus the 278.11B held in all 257 experts per layer). context_length is max_position_embeddings = 1,048,576, not 163,840. experts_active is num_experts_per_tok = 6, not 8. The plausibility bound derives from active_params_b, so these corrections change what results this model is held to."
 }


### PR DESCRIPTION
Groundwork for measuring a DGX Spark running DeepSeek-V4-Flash. Nothing here can be recorded without it: the engine, the model and the quant all had no id.

### `sparkinfer` — a new engine

A vLLM-derived stack (EXL3 trellis expert kernels, rewritten MLA prefill, the dspark speculative path) built to fit DeepSeek-V4-Flash on one 128 GB Spark. It reports `vllm.__version__ == "dev"` and exposes no version of its own, and the shipped artefact is a digest-pinned container **plus** a repository of patch files bind-mounted over it — twelve of them, covering fused MoE, MLA prefill and the dspark route. The image alone does not define the stack.

So a version here is the short git commit of the configuration repository. `compose.yml` pins the image by digest, which means the commit fully determines the build: check it out, run `./start.sh`, get the same server.

Knobs are environment variables. They are recorded lower-case and hyphenated to satisfy the registry id pattern, with the real variable named in each help string (`max-model-len` → `MAX_MODEL_LEN`).

**The defaults are upstream's, on purpose.** Canonicalization drops any value equal to its default. Seeding an operator's local override as the default would delete that override from the fingerprint — the run would look stock. `ablate` is the case that matters: upstream ships `ABLATE=0`, so a run with runtime refusal-direction ablation enabled carries `ablate=true` in its canonical args instead of vanishing. It is marked `impact: high` because it changes what the model will answer, which moves eval scores; it is not a performance knob.

### `0xSero/deepseek-v4-flash-0731-spark` — a derivative, not a quant

Its `config.json` carries:

```json
"reap_pruning": { "method": "structured-output-constrained REAP expert pruning",
                  "kept_experts_per_layer": 216, "mandatory_top_per_category": 32 }
```

216 of 256 routed experts per layer survive, pruned against 21,289 observed rows spanning code generation, reasoning and agentic tool trajectories. That is a different model, so it gets its own record — filing results under `deepseek-ai/DeepSeek-V4-Flash` would attribute this artefact's quality to a model it is not.

Worth stating plainly: **pruning removes capacity, not work.** Active parameters per token are unchanged at 20.4B, so the decode bandwidth bound is identical to the base model's and only the memory footprint falls — 290.9B to 247.7B.

The quant is EXL3 trellis 3.0 bpw, mcg codebook, published rank-sliced for `tp=4`; running it on one GPU means coalescing the slices, which the image does at boot.

### DeepSeek-V4-Flash's figures were placeholders

Its own note asked whoever ran it to verify them, because the plausibility bound derives from `active_params_b`. Read against `config.json` and the HF safetensors index:

| field | was | now |
|---|---|---|
| `params_b` | 96 | **290.9** (measured: 290,944,616,402 parameters) |
| `active_params_b` | 9 | **20.4** (derived) |
| `context_length` | 163,840 | **1,048,576** |
| `experts_active` | 8 | **6** |

`params_b` is measured. `active_params_b` is derived and labelled as such in the note: 43 layers × (6 routed + 1 shared) × 3 × 2048 × 4096 = 7.57B of experts, plus a 12.84B dense remainder obtained by subtracting the 278.11B held across all 257 experts per layer from the measured total.

`pnpm validate` — 0 errors.