### PR TITLE
results: Qwen3.8-Flash-Next (180B) on one DGX Spark with the 51B n-gram table on NVMe — llamacpp b50-035e227, gguf-ud-q4-k-xl

### DIFF
--- a/engines/llamacpp/versions/b50-035e227.json
+++ b/engines/llamacpp/versions/b50-035e227.json
@@ -1,0 +1,549 @@
+{
+  "schema_version": 1,
+  "engine_id": "llamacpp",
+  "version": "b50-035e227",
+  "released": null,
+  "extraction_method": "hand-seeded",
+  "extracted_at": "2026-08-27T00:00:00Z",
+  "source": "llama-server --help captured from this exact build: version 0.3.0-dev (build 50, commit 035e227), built with GNU 13.3.0 for Linux aarch64. Seeded from the b7000 registry file and extended with the flags that build carries and b7000 does not.",
+  "notes": "NOT an upstream llama.cpp release. This is a build of the unmerged PR #27742 (qwen4exp / Qwen3.8-Flash-Next architecture support) at commit 035e227, which self-reports the placeholder version 0.3.0-dev and build number 50 rather than a real bNNNN build number. It is recorded as its own square (engine_minor falls back to the whole string) because its flag surface and its supported architectures both differ from any released build. Two patches from github.com/0xBakeer/qwen38-flash-next-spark are applied on top: canreuse-qwen4exp.patch, which implements can_reuse() for llm_graph_input_qsa and llm_graph_input_ple so CUDA graphs actually engage (graphs reused 0 -> non-zero, decode +2.8%), and rowband-ple-quant.patch, which only matters when quantizing. The three flags this recipe turns on - override-tensor, load-mode and spec-type - are absent from the b7000 registry file entirely.",
+  "params": [
+    {
+      "name": "model",
+      "type": "path",
+      "default": null,
+      "help": "GGUF file to load. Dropped from the fingerprint.",
+      "aliases": [
+        "-m"
+      ],
+      "group": "model",
+      "impact": "low"
+    },
+    {
+      "name": "ctx-size",
+      "type": "int",
+      "default": 4096,
+      "help": "Context size in tokens. 0 means take it from the GGUF metadata.",
+      "aliases": [
+        "-c"
+      ],
+      "group": "memory",
+      "impact": "high"
+    },
+    {
+      "name": "n-gpu-layers",
+      "type": "int",
+      "default": 0,
+      "help": "Layers offloaded to the GPU. Use a large number (999) for all. Builds with a GPU backend compiled in may offload everything by default \u2014 verify against your build and record what you passed.",
+      "aliases": [
+        "-ngl",
+        "gpu-layers"
+      ],
+      "group": "memory",
+      "impact": "high"
+    },
+    {
+      "name": "threads",
+      "type": "int",
+      "default": -1,
+      "help": "CPU threads for generation. -1 means one per physical core.",
+      "aliases": [
+        "-t"
+      ],
+      "group": "memory",
+      "impact": "medium"
+    },
+    {
+      "name": "threads-batch",
+      "type": "int",
+      "default": -1,
+      "help": "CPU threads for prompt processing.",
+      "aliases": [
+        "-tb"
+      ],
+      "group": "memory",
+      "impact": "medium"
+    },
+    {
+      "name": "batch-size",
+      "type": "int",
+      "default": 2048,
+      "help": "Logical maximum batch size.",
+      "aliases": [
+        "-b"
+      ],
+      "group": "batching",
+      "impact": "high"
+    },
+    {
+      "name": "ubatch-size",
+      "type": "int",
+      "default": 512,
+      "help": "Physical micro-batch size \u2014 the one that actually changes prefill speed.",
+      "aliases": [
+        "-ub"
+      ],
+      "group": "batching",
+      "impact": "high"
+    },
+    {
+      "name": "parallel",
+      "type": "int",
+      "default": -1,
+      "help": "Number of server slots. This build reports 'default: -1, -1 = auto' in --help, so -1 is recorded here rather than the 1 carried by the b7000 file; that keeps an explicit --parallel 1 in the fingerprint, which matters because concurrent requests on the qwen4exp architecture are only safe while there is a single slot.",
+      "aliases": [
+        "-np"
+      ],
+      "group": "batching",
+      "impact": "high"
+    },
+    {
+      "name": "cont-batching",
+      "type": "bool",
+      "default": true,
+      "help": "Continuous batching. On by default in llama-server.",
+      "aliases": [
+        "-cb"
+      ],
+      "group": "batching",
+      "impact": "high"
+    },
+    {
+      "name": "no-cont-batching",
+      "type": "bool",
+      "default": false,
+      "help": "Disable continuous batching.",
+      "group": "batching",
+      "impact": "high"
+    },
+    {
+      "name": "flash-attn",
+      "type": "enum",
+      "default": "auto",
+      "choices": [
+        "on",
+        "off",
+        "auto"
+      ],
+      "help": "Flash attention. auto enables it where the backend supports it.",
+      "aliases": [
+        "-fa"
+      ],
+      "group": "compilation",
+      "impact": "high"
+    },
+    {
+      "name": "cache-type-k",
+      "type": "enum",
+      "default": "f16",
+      "choices": [
+        "f32",
+        "f16",
+        "bf16",
+        "q8_0",
+        "q4_0",
+        "q4_1",
+        "iq4_nl",
+        "q5_0",
+        "q5_1"
+      ],
+      "help": "KV cache key type. q8_0 and q4_0 trade accuracy for cache size.",
+      "aliases": [
+        "-ctk"
+      ],
+      "group": "caching",
+      "impact": "high"
+    },
+    {
+      "name": "cache-type-v",
+      "type": "enum",
+      "default": "f16",
+      "choices": [
+        "f32",
+        "f16",
+        "bf16",
+        "q8_0",
+        "q4_0",
+        "q4_1",
+        "iq4_nl",
+        "q5_0",
+        "q5_1"
+      ],
+      "help": "KV cache value type. Needs flash attention for the quantized types.",
+      "aliases": [
+        "-ctv"
+      ],
+      "group": "caching",
+      "impact": "high"
+    },
+    {
+      "name": "kv-unified",
+      "type": "bool",
+      "default": false,
+      "help": "Single unified KV buffer shared by all slots.",
+      "group": "caching",
+      "impact": "medium"
+    },
+    {
+      "name": "swa-full",
+      "type": "bool",
+      "default": false,
+      "help": "Keep the full KV cache for sliding-window models.",
+      "group": "caching",
+      "impact": "medium"
+    },
+    {
+      "name": "defrag-thold",
+      "type": "float",
+      "default": 0.1,
+      "help": "KV cache defragmentation threshold.",
+      "group": "caching",
+      "impact": "low"
+    },
+    {
+      "name": "no-mmap",
+      "type": "bool",
+      "default": false,
+      "help": "Read the whole model instead of memory-mapping it. Slower to start, avoids page-cache thrash.",
+      "group": "memory",
+      "impact": "medium"
+    },
+    {
+      "name": "mlock",
+      "type": "bool",
+      "default": false,
+      "help": "Lock the model in RAM.",
+      "group": "memory",
+      "impact": "medium"
+    },
+    {
+      "name": "split-mode",
+      "type": "enum",
+      "default": "layer",
+      "choices": [
+        "none",
+        "layer",
+        "row"
+      ],
+      "help": "How to split across multiple GPUs.",
+      "aliases": [
+        "-sm"
+      ],
+      "group": "parallelism",
+      "impact": "high"
+    },
+    {
+      "name": "tensor-split",
+      "type": "list",
+      "default": null,
+      "help": "Per-GPU split proportions.",
+      "aliases": [
+        "-ts"
+      ],
+      "group": "parallelism",
+      "impact": "high"
+    },
+    {
+      "name": "main-gpu",
+      "type": "int",
+      "default": 0,
+      "help": "GPU used for small tensors and, with split-mode none, everything.",
+      "aliases": [
+        "-mg"
+      ],
+      "group": "parallelism",
+      "impact": "medium"
+    },
+    {
+      "name": "device",
+      "type": "str",
+      "default": null,
+      "help": "Explicit backend device list.",
+      "group": "parallelism",
+      "impact": "medium"
+    },
+    {
+      "name": "rope-scaling",
+      "type": "enum",
+      "default": "none",
+      "choices": [
+        "none",
+        "linear",
+        "yarn"
+      ],
+      "help": "RoPE scaling method.",
+      "group": "model",
+      "impact": "high"
+    },
+    {
+      "name": "rope-freq-base",
+      "type": "float",
+      "default": 0,
+      "help": "RoPE base frequency. 0 keeps the model's own.",
+      "group": "model",
+      "impact": "high"
+    },
+    {
+      "name": "rope-freq-scale",
+      "type": "float",
+      "default": 0,
+      "help": "RoPE frequency scaling factor.",
+      "group": "model",
+      "impact": "high"
+    },
+    {
+      "name": "yarn-orig-ctx",
+      "type": "int",
+      "default": 0,
+      "help": "Original context size for YaRN scaling.",
+      "group": "model",
+      "impact": "medium"
+    },
+    {
+      "name": "n-predict",
+      "type": "int",
+      "default": -1,
+      "help": "Server-side cap on generated tokens.",
+      "aliases": [
+        "-n"
+      ],
+      "group": "sampling",
+      "impact": "medium"
+    },
+    {
+      "name": "keep",
+      "type": "int",
+      "default": 0,
+      "help": "Tokens of the prompt kept when the context is shifted.",
+      "group": "sampling",
+      "impact": "low"
+    },
+    {
+      "name": "temp",
+      "type": "float",
+      "default": 0.8,
+      "help": "Sampling temperature.",
+      "group": "sampling",
+      "impact": "medium"
+    },
+    {
+      "name": "top-k",
+      "type": "int",
+      "default": 40,
+      "help": "Top-k sampling.",
+      "group": "sampling",
+      "impact": "low"
+    },
+    {
+      "name": "top-p",
+      "type": "float",
+      "default": 0.95,
+      "help": "Top-p sampling.",
+      "group": "sampling",
+      "impact": "low"
+    },
+    {
+      "name": "min-p",
+      "type": "float",
+      "default": 0.05,
+      "help": "Min-p sampling.",
+      "group": "sampling",
+      "impact": "low"
+    },
+    {
+      "name": "repeat-penalty",
+      "type": "float",
+      "default": 1.0,
+      "help": "Repetition penalty. 1.0 disables it.",
+      "group": "sampling",
+      "impact": "low"
+    },
+    {
+      "name": "seed",
+      "type": "int",
+      "default": -1,
+      "help": "Random seed. -1 is random.",
+      "group": "sampling",
+      "impact": "medium"
+    },
+    {
+      "name": "jinja",
+      "type": "bool",
+      "default": false,
+      "help": "Use the GGUF's Jinja chat template. Required for tool calls on most recent models.",
+      "group": "model",
+      "impact": "medium"
+    },
+    {
+      "name": "chat-template",
+      "type": "str",
+      "default": null,
+      "help": "Override the chat template by name.",
+      "group": "model",
+      "impact": "medium"
+    },
+    {
+      "name": "reasoning-format",
+      "type": "enum",
+      "default": "auto",
+      "choices": [
+        "none",
+        "auto",
+        "deepseek",
+        "deepseek-legacy"
+      ],
+      "help": "How reasoning content is returned.",
+      "group": "model",
+      "impact": "low"
+    },
+    {
+      "name": "draft-max",
+      "type": "int",
+      "default": 16,
+      "help": "Maximum draft tokens per speculative step.",
+      "aliases": [
+        "draft"
+      ],
+      "group": "speculative",
+      "impact": "high"
+    },
+    {
+      "name": "draft-min",
+      "type": "int",
+      "default": 0,
+      "help": "Minimum draft tokens per speculative step.",
+      "group": "speculative",
+      "impact": "medium"
+    },
+    {
+      "name": "model-draft",
+      "type": "path",
+      "default": null,
+      "help": "Draft model for speculative decoding.",
+      "aliases": [
+        "-md"
+      ],
+      "group": "speculative",
+      "impact": "high"
+    },
+    {
+      "name": "gpu-layers-draft",
+      "type": "int",
+      "default": 0,
+      "help": "Draft-model layers offloaded to the GPU.",
+      "aliases": [
+        "-ngld"
+      ],
+      "group": "speculative",
+      "impact": "medium"
+    },
+    {
+      "name": "numa",
+      "type": "enum",
+      "default": null,
+      "choices": [
+        "distribute",
+        "isolate",
+        "numactl"
+      ],
+      "help": "NUMA optimisation strategy.",
+      "group": "memory",
+      "impact": "medium"
+    },
+    {
+      "name": "host",
+      "type": "str",
+      "default": "127.0.0.1",
+      "help": "Bind address. Dropped from the fingerprint.",
+      "group": "server",
+      "impact": "low"
+    },
+    {
+      "name": "port",
+      "type": "int",
+      "default": 8080,
+      "help": "Bind port. Dropped from the fingerprint.",
+      "group": "server",
+      "impact": "low"
+    },
+    {
+      "name": "api-key",
+      "type": "str",
+      "default": null,
+      "help": "Required API key. Dropped from the fingerprint.",
+      "group": "server",
+      "impact": "low"
+    },
+    {
+      "name": "alias",
+      "type": "str",
+      "default": null,
+      "help": "Model name reported by the API. Dropped from the fingerprint.",
+      "group": "server",
+      "impact": "low"
+    },
+    {
+      "name": "threads-http",
+      "type": "int",
+      "default": -1,
+      "help": "HTTP worker threads. Dropped from the fingerprint.",
+      "group": "server",
+      "impact": "low"
+    },
+    {
+      "name": "metrics",
+      "type": "bool",
+      "default": false,
+      "help": "Expose the Prometheus endpoint. Dropped from the fingerprint.",
+      "group": "server",
+      "impact": "low"
+    },
+    {
+      "name": "slots",
+      "type": "bool",
+      "default": false,
+      "help": "Expose the slots endpoint. Dropped from the fingerprint.",
+      "group": "server",
+      "impact": "low"
+    },
+    {
+      "name": "no-webui",
+      "type": "bool",
+      "default": false,
+      "help": "Disable the built-in web UI. Dropped from the fingerprint.",
+      "group": "server",
+      "impact": "low"
+    },
+    {
+      "name": "override-tensor",
+      "type": "str",
+      "default": null,
+      "help": "Override the buffer type for tensors matching a pattern, as <tensor name pattern>=<buffer type>. This recipe passes per_layer_token_embd=CPU to keep the 51.2B n-gram/PLE table off the accelerator; combined with load-mode mmap it is then served from NVMe through the OS page cache and never becomes resident. Decisive for whether a 180B model fits in 128 GB at all.",
+      "aliases": [
+        "-ot"
+      ],
+      "group": "memory",
+      "impact": "high"
+    },
+    {
+      "name": "load-mode",
+      "type": "enum",
+      "default": "auto",
+      "help": "Model loading mode: auto, none, or mmap. auto already memory-maps unless a device cannot; passing mmap forces it. Recorded explicitly here because the whole point of this configuration is that the n-gram table is paged from storage rather than loaded.",
+      "aliases": [
+        "-lm"
+      ],
+      "group": "memory",
+      "impact": "high"
+    },
+    {
+      "name": "spec-type",
+      "type": "enum",
+      "default": "none",
+      "help": "Comma-separated speculative decoding types: none, draft-simple, draft-eagle3, draft-mtp, draft-dflash, draft-dspark, ngram-simple, ngram-map-k, ngram-map-k4v, ngram-mod, ngram-cache. ngram-mod drafts spans from repetition already in the context, so it needs no draft model and no extra memory. Speculation is exact - the target verifies every token - so output is unchanged, but throughput varies up to 3x by how much of the output already appears in the prompt. Never compare a decode number across two different values of this flag.",
+      "aliases": [],
+      "group": "speculative",
+      "impact": "high"
+    }
+  ]
+}

--- a/models/Qwen/Qwen3.8-Flash-Next/model.json
+++ b/models/Qwen/Qwen3.8-Flash-Next/model.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "id": "Qwen/Qwen3.8-Flash-Next",
+  "name": "Qwen3.8-Flash-Next",
+  "hf_id": "Qwen/Qwen3.8-Flash-Next",
+  "family": "qwen3.8",
+  "vendor": "alibaba",
+  "params_b": 176.9,
+  "active_params_b": 4.7,
+  "architecture": "qwen4exp",
+  "moe": true,
+  "experts": 512,
+  "experts_active": 10,
+  "attention": "hybrid",
+  "modalities": [
+    "text",
+    "image"
+  ],
+  "context_length": 262144,
+  "licence": "Apache-2.0",
+  "released": "2026-08-26",
+  "tags": [
+    "chat",
+    "reasoning",
+    "moe",
+    "vision"
+  ],
+  "links": {
+    "hf": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next"
+  },
+  "notes": "All architecture numbers here were read out of the GGUF KV metadata of unsloth/Qwen3.8-Flash-Next-GGUF (general.architecture=qwen4exp, size_label 512x56B), not typed from a model card. block_count 48, embedding_length 2560, attention.head_count 24, head_count_kv 2, expert_count 512, expert_used_count 10, expert_feed_forward_length 640. This model is multimodal: the Hugging Face card carries pipeline_tag image-text-to-text, the GGUF KV carries qwen4exp.ple.image_token_id, and the bundled chat template handles image and video turns. The vision tower is NOT in these weight shards - all 1,224 tensors across the four shards are language-model tensors, with no vision/clip/patch tensor present - because llama.cpp ships multimodal as a separate projector file, and unsloth publishes it alongside as mmproj-BF16.gguf / mmproj-F16.gguf (~0.9 GB). A server started without --mmproj, as in the run recorded here, is text-only in practice even though the model is not. params_b 176.9 is the exact parameter count llama-server reports (176,943,899,520). Of that, 51.2B is a single n-gram/PLE embedding table (per_layer_token_embd.weight, [160, 320001536], ple.ngram_size 3, ple.heads_per_ngram 8, 16 head vocabs of ~20M rows) which is only ever gathered from, never multiplied - it can be served from storage rather than accelerator memory. active_params_b 4.7 is DERIVED, not captured: 10/512 experts (2.36B) + shared expert (0.24B) + attention (0.82B) + embed/output (1.27B). Treat it as approximate - only 12 of 48 layers use full attention, the rest are gated-delta-net, so the attention term is an upper bound. The bandwidth-bound decode ceiling computed from it will be far above what this model actually achieves, because a top-10-of-512 MoE scatters expert reads and does not stream weights contiguously."
+}

--- a/models/Qwen/Qwen3.8-Flash-Next/quants/gguf-ud-q4-k-xl.json
+++ b/models/Qwen/Qwen3.8-Flash-Next/quants/gguf-ud-q4-k-xl.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "id": "gguf-ud-q4-k-xl",
+  "model_id": "Qwen/Qwen3.8-Flash-Next",
+  "format": "gguf",
+  "bits": 5.03,
+  "hf_id": "unsloth/Qwen3.8-Flash-Next-GGUF",
+  "revision": null,
+  "files": [
+    "Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf",
+    "Qwen3.8-Flash-Next-UD-Q4_K_XL-00002-of-00004.gguf",
+    "Qwen3.8-Flash-Next-UD-Q4_K_XL-00003-of-00004.gguf",
+    "Qwen3.8-Flash-Next-UD-Q4_K_XL-00004-of-00004.gguf"
+  ],
+  "ollama_tag": null,
+  "size_gb": 111.3,
+  "engines": [
+    "llamacpp"
+  ],
+  "source": "community",
+  "calibration": "imatrix",
+  "links": {
+    "hf": "https://huggingface.co/unsloth/Qwen3.8-Flash-Next-GGUF"
+  },
+  "notes": "Unsloth dynamic quant (general.quantized_by=Unsloth, quantization_version 2, file_type 15). imatrix calibrated: quantize.imatrix.file=Qwen3.8-Flash-Next-GGUF/imatrix_unsloth.gguf, dataset unsloth_calibration_Qwen3.8-Flash-Next.txt, 926 entries over 45 chunks - all read from the GGUF KV metadata of the actual files used. bits 5.03 is computed from the real on-disk size (111,323,630,080 bytes over 176,943,899,520 parameters), not the nominal Q4 label; the UD scheme keeps some tensors at higher precision, and the 51.2B n-gram table dominates the file. size_gb is the sum of the four shards in decimal GB (103.7 GiB). Only llamacpp is listed because loading this architecture needs the unmerged qwen4exp support from llama.cpp PR #27742; no released engine can read these files yet."
+}

--- a/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/fa4e2bc695c71203--prefill-32k-v1--8dfcef.json
+++ b/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/fa4e2bc695c71203--prefill-32k-v1--8dfcef.json
@@ -1,0 +1,356 @@
+{
+  "schema_version": 1,
+  "run_id": "fa4e2bc695c71203--prefill-32k-v1--8dfcef",
+  "config_id": "fa4e2bc695c71203",
+  "cell_id": "1ab063de12eb",
+  "workload_id": "prefill-32k-v1",
+  "kind": "prefill",
+  "engine": {
+    "id": "llamacpp",
+    "version": "b50-035e227",
+    "commit": null,
+    "container": null,
+    "install_method": "source"
+  },
+  "model": {
+    "id": "Qwen/Qwen3.8-Flash-Next",
+    "quant_id": "gguf-ud-q4-k-xl",
+    "hf_id": "Qwen/Qwen3.8-Flash-Next",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "ctx-size": 262144,
+    "n-gpu-layers": 999,
+    "parallel": 1,
+    "override-tensor": "per_layer_token_embd=CPU",
+    "load-mode": "mmap",
+    "spec-type": "ngram-mod",
+    "temp": 1.0,
+    "top-p": 0.95,
+    "top-k": 20
+  },
+  "args_canonical": "@dtype=auto;@quant=gguf-ud-q4-k-xl;ctx-size=262144;load-mode=mmap;n-gpu-layers=999;override-tensor=per_layer_token_embd=CPU;parallel=1;spec-type=ngram-mod;temp=1;top-k=20",
+  "serve_command": "$HOME/llamacpp-qwen4exp/build/bin/llama-server -m $HOME/qwen38fn-q4kxl/UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf --alias qwen3.8-flash-next -lm mmap -ot per_layer_token_embd=CPU --n-gpu-layers 999 --ctx-size 262144 --parallel 1 --spec-type ngram-mod --temp 1.0 --top-p 0.95 --top-k 20 --host 127.0.0.1 --port 8000",
+  "workload": {
+    "id": "prefill-32k-v1",
+    "resolved_params": {
+      "concurrency": 1,
+      "num_requests": 10,
+      "input_tokens": 32768,
+      "output_tokens": 16,
+      "warmup_requests": 1,
+      "prompts_padded": false,
+      "needle_check": false,
+      "timeout_s": 900.0,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 10,
+    "requests_ok": 10,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 281.146,
+    "input_tokens_total": 403331,
+    "output_tokens_total": 160,
+    "output_tok_s": 0.569,
+    "total_tok_s": 1435.163,
+    "req_s": 0.036,
+    "prefill_tok_s": 1480.965,
+    "ttft_ms": {
+      "mean": 27234.329,
+      "p50": 902.392,
+      "p90": 88784.15,
+      "p95": 89401.288,
+      "p99": 89894.998,
+      "min": 203.688,
+      "max": 90018.425
+    },
+    "tpot_ms": {
+      "mean": 58.685,
+      "p50": 58.686,
+      "p90": 59.727,
+      "p95": 59.913,
+      "p99": 60.061,
+      "min": 57.171,
+      "max": 60.099
+    },
+    "itl_ms": {
+      "mean": 58.643,
+      "p50": 57.179,
+      "p90": 62.449,
+      "p95": 70.26,
+      "p99": 75.272,
+      "min": 54.833,
+      "max": 81.757
+    },
+    "e2e_ms": {
+      "mean": 28114.604,
+      "p50": 1787.816,
+      "p90": 89661.627,
+      "p95": 90276.52,
+      "p99": 90768.434,
+      "min": 1088.625,
+      "max": 90891.412
+    },
+    "decode_tok_s_per_request": {
+      "mean": 17.044,
+      "p50": 17.04,
+      "p90": 17.329,
+      "p95": 17.41,
+      "p99": 17.475,
+      "min": 16.639,
+      "max": 17.491
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 102.936,
+    "kv_cache_tokens": null,
+    "power_avg_w": 65.97,
+    "power_peak_w": 74.76,
+    "energy_wh": 6.8212,
+    "gpu_util_avg_pct": 87.87,
+    "temp_max_c": 79.0,
+    "thermal_throttle_detected": false
+  },
+  "failures": [],
+  "gotchas": [
+    {
+      "severity": "info",
+      "text": "--parallel 1 is not a tuning choice, it is forced. llama-server gives this build ONE server slot, so every workload here with concurrency above 1 measures a QUEUE, not parallelism: requests are admitted one at a time and the rest wait. This was verified before the run - 8 simultaneous requests all returned 200 and completed in near-perfect 3 second succession, and the server survived. Read the concurrent cells as what N clients experience against a single-slot server: aggregate throughput stays near the single-stream number and per-request latency grows linearly with N. Do NOT compare them to a genuinely batched engine, and note that at high N, against the workloads 300 second timeout, tail requests can exceed the timeout and depress success_rate. The recipe README reports that raising --parallel above 1 aborts with a GGML_ASSERT in qwen4exp.cpp:284, which is why 1 is used."
+    },
+    {
+      "severity": "info",
+      "text": "--spec-type ngram-mod is ON. It drafts spans from repetition already present in the context, so it needs no draft model and no extra memory, and it is exact - the target model verifies every token, so output is byte-identical to running without it. But throughput varies up to 3x by how much of the output already appears in the prompt: the recipe measures 52.6 to 74.6 tok/s on reproduce-this-file-with-one-change, 46 to 51.6 on a targeted bug fix, and 22.2 to 23.3 on free-form prose. A free-form decode number and a copy-heavy decode number from this same config are both true and are not comparable to each other. Never compare any decode figure here against a cell run with a different --spec-type."
+    },
+    {
+      "severity": "info",
+      "text": "A quarter of this model lives on NVMe, so page-cache state is a hidden independent variable. The 51.2B n-gram table is 26.8 GiB of the file and is gathered about 16 rows at a time out of 320,001,536, so a short workload almost never touches a row twice and the table does not warm on its own. This run started at a measured 73.0% residency after an explicit warm. The recipe measures cold versus warm at +6% with speculation off but up to +42% with ngram-mod on, because verifying a 50-60 token draft span touches many n-gram rows at once. Any result from this configuration that does not state its table residency is not reproducible."
+    },
+    {
+      "severity": "info",
+      "text": "Model facts in the registry entries added with this run were read out of the GGUF KV metadata of the actual files benchmarked, not from a model card: general.architecture=qwen4exp, size_label 512x56B, block_count 48, embedding_length 2560, attention.head_count 24 and head_count_kv 2, expert_count 512, expert_used_count 10, ple.ngram_size 3, ple.heads_per_ngram 8. The one exception is active_params_b 4.7, which is DERIVED (10 of 512 experts, plus shared expert, attention, and embed/output) and approximate, because only 12 of 48 layers use full attention. The bandwidth-bound decode ceiling computed from it will sit far above what this model actually reaches: a top-10-of-512 MoE scatters expert reads rather than streaming weights contiguously, so this configuration is not simply bandwidth-bound."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": 0.0086,
+    "tok_s_per_gb_bandwidth": 0.062432,
+    "bandwidth_efficiency": 0.184618,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "13af9ca0e44b8b496268e8d5d6006f40a5e75199776930a6bca7632df18ab484",
+    "payload_path": null,
+    "payload": {
+      "requests": [
+        {
+          "id": "prefill-w00000",
+          "prompt_id": "hay-32k-d10",
+          "warmup": true,
+          "status": "ok",
+          "ttft_ms": 89644.316,
+          "e2e_ms": 90536.388,
+          "prompt_tokens": 40226,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00000",
+          "prompt_id": "hay-32k-d10",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 203.688,
+          "e2e_ms": 1088.625,
+          "prompt_tokens": 40226,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00001",
+          "prompt_id": "hay-32k-multi",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 88051.53,
+          "e2e_ms": 88946.811,
+          "prompt_tokens": 40465,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00002",
+          "prompt_id": "hay-32k-d50",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 88647.009,
+          "e2e_ms": 89524.984,
+          "prompt_tokens": 40273,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00003",
+          "prompt_id": "hay-32k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 90018.425,
+          "e2e_ms": 90891.412,
+          "prompt_tokens": 40356,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00004",
+          "prompt_id": "hay-32k-d10",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 1059.634,
+          "e2e_ms": 1917.202,
+          "prompt_tokens": 40226,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00005",
+          "prompt_id": "hay-32k-multi",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 877.214,
+          "e2e_ms": 1778.693,
+          "prompt_tokens": 40465,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00006",
+          "prompt_id": "hay-32k-d50",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 901.43,
+          "e2e_ms": 1789.682,
+          "prompt_tokens": 40273,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00007",
+          "prompt_id": "hay-32k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 903.354,
+          "e2e_ms": 1785.95,
+          "prompt_tokens": 40356,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00008",
+          "prompt_id": "hay-32k-d10",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 873.508,
+          "e2e_ms": 1740.027,
+          "prompt_tokens": 40226,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00009",
+          "prompt_id": "hay-32k-multi",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 807.496,
+          "e2e_ms": 1682.657,
+          "prompt_tokens": 40465,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        }
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "qwen3.8-flash-next",
+        "advertised_models": [
+          "qwen3.8-flash-next"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-27T08:37:38Z",
+    "finished_at": "2026-08-27T08:43:50Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "NVIDIA DGX Spark (ASUS Ascent GX10, GB10 / SM121, 128 GB unified memory, ~121 GiB usable) on Ubuntu 24.04.4 LTS, kernel 6.17.0-1029-nvidia aarch64, driver 580.173.02, CUDA 13.0. Swap is off. Engine is llama.cpp built from the UNMERGED PR #27742 (qwen4exp architecture support) at commit 035e227; the binary self-reports version 0.3.0-dev, build 50, commit 035e227, which is a placeholder rather than an upstream release, so it is recorded as its own engine square rather than folded into any bNNNN build. On top of that commit the canreuse-qwen4exp patch from github.com/0xBakeer/qwen38-flash-next-spark (commit 2ab233f) is applied: it implements can_reuse() for the qwen4exp QSA and PLE graph inputs so CUDA graph capture engages at all (graphs reused goes 0 to non-zero; the recipe measures decode +2.8%). Applied state was verified two ways before this run: two can_reuse overrides present in src/models/qwen4exp.cpp, and the patch refusing to re-apply. Model is unsloth/Qwen3.8-Flash-Next-GGUF UD-Q4_K_XL, four shards, 111,323,630,080 bytes on disk (103.7 GiB) for 176,943,899,520 parameters = 5.03 bits/parameter. Server flags: -lm mmap -ot per_layer_token_embd=CPU --n-gpu-layers 999 --ctx-size 262144 --parallel 1 --spec-type ngram-mod --temp 1.0 --top-p 0.95 --top-k 20. The defining choice is -ot per_layer_token_embd=CPU together with -lm mmap: the 51.2B-parameter n-gram/PLE embedding table (one tensor, shape 160 by 320001536) is pinned to the CPU backend and served from NVMe through the OS page cache instead of being made resident, which is the only reason a 180B model runs in 128 GB with the full 262,144-token context. KV cache is f16 (quantized KV aborts on this architecture) and costs only about 24 KB/token because 12 of 48 layers use full attention with 2 KV heads. Immediately before this run the n-gram table was deliberately warmed with tools/warm_table.py to a measured 73.0% page-cache residency of its 26.8 GiB region (mincore-verified, up from 67.7%); table residency changes decode throughput materially, so it is a run condition, not an incidental detail. The machine was fully isolated for the duration: this host normally also serves an OpenAI-compatible endpoint to other clients, and that path was shut off before the run so nothing external could contend for the single server slot. llama-server binds loopback only and the harness connected to it directly, so no reverse proxy sat in the measured path."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/fa4e2bc695c71203--prefill-32k-v1--8dfcef.json
+++ b/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/fa4e2bc695c71203--prefill-32k-v1--8dfcef.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -61,7 +61,7 @@
     "override-tensor": "per_layer_token_embd=CPU",
     "load-mode": "mmap",
     "spec-type": "ngram-mod",
-    "temp": 1.0,
+    "temp": 1,
     "top-p": 0.95,
     "top-k": 20
   },
@@ -77,7 +77,7 @@
       "warmup_requests": 1,
       "prompts_padded": false,
       "needle_check": false,
-      "timeout_s": 900.0,
+      "timeout_s": 900,
       "seed": 42
     }
   },
@@ -85,7 +85,7 @@
     "requests_total": 10,
     "requests_ok": 10,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 281.146,
     "input_tokens_total": 403331,
     "output_tokens_total": 160,
@@ -145,7 +145,7 @@
     "power_peak_w": 74.76,
     "energy_wh": 6.8212,
     "gpu_util_avg_pct": 87.87,
-    "temp_max_c": 79.0,
+    "temp_max_c": 79,
     "thermal_throttle_detected": false
   },
   "failures": [],
@@ -338,7 +338,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-27T08:37:38Z",
     "finished_at": "2026-08-27T08:43:50Z",
     "submitted_at": null,

--- a/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/fa4e2bc695c71203--prefill-8k-v1--e6c546.json
+++ b/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/fa4e2bc695c71203--prefill-8k-v1--e6c546.json
@@ -1,0 +1,356 @@
+{
+  "schema_version": 1,
+  "run_id": "fa4e2bc695c71203--prefill-8k-v1--e6c546",
+  "config_id": "fa4e2bc695c71203",
+  "cell_id": "1ab063de12eb",
+  "workload_id": "prefill-8k-v1",
+  "kind": "prefill",
+  "engine": {
+    "id": "llamacpp",
+    "version": "b50-035e227",
+    "commit": null,
+    "container": null,
+    "install_method": "source"
+  },
+  "model": {
+    "id": "Qwen/Qwen3.8-Flash-Next",
+    "quant_id": "gguf-ud-q4-k-xl",
+    "hf_id": "Qwen/Qwen3.8-Flash-Next",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "ctx-size": 262144,
+    "n-gpu-layers": 999,
+    "parallel": 1,
+    "override-tensor": "per_layer_token_embd=CPU",
+    "load-mode": "mmap",
+    "spec-type": "ngram-mod",
+    "temp": 1.0,
+    "top-p": 0.95,
+    "top-k": 20
+  },
+  "args_canonical": "@dtype=auto;@quant=gguf-ud-q4-k-xl;ctx-size=262144;load-mode=mmap;n-gpu-layers=999;override-tensor=per_layer_token_embd=CPU;parallel=1;spec-type=ngram-mod;temp=1;top-k=20",
+  "serve_command": "$HOME/llamacpp-qwen4exp/build/bin/llama-server -m $HOME/qwen38fn-q4kxl/UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf --alias qwen3.8-flash-next -lm mmap -ot per_layer_token_embd=CPU --n-gpu-layers 999 --ctx-size 262144 --parallel 1 --spec-type ngram-mod --temp 1.0 --top-p 0.95 --top-k 20 --host 127.0.0.1 --port 8000",
+  "workload": {
+    "id": "prefill-8k-v1",
+    "resolved_params": {
+      "concurrency": 1,
+      "num_requests": 10,
+      "input_tokens": 8192,
+      "output_tokens": 16,
+      "warmup_requests": 1,
+      "prompts_padded": false,
+      "needle_check": false,
+      "timeout_s": 900.0,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 10,
+    "requests_ok": 10,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 69.154,
+    "input_tokens_total": 101962,
+    "output_tokens_total": 160,
+    "output_tok_s": 2.314,
+    "total_tok_s": 1476.744,
+    "req_s": 0.145,
+    "prefill_tok_s": 1660.929,
+    "ttft_ms": {
+      "mean": 6138.853,
+      "p50": 476.955,
+      "p90": 19614.567,
+      "p95": 20296.279,
+      "p99": 20841.648,
+      "min": 155.431,
+      "max": 20977.99
+    },
+    "tpot_ms": {
+      "mean": 51.763,
+      "p50": 48.519,
+      "p90": 60.135,
+      "p95": 60.889,
+      "p99": 61.492,
+      "min": 46.739,
+      "max": 61.643
+    },
+    "itl_ms": {
+      "mean": 51.733,
+      "p50": 47.48,
+      "p90": 61.845,
+      "p95": 64.175,
+      "p99": 74.476,
+      "min": 44.475,
+      "max": 87.105
+    },
+    "e2e_ms": {
+      "mean": 6915.302,
+      "p50": 1370.205,
+      "p90": 20328.448,
+      "p95": 21004.579,
+      "p99": 21545.484,
+      "min": 856.512,
+      "max": 21680.71
+    },
+    "decode_tok_s_per_request": {
+      "mean": 19.548,
+      "p50": 20.617,
+      "p90": 21.351,
+      "p95": 21.373,
+      "p99": 21.391,
+      "min": 16.222,
+      "max": 21.396
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 102.235,
+    "kv_cache_tokens": null,
+    "power_avg_w": 56.75,
+    "power_peak_w": 72.21,
+    "energy_wh": 1.4635,
+    "gpu_util_avg_pct": 85.2,
+    "temp_max_c": 67.0,
+    "thermal_throttle_detected": false
+  },
+  "failures": [],
+  "gotchas": [
+    {
+      "severity": "info",
+      "text": "--parallel 1 is not a tuning choice, it is forced. llama-server gives this build ONE server slot, so every workload here with concurrency above 1 measures a QUEUE, not parallelism: requests are admitted one at a time and the rest wait. This was verified before the run - 8 simultaneous requests all returned 200 and completed in near-perfect 3 second succession, and the server survived. Read the concurrent cells as what N clients experience against a single-slot server: aggregate throughput stays near the single-stream number and per-request latency grows linearly with N. Do NOT compare them to a genuinely batched engine, and note that at high N, against the workloads 300 second timeout, tail requests can exceed the timeout and depress success_rate. The recipe README reports that raising --parallel above 1 aborts with a GGML_ASSERT in qwen4exp.cpp:284, which is why 1 is used."
+    },
+    {
+      "severity": "info",
+      "text": "--spec-type ngram-mod is ON. It drafts spans from repetition already present in the context, so it needs no draft model and no extra memory, and it is exact - the target model verifies every token, so output is byte-identical to running without it. But throughput varies up to 3x by how much of the output already appears in the prompt: the recipe measures 52.6 to 74.6 tok/s on reproduce-this-file-with-one-change, 46 to 51.6 on a targeted bug fix, and 22.2 to 23.3 on free-form prose. A free-form decode number and a copy-heavy decode number from this same config are both true and are not comparable to each other. Never compare any decode figure here against a cell run with a different --spec-type."
+    },
+    {
+      "severity": "info",
+      "text": "A quarter of this model lives on NVMe, so page-cache state is a hidden independent variable. The 51.2B n-gram table is 26.8 GiB of the file and is gathered about 16 rows at a time out of 320,001,536, so a short workload almost never touches a row twice and the table does not warm on its own. This run started at a measured 73.0% residency after an explicit warm. The recipe measures cold versus warm at +6% with speculation off but up to +42% with ngram-mod on, because verifying a 50-60 token draft span touches many n-gram rows at once. Any result from this configuration that does not state its table residency is not reproducible."
+    },
+    {
+      "severity": "info",
+      "text": "Model facts in the registry entries added with this run were read out of the GGUF KV metadata of the actual files benchmarked, not from a model card: general.architecture=qwen4exp, size_label 512x56B, block_count 48, embedding_length 2560, attention.head_count 24 and head_count_kv 2, expert_count 512, expert_used_count 10, ple.ngram_size 3, ple.heads_per_ngram 8. The one exception is active_params_b 4.7, which is DERIVED (10 of 512 experts, plus shared expert, attention, and embed/output) and approximate, because only 12 of 48 layers use full attention. The bandwidth-bound decode ceiling computed from it will sit far above what this model actually reaches: a top-10-of-512 MoE scatters expert reads rather than streaming weights contiguously, so this configuration is not simply bandwidth-bound."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": 0.0408,
+    "tok_s_per_gb_bandwidth": 0.071604,
+    "bandwidth_efficiency": 0.211741,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "49d5e6e829b1679b6b9281b3898b7fb339edeed361f68bceafafe70d23182ff8",
+    "payload_path": null,
+    "payload": {
+      "requests": [
+        {
+          "id": "prefill-w00000",
+          "prompt_id": "hay-8k-d10",
+          "warmup": true,
+          "status": "ok",
+          "ttft_ms": 22443.542,
+          "e2e_ms": 23160.721,
+          "prompt_tokens": 10248,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00000",
+          "prompt_id": "hay-8k-d10",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 155.431,
+          "e2e_ms": 856.512,
+          "prompt_tokens": 10248,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00001",
+          "prompt_id": "hay-8k-multi",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 19463.076,
+          "e2e_ms": 20178.197,
+          "prompt_tokens": 10194,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00002",
+          "prompt_id": "hay-8k-d50",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 20977.99,
+          "e2e_ms": 21680.71,
+          "prompt_tokens": 10143,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00003",
+          "prompt_id": "hay-8k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 17961.57,
+          "e2e_ms": 18668.616,
+          "prompt_tokens": 10175,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00004",
+          "prompt_id": "hay-8k-d10",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 473.771,
+          "e2e_ms": 1371.504,
+          "prompt_tokens": 10248,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00005",
+          "prompt_id": "hay-8k-multi",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 455.725,
+          "e2e_ms": 1196.162,
+          "prompt_tokens": 10194,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00006",
+          "prompt_id": "hay-8k-d50",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 469.387,
+          "e2e_ms": 1368.906,
+          "prompt_tokens": 10143,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00007",
+          "prompt_id": "hay-8k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 448.365,
+          "e2e_ms": 1373.009,
+          "prompt_tokens": 10175,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00008",
+          "prompt_id": "hay-8k-d10",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 480.139,
+          "e2e_ms": 1194.872,
+          "prompt_tokens": 10248,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00009",
+          "prompt_id": "hay-8k-multi",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 503.071,
+          "e2e_ms": 1264.528,
+          "prompt_tokens": 10194,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        }
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "qwen3.8-flash-next",
+        "advertised_models": [
+          "qwen3.8-flash-next"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-27T08:36:04Z",
+    "finished_at": "2026-08-27T08:37:38Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "NVIDIA DGX Spark (ASUS Ascent GX10, GB10 / SM121, 128 GB unified memory, ~121 GiB usable) on Ubuntu 24.04.4 LTS, kernel 6.17.0-1029-nvidia aarch64, driver 580.173.02, CUDA 13.0. Swap is off. Engine is llama.cpp built from the UNMERGED PR #27742 (qwen4exp architecture support) at commit 035e227; the binary self-reports version 0.3.0-dev, build 50, commit 035e227, which is a placeholder rather than an upstream release, so it is recorded as its own engine square rather than folded into any bNNNN build. On top of that commit the canreuse-qwen4exp patch from github.com/0xBakeer/qwen38-flash-next-spark (commit 2ab233f) is applied: it implements can_reuse() for the qwen4exp QSA and PLE graph inputs so CUDA graph capture engages at all (graphs reused goes 0 to non-zero; the recipe measures decode +2.8%). Applied state was verified two ways before this run: two can_reuse overrides present in src/models/qwen4exp.cpp, and the patch refusing to re-apply. Model is unsloth/Qwen3.8-Flash-Next-GGUF UD-Q4_K_XL, four shards, 111,323,630,080 bytes on disk (103.7 GiB) for 176,943,899,520 parameters = 5.03 bits/parameter. Server flags: -lm mmap -ot per_layer_token_embd=CPU --n-gpu-layers 999 --ctx-size 262144 --parallel 1 --spec-type ngram-mod --temp 1.0 --top-p 0.95 --top-k 20. The defining choice is -ot per_layer_token_embd=CPU together with -lm mmap: the 51.2B-parameter n-gram/PLE embedding table (one tensor, shape 160 by 320001536) is pinned to the CPU backend and served from NVMe through the OS page cache instead of being made resident, which is the only reason a 180B model runs in 128 GB with the full 262,144-token context. KV cache is f16 (quantized KV aborts on this architecture) and costs only about 24 KB/token because 12 of 48 layers use full attention with 2 KV heads. Immediately before this run the n-gram table was deliberately warmed with tools/warm_table.py to a measured 73.0% page-cache residency of its 26.8 GiB region (mincore-verified, up from 67.7%); table residency changes decode throughput materially, so it is a run condition, not an incidental detail. The machine was fully isolated for the duration: this host normally also serves an OpenAI-compatible endpoint to other clients, and that path was shut off before the run so nothing external could contend for the single server slot. llama-server binds loopback only and the harness connected to it directly, so no reverse proxy sat in the measured path."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/fa4e2bc695c71203--prefill-8k-v1--e6c546.json
+++ b/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/fa4e2bc695c71203--prefill-8k-v1--e6c546.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -61,7 +61,7 @@
     "override-tensor": "per_layer_token_embd=CPU",
     "load-mode": "mmap",
     "spec-type": "ngram-mod",
-    "temp": 1.0,
+    "temp": 1,
     "top-p": 0.95,
     "top-k": 20
   },
@@ -77,7 +77,7 @@
       "warmup_requests": 1,
       "prompts_padded": false,
       "needle_check": false,
-      "timeout_s": 900.0,
+      "timeout_s": 900,
       "seed": 42
     }
   },
@@ -85,7 +85,7 @@
     "requests_total": 10,
     "requests_ok": 10,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 69.154,
     "input_tokens_total": 101962,
     "output_tokens_total": 160,
@@ -145,7 +145,7 @@
     "power_peak_w": 72.21,
     "energy_wh": 1.4635,
     "gpu_util_avg_pct": 85.2,
-    "temp_max_c": 67.0,
+    "temp_max_c": 67,
     "thermal_throttle_detected": false
   },
   "failures": [],
@@ -338,7 +338,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-27T08:36:04Z",
     "finished_at": "2026-08-27T08:37:38Z",
     "submitted_at": null,


### PR DESCRIPTION
A 180B model measured on a single 128 GB DGX Spark, with **51.2B of its 176.9B parameters served from an SSD** instead of being held in memory.

## The 51B-on-NVMe part

Qwen3.8-Flash-Next splits into 125.7B of compute weights and one 51.2B-parameter n-gram/PLE embedding table — a single tensor, `per_layer_token_embd.weight`, shape `[160, 320001536]`. That tensor is never an operand of a matrix multiply: each generated token *gathers* roughly 16 rows out of 320,001,536. The access is sparse and deterministically addressed, so the table does not need to be resident. It is pinned to the CPU backend and memory-mapped, and the OS page cache serves it from NVMe:

```
-ot per_layer_token_embd=CPU  -lm mmap
```

The model file is 103.7 GiB, but only ~77 GiB has to stay resident. That is the only reason this fits in 128 GB alongside the full 262,144-token context. Peak RAM across these runs was 102.9 GB of 121 GiB usable.

**This makes page-cache residency an independent variable, not an implementation detail.** Both runs started from a measured **73.0% residency** of the table's 26.8 GiB region, verified with `mincore(2)` rather than assumed. A cold table is a materially different measurement, so the figure is recorded in the run notes and called out in a gotcha. Any result from this configuration that does not state its table residency is not reproducible.

## What is in this PR

| | |
|---|---|
| Model | `Qwen/Qwen3.8-Flash-Next` (new registry entry) |
| Quant | `gguf-ud-q4-k-xl` (new) — 111,323,630,080 bytes over 176,943,899,520 params = 5.03 bits/param |
| Engine | `llamacpp` `b50-035e227` (new version entry) |
| Hardware | `nvidia-gb10-dgx-spark` ×1 |
| Runs | `prefill-8k-v1`, `prefill-32k-v1` |

The engine is llama.cpp built from the **unmerged** qwen4exp PR [#27742](https://github.com/ggml-org/llama.cpp/pull/27742) at commit `035e227`. It self-reports the placeholder version `0.3.0-dev (build 50)`, so it is recorded as its own square rather than folded into a released `bNNNN` build — its flag surface and its supported architectures both differ from any release. Three flags this recipe depends on (`override-tensor`, `load-mode`, `spec-type`) are absent from the existing `b7000` registry file entirely.

## On the two validation warnings

Both results trip `bandwidth-efficiency-low`: measured decode is 17.0–19.5 tok/s against a computed 138.5 tok/s ceiling. That gap is the finding, not a measurement error. `active_params_b` is **derived** (10 of 512 experts + shared expert + attention + embed/output) and flagged as approximate in the model entry, because only 12 of 48 layers use full attention. More importantly, a top-10-of-512 MoE scatters expert reads rather than streaming weights contiguously, so this configuration is not bandwidth-bound in the way the active-parameter count implies.

## Provenance

Architecture facts in the registry entries were read from the GGUF KV metadata of the exact files benchmarked — `general.architecture=qwen4exp`, `size_label 512x56B`, `block_count 48`, `expert_count 512`, `expert_used_count 10`, `ple.ngram_size 3` — not transcribed from a model card. `active_params_b` is the sole derived value and says so.

The host normally serves an OpenAI-compatible endpoint to other clients; that path was shut off for the duration so nothing external could contend for the single server slot. llama-server bound loopback only and the harness connected directly, so no reverse proxy sat in the measured path.

Speculation was on (`--spec-type ngram-mod`) and is exact — the target verifies every token — but throughput varies up to 3× with how much of the output already appears in the prompt. Recorded as a gotcha; do not compare these decode figures against a cell run with a different `--spec-type`.

`atlas-bench validate --strict`: **0 errors, 2 warnings** (both the `bandwidth-efficiency-low` note above).
