### PR TITLE
fix: an agentic result has to validate, not just be written

### DIFF
--- a/bench/atlas_bench/workloads/agentic.py
+++ b/bench/atlas_bench/workloads/agentic.py
@@ -174,6 +174,11 @@ async def run_agentic(ctx: RunContext) -> WorkloadOutcome:
     metrics["session_prompt_tokens_max"] = distribution(growth) if growth else None
 
     sessions.sort(key=lambda s: s["conversation_id"])
+    # Sessions are NOT sweep points. `sweep` is "one swept point with its own metric block",
+    # which is what the schema enforces and what the site's sweep chart draws; a session row
+    # has no metric block and a conversation id instead of an axis value. They live in the
+    # raw payload, where the per-session context growth is preserved without pretending to
+    # be an axis.
     gotchas = []
     if not honour_delays:
         gotchas.append(
@@ -205,7 +210,6 @@ async def run_agentic(ctx: RunContext) -> WorkloadOutcome:
             "temperature": float(ctx.param("temperature", ctx.spec.request.temperature)),
             "timeout_s": ctx.timeout_s,
         },
-        sweep=sessions,
         raw={"requests": raw_payload(results), "sessions": sessions},
         gotchas=gotchas,
         warnings=list(ctx.warnings),

--- a/bench/tests/test_run_e2e.py
+++ b/bench/tests/test_run_e2e.py
@@ -492,6 +492,27 @@ async def test_documents_missing_leaves_the_item_unscored(atlas_repo: Path) -> N
     assert record["metrics"]["requests_ok"] == 1
 
 
+async def test_agentic_result_passes_schema_validation(atlas_repo: Path) -> None:
+    """The record an agentic run writes must validate, not merely be written.
+
+    The first real agentic result failed on two counts the unit tests could not see:
+    per-session rows were put in `sweep`, which the schema defines as a swept point WITH a
+    metric block, and the session-depth distribution was a metric name the closed block does
+    not allow. Both only surface against the real schema.
+    """
+    server = FakeOpenAIServer(responder=lambda m: "ack")
+    output = await run(atlas_repo, server, make_spec("agentic-test-v1"))
+    issues = drop_pre_migration_schema_errors(
+        validate_file(output.paths[0], Registry(atlas_repo))
+    )
+    errors = [i for i in issues if i.level == "error"]
+    assert not errors, f"agentic result does not validate: {[i.message for i in errors]}"
+
+    record = json.loads(output.paths[0].read_text())
+    assert record.get("sweep") in (None, []), "sessions are not swept points"
+    assert record["raw"]["payload"]["sessions"], "per-session detail must survive in raw"
+
+
 async def test_agentic_replays_the_recording_not_the_model(atlas_repo: Path) -> None:
     """Every assistant turn is measured, and the history that grows is the recording's.
 
@@ -506,7 +527,7 @@ async def test_agentic_replays_the_recording_not_the_model(atlas_repo: Path) -> 
     assert record["kind"] == "agentic"
     # Two assistant turns in the recording, so two measured requests.
     assert record["metrics"]["requests_ok"] == 2
-    sessions = record["sweep"]
+    sessions = record["raw"]["payload"]["sessions"]
     assert len(sessions) == 1
     assert sessions[0]["conversation_id"] == "sess-1"
     assert sessions[0]["turns_measured"] == 2
@@ -542,7 +563,7 @@ async def test_agentic_records_whether_tool_delays_were_honoured(atlas_repo: Pat
     # The fixture sets honour_tool_delays: False so the 30s pause is not slept through.
     assert record["workload"]["resolved_params"]["honour_tool_delays"] is False
     assert any("upper bound" in g["text"] for g in record["gotchas"])
-    assert record["sweep"][0]["tool_delay_s"] == 0.0
+    assert record["raw"]["payload"]["sessions"][0]["tool_delay_s"] == 0.0
 
 
 async def test_dry_run_touches_nothing(atlas_repo: Path, fake_server: FakeOpenAIServer) -> None:

--- a/schemas/common.schema.json
+++ b/schemas/common.schema.json
@@ -81,6 +81,7 @@
         "decode_tok_s_per_request": { "$ref": "#/$defs/nullable_distribution" },
         "vram_peak_gb": { "type": ["number", "null"], "minimum": 0 },
         "ram_peak_gb": { "type": ["number", "null"], "minimum": 0 },
+        "session_prompt_tokens_max": { "$ref": "#/$defs/nullable_distribution", "description": "Deepest prompt reached in each measured session, across sessions. Only for kind=agentic, where the prompt grows every turn and the depth it reaches is the point of the workload." },
         "kv_cache_tokens": { "$ref": "#/$defs/nullable_integer" },
         "power_avg_w": { "type": ["number", "null"], "minimum": 0 },
         "power_peak_w": { "type": ["number", "null"], "minimum": 0 },


### PR DESCRIPTION
The first real agentic run — **1,007 turns against Qwen3.8-27B, every request successful** — produced a record the schema rejects on two counts. Three behavioural tests passed while the artifact they produced could not be published, because none of them validated the file.

### Sessions are not swept points

`sweep` is defined as one swept point **with its own metric block**, and that is what the site's sweep chart draws. A session row has no metric block and carries a `conversation_id` where an axis value belongs:

```
error schema — sweep: [{'conversation_id': 'astropy__astropy-12907', ...
```

Sessions now live only in `raw.payload.sessions`, where the per-session context growth is preserved without pretending to be an axis.

### `session_prompt_tokens_max` needed declaring

It is a real measurement — the deepest prompt each session reached, which is the entire point of a workload whose context grows every turn — but the metric block is closed and it was not in it. Now declared in `common.schema.json` as a nullable distribution rather than smuggled in.

### The test that was missing

`test_agentic_result_passes_schema_validation` runs the workload and puts the result through the real validator. The three existing tests checked *behaviour* — that the recording is replayed, that context grows, that skipped delays are declared — and all three passed against a file that could not be merged.

### The affected measurement

The Qwen agentic result is valid as a measurement (1007/1007 turns, 21.8 tok/s, context growing 13.5k → 23.7k tokens across sessions) but its record has the wrong shape, so it is **not** being submitted. It will be re-measured once the Granite runs free the machine. The other two new Qwen results — `eval-hallucination-v1` and `eval-longctx-reasoning-v1` — validate and are going in now.

`uv run pytest` 449 passed / 3 skipped · `pnpm test` 322 passed · `pnpm validate` 0 errors.