### PR TITLE
registry: the three Granite 4.2 models

### DIFF
--- a/models/ibm-granite/granite-4.2-30b/model.json
+++ b/models/ibm-granite/granite-4.2-30b/model.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "id": "ibm-granite/granite-4.2-30b",
+  "name": "Granite 4.2 30B",
+  "hf_id": "ibm-granite/granite-4.2-30b",
+  "family": "granite-4.2",
+  "vendor": "ibm",
+  "params_b": 29.28,
+  "active_params_b": 29.28,
+  "architecture": "GraniteForCausalLM",
+  "moe": false,
+  "attention": "gqa",
+  "modalities": [
+    "text"
+  ],
+  "context_length": 131072,
+  "licence": "Apache-2.0",
+  "released": "2026-08-25",
+  "tags": [
+    "chat",
+    "reasoning",
+    "thinking",
+    "tools"
+  ],
+  "links": {
+    "hf": "https://huggingface.co/ibm-granite/granite-4.2-30b"
+  },
+  "notes": "Read from config.json on 2026-08-25: GraniteForCausalLM, 64 layers, hidden 4096, vocab 100,352, max_position_embeddings 131,072, bfloat16. Dense \u2014 no MoE fields in the config \u2014 so active_params_b equals params_b. params_b is measured from the Hugging Face safetensors index (29,276,770,304 parameters), not estimated from the name: the repository is published as 'granite-4.2-30b' while the checkpoint holds 29.28B. The card advertises reasoning and tool calling; whether thinking is on by default is a property of the chat template and belongs in each run's provenance rather than here."
+}

--- a/models/ibm-granite/granite-4.2-30b/quants/bf16.json
+++ b/models/ibm-granite/granite-4.2-30b/quants/bf16.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "bf16",
+  "model_id": "ibm-granite/granite-4.2-30b",
+  "format": "bf16",
+  "bits": 16,
+  "hf_id": "ibm-granite/granite-4.2-30b",
+  "revision": null,
+  "size_gb": 58.55,
+  "engines": [
+    "vllm",
+    "sglang",
+    "tgi"
+  ],
+  "source": "official",
+  "links": {
+    "hf": "https://huggingface.co/ibm-granite/granite-4.2-30b"
+  },
+  "notes": "The published weights, unquantized. size_gb is the safetensors payload from the Hugging Face file listing (58,553,607,904 bytes)."
+}

--- a/models/ibm-granite/granite-4.2-3b/model.json
+++ b/models/ibm-granite/granite-4.2-3b/model.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "id": "ibm-granite/granite-4.2-3b",
+  "name": "Granite 4.2 3B",
+  "hf_id": "ibm-granite/granite-4.2-3b",
+  "family": "granite-4.2",
+  "vendor": "ibm",
+  "params_b": 3.66,
+  "active_params_b": 3.66,
+  "architecture": "GraniteForCausalLM",
+  "moe": false,
+  "attention": "gqa",
+  "modalities": [
+    "text"
+  ],
+  "context_length": 131072,
+  "licence": "Apache-2.0",
+  "released": "2026-08-25",
+  "tags": [
+    "chat",
+    "reasoning",
+    "thinking",
+    "tools"
+  ],
+  "links": {
+    "hf": "https://huggingface.co/ibm-granite/granite-4.2-3b"
+  },
+  "notes": "Read from config.json on 2026-08-25: GraniteForCausalLM, 40 layers, hidden 2560, vocab 100,352, max_position_embeddings 131,072, bfloat16. Dense \u2014 no MoE fields in the config \u2014 so active_params_b equals params_b. params_b is measured from the Hugging Face safetensors index (3,659,737,600 parameters), not estimated from the name: the repository is published as 'granite-4.2-3b' while the checkpoint holds 3.66B. The card advertises reasoning and tool calling; whether thinking is on by default is a property of the chat template and belongs in each run's provenance rather than here."
+}

--- a/models/ibm-granite/granite-4.2-3b/quants/bf16.json
+++ b/models/ibm-granite/granite-4.2-3b/quants/bf16.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "bf16",
+  "model_id": "ibm-granite/granite-4.2-3b",
+  "format": "bf16",
+  "bits": 16,
+  "hf_id": "ibm-granite/granite-4.2-3b",
+  "revision": null,
+  "size_gb": 7.32,
+  "engines": [
+    "vllm",
+    "sglang",
+    "tgi"
+  ],
+  "source": "official",
+  "links": {
+    "hf": "https://huggingface.co/ibm-granite/granite-4.2-3b"
+  },
+  "notes": "The published weights, unquantized. size_gb is the safetensors payload from the Hugging Face file listing (7,319,517,120 bytes)."
+}

--- a/models/ibm-granite/granite-4.2-8b/model.json
+++ b/models/ibm-granite/granite-4.2-8b/model.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "id": "ibm-granite/granite-4.2-8b",
+  "name": "Granite 4.2 8B",
+  "hf_id": "ibm-granite/granite-4.2-8b",
+  "family": "granite-4.2",
+  "vendor": "ibm",
+  "params_b": 8.79,
+  "active_params_b": 8.79,
+  "architecture": "GraniteForCausalLM",
+  "moe": false,
+  "attention": "gqa",
+  "modalities": [
+    "text"
+  ],
+  "context_length": 131072,
+  "licence": "Apache-2.0",
+  "released": "2026-08-25",
+  "tags": [
+    "chat",
+    "reasoning",
+    "thinking",
+    "tools"
+  ],
+  "links": {
+    "hf": "https://huggingface.co/ibm-granite/granite-4.2-8b"
+  },
+  "notes": "Read from config.json on 2026-08-25: GraniteForCausalLM, 40 layers, hidden 4096, vocab 100,352, max_position_embeddings 131,072, bfloat16. Dense \u2014 no MoE fields in the config \u2014 so active_params_b equals params_b. params_b is measured from the Hugging Face safetensors index (8,791,592,960 parameters), not estimated from the name: the repository is published as 'granite-4.2-8b' while the checkpoint holds 8.79B. The card advertises reasoning and tool calling; whether thinking is on by default is a property of the chat template and belongs in each run's provenance rather than here."
+}

--- a/models/ibm-granite/granite-4.2-8b/quants/bf16.json
+++ b/models/ibm-granite/granite-4.2-8b/quants/bf16.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "bf16",
+  "model_id": "ibm-granite/granite-4.2-8b",
+  "format": "bf16",
+  "bits": 16,
+  "hf_id": "ibm-granite/granite-4.2-8b",
+  "revision": null,
+  "size_gb": 17.58,
+  "engines": [
+    "vllm",
+    "sglang",
+    "tgi"
+  ],
+  "source": "official",
+  "links": {
+    "hf": "https://huggingface.co/ibm-granite/granite-4.2-8b"
+  },
+  "notes": "The published weights, unquantized. size_gb is the safetensors payload from the Hugging Face file listing (17,583,228,032 bytes)."
+}


### PR DESCRIPTION
IBM published `granite-4.2-3b`, `-8b` and `-30b` today. Records so they can be measured.

All three are dense `GraniteForCausalLM` at bfloat16 with a 131,072-token window — an architecture vLLM has supported for a long time, confirmed present in `vllm/vllm-openai:v0.27.1-aarch64`'s registry. No engine work needed.

| model | params (measured) | bf16 on disk |
|---|---|---|
| granite-4.2-3b | **3.66B** | 7.32 GB |
| granite-4.2-8b | **8.79B** | 17.58 GB |
| granite-4.2-30b | **29.28B** | 58.55 GB |

`params_b` comes from each safetensors index, not from the name — the names round, and the bandwidth ceiling derives from that figure, so rounding it into the record would move every bound. Dense with no MoE fields, so `active_params_b` equals `params_b`.

The cards advertise reasoning and tool calling. Whether thinking is on by default is a property of the chat template and belongs in each run's provenance rather than the model record, so it is not asserted here.

`pnpm validate` 0 errors.