### PR TITLE
bench: count a streamed delta whatever field carries its text

### DIFF
--- a/bench/atlas_bench/client.py
+++ b/bench/atlas_bench/client.py
@@ -54,6 +54,22 @@ _TIMEOUT_PATTERNS = re.compile(r"timed out|timeout", re.IGNORECASE)
 MIN_DECODE_WINDOW_S = 0.001
 
 
+#: Keys a streamed delta may carry its text under. `content` is the OpenAI field;
+#: `reasoning_content` is what vLLM and LM Studio put a thought block in; `reasoning` is a
+#: third spelling in the wild (SparkInfer). A server that emits only a thought block still
+#: decoded tokens, and missing them makes a working request look like an empty answer.
+_DELTA_TEXT_KEYS = ("content", "reasoning_content", "reasoning")
+
+
+def _delta_text(delta: dict[str, Any]) -> str:
+    """The text of one streamed delta, whichever field the server used for it."""
+    for key in _DELTA_TEXT_KEYS:
+        value = delta.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
 def utc_now() -> str:
     """Current UTC time as ``2026-08-23T10:00:00Z``."""
     return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -382,7 +398,7 @@ class ChatClient:
                         usage = chunk["usage"]
                     for choice in chunk.get("choices") or []:
                         delta = choice.get("delta") or {}
-                        content = delta.get("content") or delta.get("reasoning_content") or ""
+                        content = _delta_text(delta)
                         if content:
                             now = time.perf_counter()
                             if result.first_token_at is None:

--- a/bench/tests/conftest.py
+++ b/bench/tests/conftest.py
@@ -59,6 +59,7 @@ class FakeOpenAIServer:
         report_usage: bool = True,
         reject_stream_options: bool = False,
         stream_error: str | None = None,
+        delta_key: str = "content",
     ) -> None:
         self.model = model
         self.chunks = chunks
@@ -75,6 +76,8 @@ class FakeOpenAIServer:
         self.reject_stream_options = reject_stream_options
         #: LM Studio-style: answer 200, then report the failure inside the stream.
         self.stream_error = stream_error
+        #: Which delta field the text arrives under: SparkInfer uses "reasoning".
+        self.delta_key = delta_key
         self.requests: list[dict[str, Any]] = []
 
     # ------------------------------------------------------------------ wiring
@@ -131,7 +134,7 @@ class FakeOpenAIServer:
         pieces = self._pieces(text)
         frames: list[bytes] = []
         for piece in pieces:
-            frames.append(_frame({"choices": [{"index": 0, "delta": {"content": piece}}]}))
+            frames.append(_frame({"choices": [{"index": 0, "delta": {self.delta_key: piece}}]}))
         frames.append(_frame({"choices": [{"index": 0, "delta": {}, "finish_reason": "length"}]}))
         if self.report_usage and (body.get("stream_options") or {}).get("include_usage"):
             frames.append(

--- a/bench/tests/test_client.py
+++ b/bench/tests/test_client.py
@@ -104,6 +104,24 @@ async def test_a_single_chunk_response_reports_no_decode_rate() -> None:
     assert result.e2e_s is not None
 
 
+@pytest.mark.parametrize("delta_key", ["content", "reasoning_content", "reasoning"])
+async def test_text_is_counted_whatever_field_the_delta_uses(delta_key: str) -> None:
+    """A thought-only stream is still decoded tokens, not an empty answer.
+
+    `reasoning_content` is what vLLM and LM Studio use; SparkInfer emits `reasoning`. A
+    server whose whole 256-token budget goes into a thought block sends no `content` at all,
+    and reading only the two known fields turned every such request into
+    "stream produced no content deltas" — 594 of 600 requests on a working server.
+    """
+    server = FakeOpenAIServer(chunks=5, delta_key=delta_key)
+    async with ChatClient("http://fake", "fake-model", transport=server.transport) as client:
+        result = await client.chat_stream(MESSAGES, request_id="r1", max_tokens=32)
+
+    assert result.ok, f"{delta_key} deltas must count as output"
+    assert len(result.chunk_times) == 5
+    assert result.ttft_s is not None
+
+
 async def test_a_buffered_flush_is_not_a_decode_measurement() -> None:
     """Several deltas arriving at once is a flush, not a decode interval.
 


### PR DESCRIPTION
A DeepSeek-V4-Flash run on the DGX Spark reported this against a server that was working perfectly:

| workload | requests ok |
|---|---|
| serve-chat c8 | 2 / 200 |
| serve-chat c32 | 6 / 400 |
| serve-chat c64 | 10 / 640 |
| prefill-8k / 32k / 128k | 0 / 10 each |

All recorded as `malformed-output` — "stream produced no content deltas". Meanwhile every eval workload beside them passed **100%**, which is what made it obvious the server was fine and the harness was not.

SparkInfer streams a thought block under `delta.reasoning`:

```json
"choices":[{"delta":{"reasoning":" need answer"}}]
```

The stream loop looked at `content` and `reasoning_content` only. With thinking on and `effort=max` — both engine defaults for that stack — the entire 256-token output budget goes into the thought block and no `content` delta is ever sent, so the loop saw the opening `{"content": ""}` frame, matched nothing after it, and declared the request empty.

The three spellings now share one lookup (`content`, `reasoning_content`, `reasoning`). Reasoning tokens are decoded tokens — same cost to produce — so counting them in throughput is correct rather than lenient.

**Scoring is deliberately untouched.** `chat_once` still reads `message.content` alone, so an answer is still the answer and not the thinking that preceded it. This changes only which streamed frames count as output.

Tests: the fake server grows a `delta_key` option, and the new test is parametrized over all three fields so none can regress. `uv run pytest` — 424 passed, 3 skipped.