### PR TITLE
workloads: give the two newest evals room to answer

### DIFF
--- a/workloads/eval-hallucination-v1.json
+++ b/workloads/eval-hallucination-v1.json
@@ -4,11 +4,11 @@
   "id": "eval-hallucination-v1",
   "kind": "eval",
   "dataset_id": "aa-omniscience-v1",
-  "description": "600 short factual questions across six domains, scored three ways: right, wrong, or declined. Distinct from eval-knowledge-v1, which asks what a model knows — this asks what it does when it does not know, and charges it for guessing. Reports omniscience_index = (correct - incorrect) / total alongside accuracy.",
+  "description": "600 short factual questions across six domains, scored three ways: right, wrong, or declined. Distinct from eval-knowledge-v1, which asks what a model knows \u2014 this asks what it does when it does not know, and charges it for guessing. Reports omniscience_index = (correct - incorrect) / total alongside accuracy.",
   "params": {
     "concurrency": 4,
     "num_requests": 600,
-    "output_tokens": 512,
+    "output_tokens": 2048,
     "temperature": 0,
     "seed": 42,
     "timeout_s": 300,
@@ -19,8 +19,12 @@
   "eval": {
     "suite": "hallucination",
     "scorer": "abstention",
-    "max_output_tokens": 512
+    "max_output_tokens": 2048
   },
-  "metrics_required": ["accuracy", "success_rate", "avg_latency_ms"],
-  "notes": "Accuracy alone rewards guessing: a fabrication and an honest \"I don't know\" both score zero, so a model that never declines looks no worse than one that declines honestly. omniscience_index charges a wrong answer exactly what a right one earns and leaves declining free, so the two separate. hallucination_rate is the share of committed answers that were wrong. Scoring is substring matching plus a narrow abstention regex, NOT the grader Artificial Analysis run, so a number from here is not comparable to a published AA figure and must not be quoted as one. Source: AA-Omniscience public subset, https://huggingface.co/datasets/ArtificialAnalysis/AA-Omniscience-Public (Apache-2.0), part of the Artificial Analysis Intelligence Index v4.1.1."
+  "metrics_required": [
+    "accuracy",
+    "success_rate",
+    "avg_latency_ms"
+  ],
+  "notes": "Accuracy alone rewards guessing: a fabrication and an honest \"I don't know\" both score zero, so a model that never declines looks no worse than one that declines honestly. omniscience_index charges a wrong answer exactly what a right one earns and leaves declining free, so the two separate. hallucination_rate is the share of committed answers that were wrong. Scoring is substring matching plus a narrow abstention regex, NOT the grader Artificial Analysis run, so a number from here is not comparable to a published AA figure and must not be quoted as one. Source: AA-Omniscience public subset, https://huggingface.co/datasets/ArtificialAnalysis/AA-Omniscience-Public (Apache-2.0), part of the Artificial Analysis Intelligence Index v4.1.1. Output budget raised from 512 to 2048 on 2026-08-26: 512 was an outlier in this suite and it was the binding constraint, not the model: at that cap Qwen3.8-27B averaged 501 output tokens \u2014 98% of the budget \u2014 and 554 of 600 items came back with empty content, while the same model on eval-knowledge-v1, the closest analogue in answer length, averages 53 tokens against a 2048 cap and never truncates. gemma-4-E2B lost 301 of 600 the same way. 2048 matches eval-knowledge, eval-reasoning and eval-multilingual, so a model that still truncates here is telling you something about itself rather than about the workload."
 }

--- a/workloads/eval-longctx-reasoning-v1.json
+++ b/workloads/eval-longctx-reasoning-v1.json
@@ -4,11 +4,11 @@
   "id": "eval-longctx-reasoning-v1",
   "kind": "eval",
   "dataset_id": "aa-lcr-v1",
-  "description": "100 questions over 30 sets of real documents — company filings, government consultations, legal judgments, academic papers — at 72k to 115k input tokens. Answering means combining facts spread across several documents. Distinct from eval-longctx-v1 and the longctx-needle workloads, which plant one sentence in synthetic filler and ask the model to find it.",
+  "description": "100 questions over 30 sets of real documents \u2014 company filings, government consultations, legal judgments, academic papers \u2014 at 72k to 115k input tokens. Answering means combining facts spread across several documents. Distinct from eval-longctx-v1 and the longctx-needle workloads, which plant one sentence in synthetic filler and ask the model to find it.",
   "params": {
     "concurrency": 1,
     "num_requests": 100,
-    "output_tokens": 1024,
+    "output_tokens": 2048,
     "temperature": 0,
     "seed": 42,
     "timeout_s": 1800,
@@ -19,8 +19,12 @@
   "eval": {
     "suite": "longctx-reasoning",
     "scorer": "contains",
-    "max_output_tokens": 1024
+    "max_output_tokens": 2048
   },
-  "metrics_required": ["accuracy", "success_rate", "avg_latency_ms"],
-  "notes": "Needs the document corpus: run `python3 datasets/aa-lcr-v1/prepare.py` first. It is fetched rather than vendored because it is third-party material this repository does not redistribute. Without it every item is left UNSCORED rather than answered without its documents — a long-context question asked with no documents attached is not a smaller measurement, it is an easier and different one. Concurrency is 1 because a single item is already 72k-115k tokens of prefill. A configuration whose context window is smaller than the item will fail it outright; that is a true statement about the configuration, not a defect in the run. Scoring is casefolded substring matching, NOT the grader Artificial Analysis run, so a number from here is not comparable to a published AA figure and must not be quoted as one. Source: AA-LCR, https://huggingface.co/datasets/ArtificialAnalysis/AA-LCR (Apache-2.0), part of the Artificial Analysis Intelligence Index v4.1.1."
+  "metrics_required": [
+    "accuracy",
+    "success_rate",
+    "avg_latency_ms"
+  ],
+  "notes": "Needs the document corpus: run `python3 datasets/aa-lcr-v1/prepare.py` first. It is fetched rather than vendored because it is third-party material this repository does not redistribute. Without it every item is left UNSCORED rather than answered without its documents \u2014 a long-context question asked with no documents attached is not a smaller measurement, it is an easier and different one. Concurrency is 1 because a single item is already 72k-115k tokens of prefill. A configuration whose context window is smaller than the item will fail it outright; that is a true statement about the configuration, not a defect in the run. Scoring is casefolded substring matching, NOT the grader Artificial Analysis run, so a number from here is not comparable to a published AA figure and must not be quoted as one. Source: AA-LCR, https://huggingface.co/datasets/ArtificialAnalysis/AA-LCR (Apache-2.0), part of the Artificial Analysis Intelligence Index v4.1.1. Output budget raised from 1024 to 2048 on 2026-08-26: 1024 was close to binding: Qwen3.8-27B averaged 919 output tokens against it, 90% of the budget. Raised to 2048 to match the rest of the eval suite so the score measures reasoning over the documents rather than the room left to answer in."
 }


### PR DESCRIPTION
`eval-hallucination-v1` returned **554 of 600 items unscorable** on Qwen3.8-27B and **301 of 600** on gemma-4-E2B. Both were recorded honestly as unscorable rather than wrong — but at 92% the eval cannot discriminate between models, which makes it worthless for the thing it was adopted to measure.

### The cap was the cause, not the models

Same model, same suite, different budgets:

| eval | cap | avg output | unscorable |
|---|---|---|---|
| **hallucination** | **512** | **501** (98% of cap) | **554 / 600** |
| knowledge | 2048 | **53** | 0 |
| multilingual | 2048 | 126 | 0 |
| reasoning | 2048 | 307 | 0 |
| math | 4096 | 253 | 0 |
| code | 4096 | 1433 | 0 |
| longctx-reasoning | 1024 | **919** (90% of cap) | 2 |

`eval-knowledge-v1` is the closest analogue in answer length — short factual targets — and Qwen uses **53 tokens** against a 2048 cap without ever truncating. The 501-token average on hallucination is not the model thinking hard; it is the model being cut off on essentially every request. 512 was simply an outlier in this suite, chosen before any thinking model had run against it.

`eval-longctx-reasoning-v1` had the same defect one step less severe, at 90% of its cap.

### Both now 2048

Matching knowledge, reasoning and multilingual. A model that still truncates at 2048 on a question whose answer is an accounting reference or a date is telling you something about itself rather than about the workload — and that would be a finding worth having.

Existing results keep their own `resolved_params`, so a cell measured at 512 stays self-describing and is not silently comparable to one measured at 2048. The affected cells will be re-measured.

`pnpm validate` 0 errors · `uv run pytest` 452 passed.