### PR TITLE
fix: the bandwidth ceiling table was wrong in two different ways

### DIFF
--- a/app/src/views/hardware-view.ts
+++ b/app/src/views/hardware-view.ts
@@ -1,6 +1,6 @@
 import { html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import type { Hardware } from '@atlas/core';
+import { activeWeightGb, type Hardware } from '@atlas/core';
 import { addButton } from '../components/add-modal.js';
 import { icon } from '../components/icons.js';
 import '../components/mini-coverage.js';
@@ -185,16 +185,27 @@ export class AtlasHardwareView extends ViewElement {
       .flatMap((m) => m.quants.map((qq) => ({ m, qq })))
       .filter(({ qq }) => qq.size_gb != null && (!h.memory_gb || qq.size_gb! <= h.memory_gb))
       .map(({ m, qq }) => {
-        const weight =
-          m.model.moe && m.model.active_params_b
-            ? (qq.size_gb! * m.model.active_params_b) / m.model.params_b
-            : qq.size_gb!;
+        // Bytes actually read per decoded token, which is not the checkpoint size. Gating
+        // this on `moe` was wrong: gemma-4-E2B is dense and still reads 2.3B of its 5.1B
+        // per token, because Per-Layer Embeddings are looked up rather than multiplied —
+        // its own model record says decode bandwidth follows the effective figure. Using
+        // the full 10.25 GB put its ceiling at 26.6 tok/s and made a real 49.9 tok/s
+        // measurement read as 187% of a physical bound. `activeWeightGb` is the shared
+        // definition the validator already bounds results with; the two must not disagree.
+        const weight = activeWeightGb(m.model, qq) ?? qq.size_gb!;
         const ceiling = bw ? bw / weight : null;
         const measured = runs
           .filter((r) => r.model.id === m.model.id && r.model.quant_id === qq.id)
           .map((r) => r.metrics.decode_tok_s_per_request ?? null)
           .filter((v): v is number => v !== null);
-        return { m, qq, weight, ceiling, best: measured.length ? Math.max(...measured) : null };
+        return {
+          m,
+          qq,
+          weight,
+          checkpoint: qq.size_gb!,
+          ceiling,
+          best: measured.length ? Math.max(...measured) : null,
+        };
       })
       .sort(
         (a, b) =>
@@ -340,10 +351,15 @@ export class AtlasHardwareView extends ViewElement {
           <p class="small muted mb-3">
             ${
               bw
-                ? html`At ${bw} GB/s, a single stream cannot decode faster than the weights can be
-                  read once per token. The ceiling below is that bound (MoE uses active weights);
-                  speculative decoding is the only way past it. Measured numbers are the best
-                  single-stream decode on this device.`
+                ? html`At ${bw} GB/s, a single stream cannot decode faster than its weights can be
+                  read once per token. <b>Read / token</b> is what a token actually costs, which is
+                  below the checkpoint size whenever a model activates only part of itself — an MoE
+                  routing to a few experts, or a dense model like gemma-4-E2B whose Per-Layer
+                  Embeddings are looked up rather than multiplied. The ceiling is bandwidth over
+                  that figure. A measurement above it is marked: decoding more than one token per
+                  pass (speculative decoding) is the legitimate way past, and the other explanation
+                  is that the model's active-parameter figure is wrong. Measured numbers are the
+                  best single-stream decode recorded on this device.`
                 : 'No bandwidth figure is registered for this device, so no ceiling can be computed — a pull request with the vendor figure would fix that.'
             }
           </p>
@@ -354,7 +370,8 @@ export class AtlasHardwareView extends ViewElement {
                     <thead>
                       <tr>
                         <th>model / quant</th>
-                        <th class="num">weights</th>
+                        <th class="num">checkpoint</th>
+                        <th class="num">read / token</th>
                         <th class="num">ceiling</th>
                         <th class="num">measured</th>
                         <th class="num">of ceiling</th>
@@ -369,7 +386,14 @@ export class AtlasHardwareView extends ViewElement {
                                 >${x.m.model.id}</a
                               ><span class="muted">/${x.qq.id}</span>
                             </td>
-                            <td class="num">${fmtNum(x.weight, 1)} GB</td>
+                            <td class="num">${fmtNum(x.checkpoint, 1)} GB</td>
+                            <td class="num">
+                              ${fmtNum(x.weight, 1)} GB${
+                                x.weight < x.checkpoint * 0.995
+                                  ? html`<span class="muted small"> active</span>`
+                                  : nothing
+                              }
+                            </td>
                             <td class="num">
                               ${x.ceiling === null ? '–' : `${fmtTokS(x.ceiling)}`}
                             </td>
@@ -377,7 +401,16 @@ export class AtlasHardwareView extends ViewElement {
                               ${x.best === null ? html`<span class="faint">–</span>` : html`<b>${fmtTokS(x.best)}</b>`}
                             </td>
                             <td class="num">
-                              ${x.best !== null && x.ceiling ? `${Math.round((x.best / x.ceiling) * 100)}%` : ''}
+                              ${
+                                x.best !== null && x.ceiling
+                                  ? x.best > x.ceiling
+                                    ? html`<span
+                                        title="Above the single-pass bound. Either the engine decoded more than one token per pass — speculative decoding — or the active-weight figure for this model is wrong. Open the run to see which."
+                                        >${Math.round((x.best / x.ceiling) * 100)}%&nbsp;⚠</span
+                                      >`
+                                    : `${Math.round((x.best / x.ceiling) * 100)}%`
+                                  : ''
+                              }
                             </td>
                           </tr>`,
                       )}

--- a/packages/core/src/plausibility.test.ts
+++ b/packages/core/src/plausibility.test.ts
@@ -81,6 +81,27 @@ function result(metrics: MetricBlock, over: Partial<ResultRecord> = {}): ResultR
 
 const codes = (issues: ReturnType<typeof checkPlausibility>) => issues.map((i) => i.code);
 
+describe('speculative decoding raises the bound', () => {
+  it('recognises the dspark and eagle spellings, not just "speculative"', () => {
+    // SparkInfer speaks dspark and several engines speak eagle. Matching only on the word
+    // "speculative" bounded them at one token per pass and turned a legitimate measurement
+    // into a physics violation.
+    expect(tokensPerForwardPass({ 'dspark-tokens': 5 })).toBe(6);
+    expect(tokensPerForwardPass({ 'speculative-eagle-topk': 1 })).toBeGreaterThan(1);
+    expect(tokensPerForwardPass({ 'speculative-num-draft-tokens': 4 })).toBe(5);
+  });
+
+  it('leaves a non-speculative configuration at one token per pass', () => {
+    expect(tokensPerForwardPass({ 'max-num-seqs': 4, 'gpu-memory-utilization': 0.95 })).toBe(1);
+  });
+
+  it('prefers a measured acceptance rate over the configured draft length', () => {
+    expect(tokensPerForwardPass({ 'dspark-tokens': 5 }, { accepted_tokens_per_step: 2.4 } as never)).toBe(
+      2.4,
+    );
+  });
+});
+
 describe('weights and the bandwidth ceiling', () => {
   it('uses active weights for MoE models', () => {
     expect(activeWeightGb(dense, fp8)).toBeCloseTo(28.5, 5);

--- a/packages/core/src/plausibility.ts
+++ b/packages/core/src/plausibility.ts
@@ -84,7 +84,19 @@ export function tokensPerForwardPass(args: Args, metrics?: MetricBlock | null): 
   let drafts: number | null = null;
   for (const [rawKey, rawValue] of Object.entries(args ?? {})) {
     const key = normalizeKey(rawKey);
-    if (!key.includes('speculative') && !key.startsWith('draft') && key !== 'model-draft') continue;
+    // `dspark` is SparkInfer's speculative route and `eagle` is how several engines spell
+    // theirs; neither contains the word "speculative", so matching on that alone missed
+    // them entirely and bounded a speculating engine as though it decoded one token per
+    // pass. That is the one bound a measurement is allowed to beat, and reporting it as a
+    // violation blames the engine for doing the thing it was configured to do.
+    if (
+      !key.includes('speculative') &&
+      !key.includes('dspark') &&
+      !key.includes('eagle') &&
+      !key.startsWith('draft') &&
+      key !== 'model-draft'
+    )
+      continue;
     configured = true;
     const n = draftTokensFrom(key, rawValue);
     if (n !== null) drafts = Math.max(drafts ?? 0, n);
@@ -99,7 +111,8 @@ function draftTokensFrom(key: string, value: ArgValue): number | null {
     key === 'speculative-num-steps' ||
     key === 'speculative-num-draft-tokens' ||
     key === 'draft-max' ||
-    key === 'draft'
+    key === 'draft' ||
+    key === 'dspark-tokens'
   ) {
     const n = Number(value);
     return Number.isFinite(n) && n > 0 ? n : null;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -291,7 +291,7 @@ export interface Quant {
 
 /* -------------------------------------------------------------------- workload */
 
-export type WorkloadKind = 'serving' | 'sweep' | 'prefill' | 'longctx' | 'eval';
+export type WorkloadKind = 'serving' | 'sweep' | 'prefill' | 'longctx' | 'eval' | 'agentic';
 
 export type ScorerKind =
   'exact' | 'numeric' | 'mc' | 'contains' | 'json' | 'code-exec' | 'judge' | 'needle' | 'vision';
@@ -327,7 +327,7 @@ export interface Dataset {
   schema_version: 1;
   id: string;
   name: string;
-  kind: 'prompts' | 'eval' | 'images' | 'haystack';
+  kind: 'prompts' | 'eval' | 'images' | 'haystack' | 'conversations';
   description?: string | null;
   licence: string;
   files: string[];


### PR DESCRIPTION
Khaled spotted this on the DGX Spark hardware page: a DeepSeek row claiming **8.2 GB** of weights for a model whose checkpoint is 99.5 GB. Pulling that thread found two independent bugs, both of which had been printing measurements that beat a physical bound — which is the table telling you it is broken.

### gemma-4-E2B/bf16 read 187% of its ceiling

The table applied the active-weight fraction only when `model.moe` was true:

```ts
const weight =
  m.model.moe && m.model.active_params_b
    ? (qq.size_gb! * m.model.active_params_b) / m.model.params_b
    : qq.size_gb!;
```

Gemma is dense — and still touches 2.3B of its 5.1B parameters per token, because Per-Layer Embeddings are **looked up rather than multiplied**. Its own model record says so explicitly:

> params_b is the total, active_params_b the effective count … decode bandwidth follows the effective figure.

So the table ignored the exact field that record says governs the bound.

| | before | after |
|---|---|---|
| read / token | 10.25 GB | **4.62 GB** |
| ceiling | 26.6 tok/s | **59.1 tok/s** |
| measured 49.9 | **187%** | **84%** |

The view now calls `activeWeightGb` from core — the same definition the validator already bounds results with, which never had the `moe` gate. Two places computing the same physics differently is how one of them stays wrong.

### The DeepSeek row read 108% because nothing knew it was speculating

`tokensPerForwardPass` matched on keys containing `speculative`. SparkInfer spells its speculative route **`dspark`**; several engines spell theirs **`eagle`**. Neither matched, so an engine configured for 5 draft tokens per pass was bounded as though it decoded one.

Speculative decoding is the *one* bound a measurement is legitimately allowed to beat — the module docstring says as much — and reporting it as a violation blames the engine for doing what it was configured to do. Now recognised, with `dspark-tokens` added to the draft-length lookup and tests covering all three spellings plus the non-speculative case and the measured-acceptance-rate override.

### The column label was the reported symptom

`weights: 8.2 GB` against a 99.5 GB checkpoint reads as a wrong model size. It is bytes-read-per-token, which is a different quantity. Now two columns — `checkpoint` and `read / token`, the smaller marked *active* — and the prose explains why they differ instead of the parenthetical "(MoE uses active weights)" that encoded the bug.

A measurement still above the bound after all this is marked `⚠` with both possible causes named, rather than printed as a bare percentage.

### Also

Two type errors `tsc --noEmit` caught and `tsx` did not: `WorkloadKind` and the `Dataset` kind union never learned `agentic` and `conversations` when those were added.

`pnpm test` 322 passed · `pnpm validate` 0 errors · `tsc --noEmit` clean · build clean.