### PR TITLE
fix: AA-LCR document names survive a zip without the UTF-8 flag

### DIFF
--- a/bench/atlas_bench/workloads/eval.py
+++ b/bench/atlas_bench/workloads/eval.py
@@ -146,6 +146,18 @@ def _row_messages(row: EvalRow, ctx: RunContext, dataset_dir: Path) -> list[dict
     return build_messages(row, dataset_dir)
 
 
+def _failure_message(
+    category: str, sample: RequestResult, unscorable_reasons: dict[str, int]
+) -> str:
+    """What actually went wrong, in words a reader can act on."""
+    if category == "unscorable":
+        parts = ", ".join(f"{n} {reason}" for reason, n in sorted(unscorable_reasons.items()))
+        return f"completed but could not be judged: {parts}"
+    if category == "refusal":
+        return "refusal detected"
+    return sample.error_message or category
+
+
 def _score(row: EvalRow, result: RequestResult, default_scorer: str) -> ScoreResult:
     """Score one completed item with the row's own scorer."""
     if row.meta.get("documents_unavailable"):
@@ -262,6 +274,7 @@ async def run_eval(ctx: RunContext) -> WorkloadOutcome:
     scored_total = 0
     correct_total = 0
     verdicts: dict[str, int] = defaultdict(int)
+    unscorable_reasons: dict[str, int] = defaultdict(int)
 
     for row, result, score in outcomes:
         latency_ms = round((result.e2e_s or 0.0) * 1000, 3)
@@ -282,8 +295,11 @@ async def run_eval(ctx: RunContext) -> WorkloadOutcome:
         elif not score.scored:
             # The request completed and the item still could not be judged. The comment
             # below promises these are counted in `failures`; without this branch they were
-            # counted nowhere and simply disappeared from the report.
-            failures_by_category[score.detail or "unscored"].append(result)
+            # counted nowhere and simply disappeared from the report. The category is the
+            # SPEC's closed vocabulary — the specific reason travels in the message, so a
+            # new scorer cannot quietly invent a category the schema rejects.
+            unscorable_reasons[score.detail or "unscored"] += 1
+            failures_by_category["unscorable"].append(result)
         elif not score.correct and is_refusal(result.text):
             failures_by_category["refusal"].append(result)
         if score.scored:
@@ -342,7 +358,7 @@ async def run_eval(ctx: RunContext) -> WorkloadOutcome:
             "at": "score" if category == "refusal" else "request",
             "count": len(results),
             "category": category,
-            "message": (results[0].error_message or "refusal detected")[:500],
+            "message": _failure_message(category, results[0], unscorable_reasons)[:500],
             "sample_request_id": results[0].request_id,
         }
         for category, results in sorted(failures_by_category.items())

--- a/bench/tests/datasets_prepare_aa_lcr.py
+++ b/bench/tests/datasets_prepare_aa_lcr.py
@@ -1,0 +1,19 @@
+"""Import shim so the AA-LCR prepare script is testable.
+
+`datasets/aa-lcr-v1/prepare.py` is a standalone script, not part of the package, and its
+filename is not importable as a module. Loading it by path keeps the zip-name decoding
+covered by the suite instead of only by the one run that noticed it was wrong.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_PATH = Path(__file__).resolve().parents[2] / "datasets" / "aa-lcr-v1" / "prepare.py"
+_spec = importlib.util.spec_from_file_location("aa_lcr_prepare", _PATH)
+assert _spec and _spec.loader
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+_entry_name = _module._entry_name

--- a/bench/tests/test_run_e2e.py
+++ b/bench/tests/test_run_e2e.py
@@ -378,6 +378,27 @@ def test_an_empty_answer_is_unscorable_not_wrong() -> None:
     assert result.correct is False
 
 
+def test_zip_entry_names_survive_a_missing_utf8_flag() -> None:
+    """A zip that stores UTF-8 names without setting bit 11 must still round-trip.
+
+    zipfile falls back to CP437, so a curly apostrophe arrives as mojibake and the file no
+    longer exists under the name the questions reference. Four AA-LCR items went unscorable
+    for exactly that reason, with nothing wrong in the data.
+    """
+    from zipfile import ZipInfo
+
+    from datasets_prepare_aa_lcr import _entry_name  # type: ignore[import-not-found]
+
+    real = "EU\u2019s Official Journal.txt"
+    mangled = ZipInfo(real.encode("utf-8").decode("cp437"))
+    mangled.flag_bits = 0
+    assert _entry_name(mangled) == real
+
+    proper = ZipInfo(real)
+    proper.flag_bits = 0x800
+    assert _entry_name(proper) == real
+
+
 async def test_documents_are_prepended_to_the_question(atlas_repo: Path) -> None:
     """The corpus goes in front of the question, and the question survives.
 

--- a/datasets/aa-lcr-v1/prepare.py
+++ b/datasets/aa-lcr-v1/prepare.py
@@ -34,6 +34,23 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _entry_name(entry: zipfile.ZipInfo) -> str:
+    """The entry's real filename, undoing zipfile's CP437 fallback.
+
+    A zip stores filenames as bytes and only promises UTF-8 when general-purpose bit 11 is
+    set. This archive stores UTF-8 without setting it, so zipfile decodes as CP437 and a
+    curly apostrophe arrives as "\u0393\u00c7\u00d6". Four documents then did not exist under the
+    names the questions reference, and four items went unscorable for a reason that had
+    nothing to do with the data.
+    """
+    if entry.flag_bits & 0x800:
+        return entry.filename
+    try:
+        return entry.filename.encode("cp437").decode("utf-8")
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return entry.filename
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--force", action="store_true", help="re-download and re-extract")
@@ -71,13 +88,19 @@ def main(argv: list[str] | None = None) -> int:
 
     with zipfile.ZipFile(archive) as bundle:
         for entry in bundle.infolist():
+            name = _entry_name(entry)
             # Zip entries are attacker-controlled paths in the general case; keep the
             # extraction inside the dataset directory whatever the archive claims.
-            destination = (target / entry.filename).resolve()
+            destination = (target / name).resolve()
             if not str(destination).startswith(str(target.resolve())):
-                print(f"refusing entry outside the target: {entry.filename}", file=sys.stderr)
+                print(f"refusing entry outside the target: {name}", file=sys.stderr)
                 return 1
-        bundle.extractall(target)
+            if entry.is_dir():
+                destination.mkdir(parents=True, exist_ok=True)
+                continue
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with bundle.open(entry) as source, destination.open("wb") as out:
+                shutil.copyfileobj(source, out)
     archive.unlink(missing_ok=True)
 
     files = sum(1 for _ in target.rglob("*") if _.is_file())

--- a/schemas/result.schema.json
+++ b/schemas/result.schema.json
@@ -250,6 +250,7 @@
               "refusal",
               "crash",
               "unsupported",
+              "unscorable",
               "other"
             ]
           },


### PR DESCRIPTION
Four of the 100 AA-LCR items came back `documents-unavailable` on the first real run. The data was fine.

A zip stores filenames as bytes and only promises UTF-8 when general-purpose bit 11 is set. This archive stores UTF-8 **without** setting it, so `zipfile` falls back to CP437 and the curly apostrophe in *"the EU's Official Journal"* extracts as `ΓÇÖ`:

```
disk: 'he EUΓÇÖs Official J'
want: 'he EU’s Official Jou'
```

The file then does not exist under the name the question references. `prepare.py` now re-decodes any entry whose UTF-8 flag is clear, and extracts entry-by-entry so the path-traversal check applies to the *corrected* name rather than the mangled one. All 230 files resolve; no item is short of its documents.

A test builds both a flagged and an unflagged `ZipInfo` so this stays covered by the suite rather than by the one run that happened to notice.

### The workload did the right thing

It left those four unscored and named the reason, instead of asking a 95k-token question with two of its documents missing and folding the answer into accuracy. That is exactly what the unscorable path exists for — the bug cost four items, not a wrong number.

### Two follow-ons that `pnpm validate` caught

`failures[].category` is a **closed** SPEC vocabulary, and routing a scorer's own detail string into it produced categories the schema rejects (`empty-output`, `documents-unavailable`). Unscorable items now land under one new `unscorable` category, with the specific reasons counted in the message:

> completed but could not be judged: 294 empty-output

So a future scorer cannot invent a schema-breaking category just by returning a new detail string.

### Results deleted, not submitted

Both AA result files are removed and will be re-measured — the long-context one because four items were missing documents, the hallucination one because it predates this categorisation.

`uv run pytest` 448 passed / 3 skipped · `pnpm test` 322 passed · `tsc --noEmit` clean · `pnpm validate` 0 errors.