### PR TITLE
fix: a closing think tag with no opening one is still thinking

### DIFF
--- a/bench/atlas_bench/scorers/__init__.py
+++ b/bench/atlas_bench/scorers/__init__.py
@@ -62,10 +62,19 @@ class ScoreResult:
 
 
 def strip_think(text: str) -> str:
-    """Drop ``<think>…</think>`` blocks, including an unterminated leading one."""
+    """Drop ``<think>…</think>`` blocks, an unterminated leading one, and an unopened one.
+
+    A closing tag with no opening tag means the chat template opened the block in the prompt
+    and the model only had to close it — Granite 4.2 does this, and so do several reasoning
+    models. Everything up to that tag is thinking, and leaving it in front of the answer
+    corrupts every scorer: the extracted answer becomes a paragraph of deliberation.
+    """
     body = _THINK_RE.sub(" ", text or "")
-    if "<think>" in body.lower() and "</think>" not in body.lower():
+    lowered = body.lower()
+    if "<think>" in lowered and "</think>" not in lowered:
         body = _UNTERMINATED_THINK_RE.sub("", body)
+    elif "</think>" in lowered and "<think>" not in lowered:
+        body = body[lowered.rindex("</think>") + len("</think>") :]
     return body
 
 

--- a/bench/tests/test_client.py
+++ b/bench/tests/test_client.py
@@ -44,6 +44,28 @@ def test_oom_beats_the_status_class() -> None:
     assert categorize_error(500, "torch.cuda.OutOfMemoryError", None) == "oom"
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # Granite 4.2: the template opens the block, so the model only closes it.
+        ("Let me think about it. The value is 42.\n</think>\nThe answer is 42", "The answer is 42"),
+        ("<think>hidden working</think>The answer is 42", "The answer is 42"),
+        ("The answer is 42", "The answer is 42"),
+    ],
+)
+def test_a_closing_think_tag_without_an_opening_one_is_still_thinking(
+    raw: str, expected: str
+) -> None:
+    """Everything before an unopened `</think>` is deliberation, not the answer.
+
+    Leaving it in place does not merely add noise: the extracted answer becomes a paragraph
+    of reasoning, and every scorer then compares that paragraph against the expected value.
+    """
+    from atlas_bench.scorers import extract_answer
+
+    assert extract_answer(raw) == expected
+
+
 def test_refusal_detection() -> None:
     """Refusals are a distinct eval failure category."""
     assert is_refusal("I'm sorry, I can't help with that.")


### PR DESCRIPTION
The pre-run probe on Granite 4.2 caught two things before they cost a night of DGX time. Both would have produced published numbers that described the configuration rather than the model.

### Granite closes a think block it never opens

The chat template writes `<think>`, so the model only emits the closing tag:

```
Okay, the user is asking for the weather in Berlin. I need to use get_weather…
</think>
<tool_call>…
```

`strip_think` handled a matched pair and an unterminated *leading* tag. It did not handle this, so everything before the unopened `</think>` sailed through as the answer.

That is not added noise — it is a wrong measurement. The extracted answer becomes a paragraph of deliberation, and every scorer then compares that paragraph against the expected value. It would have quietly deflated **all eleven eval scores for all three Granite models**.

The rule now: a closing tag with no opening tag means the prompt opened the block, so everything up to and including it is thinking. Several reasoning models ship this way, so this is general rather than a Granite workaround.

### Tool calling produced nothing under the `granite4` parser

The model is not at fault. It emits a perfectly good call:

```xml
<tool_call><function=get_weather><parameter=city>Berlin</parameter></function></tool_call>
```

`granite4` cannot read that format. Confirmed against the live server:

| parser | `tool_choice: auto` |
|---|---|
| `granite4` | `tool_calls: null`, finish `stop` |
| `granite4`, `tool_choice: required` | correct call — so the model *can*, guided decoding forces it |
| **`qwen3_xml`** | **correct call, finish `tool_calls`** |

So `eval-tools` would have scored **0** for a configuration reason rather than a model one — the same failure Gemma had on vLLM before its parser was set. The Granite driver now uses `qwen3_xml`.

### Why this was caught at all

The driver probes streaming *and* a live tool call before committing to 29 workloads, and prints `WARN: no tool call produced — eval-tools will score 0 for this cell`. That warning is what stopped the run 34 minutes in instead of after three models. No partial results were kept.

`uv run pytest` 452 passed / 3 skipped · `pnpm validate` 0 errors.