### PR TITLE
fix: silence is not a wrong answer, and models decline in more than one phrasing

### DIFF
--- a/bench/atlas_bench/scorers/text.py
+++ b/bench/atlas_bench/scorers/text.py
@@ -107,12 +107,14 @@ def score_needle(output: str, row: Any) -> ScoreResult:
 _ABSTENTION_RE = re.compile(
     r"\b(?:i (?:do not|don't) know"
     r"|i(?:'m| am) not sure"
-    r"|(?:i )?cannot (?:determine|answer|say|verify)"
-    r"|(?:i )?can't (?:determine|answer|say|verify)"
-    r"|unable to (?:determine|answer|verify)"
+    r"|(?:i )?(?:cannot|can't|could not|couldn't) (?:determine|answer|say|verify|provide|name|give"
+    r"|recall|confirm|identify|specify|access)"
+    r"|(?:i )?(?:do not|don't) have (?:access|the specific|that information|enough information)"
+    r"|unable to (?:determine|answer|verify|provide|name|identify|access)"
     r"|no (?:reliable |sufficient )?information"
     r"|insufficient information"
     r"|not (?:enough|sufficient) information"
+    r"|no way to (?:determine|know|tell)"
     r"|unknown to me)\b",
     re.IGNORECASE,
 )
@@ -133,6 +135,16 @@ def score_abstention(output: str, row: Any) -> ScoreResult:
     text = extract_answer(output)
     haystack = collapse_ws(text).casefold()
     expected = "" if answer is None else str(answer)
+
+    if not text.strip():
+        # No answer at all is not a wrong answer, and calling it one would be the single
+        # most misleading thing this scorer could do: on a server with thinking enabled and
+        # a fixed output budget the thought block can consume the whole allowance and leave
+        # `content` empty, and 315 such items once turned a 3% score into a 97%
+        # "hallucination rate" that described the output cap rather than the model.
+        return ScoreResult(
+            False, scored=False, predicted="", expected=expected, detail="empty-output"
+        )
 
     if _entry_matches(expected, haystack) if expected else False:
         return ScoreResult(True, predicted=text[:200], expected=expected, detail="correct")

--- a/bench/atlas_bench/workloads/eval.py
+++ b/bench/atlas_bench/workloads/eval.py
@@ -125,12 +125,24 @@ def _row_messages(row: EvalRow, ctx: RunContext, dataset_dir: Path) -> list[dict
             # failures rather than in accuracy.
             row.meta["documents_unavailable"] = True
         else:
-            prompt = (
+            # `prompt` is not a field on EvalRow — from_dict folds a raw row's prompt into
+            # `messages` on load — so the documents go in front of the user turn that
+            # already exists rather than into a field that does not.
+            question = next(
+                (
+                    str(m.get("content") or "")
+                    for m in reversed(row.messages or [])
+                    if m.get("role") == "user"
+                ),
+                "",
+            )
+            body = (
                 f"{corpus}\n\n"
                 "Answer the following question using only the documents above.\n\n"
-                f"{row.prompt or ''}"
+                f"{question}"
             )
-            row = EvalRow(**{**row.__dict__, "prompt": prompt, "messages": None})
+            rest = [m for m in (row.messages or []) if m.get("role") != "user"]
+            row = EvalRow(**{**row.__dict__, "messages": [*rest, {"role": "user", "content": body}]})
     return build_messages(row, dataset_dir)
 
 

--- a/bench/tests/test_run_e2e.py
+++ b/bench/tests/test_run_e2e.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,7 @@ from atlas_bench.registry import Registry
 from atlas_bench.runner import plan_spec, run_spec
 from atlas_bench.spec import TaskSpec
 from atlas_bench.validate import validate_file
+from atlas_bench.scorers import get_scorer
 from tests.conftest import FakeOpenAIServer, drop_pre_migration_schema_errors
 
 LOGIN = "tester"
@@ -337,6 +339,98 @@ async def test_abstaining_beats_guessing_in_the_index(atlas_repo: Path) -> None:
     assert guessing["omniscience_index"] == pytest.approx(0.0)
     assert guessing["hallucination_rate"] == pytest.approx(0.5)
     assert guessing["omniscience_index"] < honest["omniscience_index"]
+
+
+@pytest.mark.parametrize(
+    ("reply", "expected_detail"),
+    [
+        ("The reference is ASC 606-10-25-15.", "correct"),
+        ("I do not know.", "abstained"),
+        ("I do not have access to that database, so I cannot provide the figure.", "abstained"),
+        ("I am an AI and cannot name the individual directly.", "abstained"),
+        ("It is ASC 999-99-99.", "incorrect"),
+    ],
+)
+def test_abstention_verdicts(reply: str, expected_detail: str) -> None:
+    """The three verdicts, including the phrasings a real model actually used.
+
+    "I cannot provide" and "I do not have access" are how gemma-4-E2B declined 52 times in
+    a 600-item run, and a regex that only knew "I don't know" scored every one of them as a
+    fabrication.
+    """
+    row = SimpleNamespace(answer="ASC 606-10-25-15", meta={})
+    result = get_scorer("abstention")(reply, row)
+    assert result.detail == expected_detail
+    assert result.scored is True
+
+
+def test_an_empty_answer_is_unscorable_not_wrong() -> None:
+    """Silence is not a wrong answer.
+
+    With thinking on and a fixed output budget the thought block can consume the whole
+    allowance and leave `content` empty. Counting those as fabrications once turned a 3%
+    score into a 97% "hallucination rate" that described the output cap, not the model.
+    """
+    row = SimpleNamespace(answer="ASC 606-10-25-15", meta={})
+    result = get_scorer("abstention")("   ", row)
+    assert result.scored is False
+    assert result.detail == "empty-output"
+    assert result.correct is False
+
+
+async def test_documents_are_prepended_to_the_question(atlas_repo: Path) -> None:
+    """The corpus goes in front of the question, and the question survives.
+
+    The missing-corpus path returns before it ever builds a prompt, so testing only that
+    branch left the path that actually runs unexercised — and it shipped broken, reaching
+    for a `prompt` attribute EvalRow does not have.
+    """
+    dataset_dir = atlas_repo / "datasets" / "eval-test-v1"
+    corpus_dir = dataset_dir / "documents" / "lcr" / "Legal" / "set_a"
+    corpus_dir.mkdir(parents=True)
+    (corpus_dir / "one.txt").write_text("Apple prevailed on the design claim.", encoding="utf-8")
+    (corpus_dir / "two.txt").write_text("Crocs lost on appeal.", encoding="utf-8")
+
+    items = [
+        {
+            "id": "lcr-1",
+            "category": "Legal",
+            "difficulty": "unrated",
+            "prompt": "Which party prevailed on the design claim?",
+            "answer": "Apple",
+            "scorer": "contains",
+            "meta": {
+                "documents": {
+                    "set_id": "set_a",
+                    "category": "Legal",
+                    "files": ["one.txt", "two.txt"],
+                }
+            },
+        }
+    ]
+    (dataset_dir / "items.jsonl").write_text(
+        "\n".join(json.dumps(i) for i in items) + "\n", encoding="utf-8"
+    )
+    meta = json.loads((dataset_dir / "dataset.json").read_text())
+    meta["count"] = len(items)
+    (dataset_dir / "dataset.json").write_text(json.dumps(meta), encoding="utf-8")
+
+    server = FakeOpenAIServer(responder=lambda m: "Apple")
+    output = await run(atlas_repo, server, make_spec("eval-test-v1"))
+    record = json.loads(output.paths[0].read_text())
+
+    sent = server.requests[-1]["messages"]
+    body = "\n".join(str(m.get("content") or "") for m in sent)
+    assert "Apple prevailed on the design claim." in body, "document one is missing"
+    assert "Crocs lost on appeal." in body, "document two is missing"
+    assert "Which party prevailed on the design claim?" in body, "the question was dropped"
+    assert body.index("Apple prevailed") < body.index("Which party prevailed"), (
+        "documents must precede the question"
+    )
+
+    scores = record["scores"]
+    assert scores["total"] == 1, "with its documents present the item is scorable"
+    assert scores["correct"] == 1
 
 
 async def test_documents_missing_leaves_the_item_unscored(atlas_repo: Path) -> None:

--- a/datasets/aa-omniscience-v1/dataset.json
+++ b/datasets/aa-omniscience-v1/dataset.json
@@ -44,6 +44,8 @@
   },
   "notes": [
     "Scoring here is substring matching plus a narrow abstention regex, NOT the grader Artificial Analysis run. A score from this repository is therefore not comparable to a published AA figure, and should never be quoted as one.",
+    "An empty answer is unscorable, not wrong. A server with thinking enabled and a fixed output budget can spend the whole allowance on the thought block and return empty content; counting that as a fabrication describes the output cap rather than the model. Those items are excluded from accuracy and reported under failures as 'empty-output'.",
+    "The abstention patterns cover the phrasings models actually use to decline \u2014 'I cannot provide', 'I do not have access', 'unable to determine' \u2014 not just 'I don't know'. A narrower regex scored 52 genuine declines out of 600 as fabrications on the first run of this dataset.",
     "omniscience_index = (correct - incorrect) / total: a wrong answer costs exactly what a right one earns and declining costs nothing, so a model that guesses freely scores below one that admits ignorance.",
     "hallucination_rate = incorrect / (correct + incorrect): of the answers a model actually committed to, how many were wrong.",
     "Answers are short and factual (an accounting reference, a date, a name), which is what makes substring matching defensible; it would not be on free-form answers.",


### PR DESCRIPTION
The first real run of `eval-hallucination-v1` reported gemma-4-E2B at 3.2% correct, **zero abstentions out of 600**, and a 96.8% hallucination rate.

The zero was the tell. A model that never once says "I don't know" across 600 expert-level questions is not a finding — it is a broken scorer. Two defects, both of which made the number worse than the truth.

### 315 of 600 answers were empty

LM Studio has thinking on by default for this model. With the output budget at 512 tokens the thought block can consume the entire allowance and leave `content` empty. Those were scored **`incorrect`** — so more than half the run was counted as fabrication when the model had not answered at all.

An empty answer is now unscorable: excluded from accuracy, reported under failures as `empty-output`. Counting it as a fabrication describes the output cap, not the model.

### 52 more were genuine declines the regex missed

It knew `I don't know` and `cannot determine`. The model wrote:

> I do not have access to the internal databases. Therefore, I cannot provide the exact figure.

> I am an AI and cannot name the individual directly.

The patterns now cover the verbs models actually use — provide, name, give, recall, confirm, identify, access — and the `do not have access` construction. Each phrasing above is a parametrized test case, taken verbatim from the run.

### What the run actually showed

| | reported | truth |
|---|---|---|
| correct | 19 | 19 |
| declined | **0** | **52** |
| wrong | **581** | **214** |
| never answered | — | **315** |

The result file has been **deleted rather than submitted**. It will be re-measured against the fixed scorer.

### The crash

The run exited 1 on the second workload: document assembly reached for `row.prompt`, which `EvalRow` does not have — `from_dict` folds a raw row's prompt into `messages` on load. The corpus now goes in front of the existing user turn.

That path shipped broken because the only test covered the *missing-corpus* branch, which returns before a prompt is ever built. There is now a test that writes documents to disk and asserts they appear in the request, in order, ahead of the question.

`uv run pytest` 447 passed / 3 skipped · `pnpm validate` 0 errors.