### PR TITLE
app: show what the sweep data actually contains

### DIFF
--- a/app/src/components/chart.ts
+++ b/app/src/components/chart.ts
@@ -24,6 +24,12 @@ export interface ChartPalette {
   line: string;
   surface: string;
   accent: string;
+  /** Cobalt — the primary curve (throughput). */
+  chart1: string;
+  /** Signal orange — the counterpart curve (latency). Not --warn: status colours stay reserved. */
+  chart2: string;
+  chart1Soft: string;
+  chart2Soft: string;
 }
 
 export function chartPalette(): ChartPalette {
@@ -33,6 +39,31 @@ export function chartPalette(): ChartPalette {
     line: cssVar('--line'),
     surface: cssVar('--surface'),
     accent: cssVar('--accent'),
+    chart1: cssVar('--chart-1'),
+    chart2: cssVar('--chart-2'),
+    chart1Soft: cssVar('--chart-1-soft', 'rgba(27, 79, 214, 0.14)'),
+    chart2Soft: cssVar('--chart-2-soft', 'rgba(194, 94, 0, 0.13)'),
+  };
+}
+
+/**
+ * Ribbon fill: a vertical gradient from the series' soft colour at the line down to
+ * transparent at the x-axis — the glow that makes a curve read as a lit instrument trace.
+ * Recomputed per draw because uPlot's bbox is only known then.
+ */
+export function ribbonFill(soft: string): uPlot.Series.Fill {
+  // Fade to the same colour at alpha 0 — a black-transparent stop would grey the mid-tones.
+  const m = /^rgba\((\s*\d+\s*,\s*\d+\s*,\s*\d+\s*),/.exec(soft);
+  const clear = m ? `rgba(${m[1]}, 0)` : 'transparent';
+  return (u: uPlot) => {
+    // The legend swatch asks for the fill before the plot has a bbox — a gradient over
+    // non-finite coordinates throws, so the flat soft colour stands in.
+    if (!Number.isFinite(u.bbox.top) || !Number.isFinite(u.bbox.height) || u.bbox.height <= 0)
+      return soft;
+    const grad = u.ctx.createLinearGradient(0, u.bbox.top, 0, u.bbox.top + u.bbox.height);
+    grad.addColorStop(0, soft);
+    grad.addColorStop(1, clear);
+    return grad;
   };
 }
 

--- a/app/src/components/components.test.ts
+++ b/app/src/components/components.test.ts
@@ -1,4 +1,5 @@
 import { computeCoverage } from '@atlas/core';
+import { render } from 'lit';
 import { describe, expect, it, beforeAll } from 'vitest';
 import { buildHeatMatrix, buildLookups, possibleCells } from '../data/derive.js';
 import { fixtureRegistry, fixtureRow } from '../data/fixture.js';
@@ -8,6 +9,7 @@ import './heatmap.js';
 import './param-form.js';
 import './add-modal.js';
 import './packet-preview.js';
+import { sparkline } from './ui.js';
 import {
   addSpec,
   closeAdd,
@@ -198,5 +200,23 @@ describe('add modal', () => {
     const pr = packetRegistry();
     expect(pr.engines.map((e) => e.meta.id)).toEqual(['vllm', 'mlx-lm']);
     expect(pr.models[0]!.quants.length).toBe(3);
+  });
+});
+
+describe('sparkline', () => {
+  it('draws one path, restarting after gaps so a missing sensor reading stays a gap', () => {
+    const host = document.createElement('div');
+    render(sparkline([1, 2, null, 4]), host);
+    const d = host.querySelector('path')!.getAttribute('d')!;
+    expect(d.startsWith('M')).toBe(true);
+    expect(d.match(/M/g)).toHaveLength(2);
+    // the latest reading gets the emphasis dot
+    expect(host.querySelector('circle')).not.toBeNull();
+  });
+
+  it('renders nothing when no value was measured', () => {
+    const host = document.createElement('div');
+    render(sparkline([null, null]), host);
+    expect(host.querySelector('svg')).toBeNull();
   });
 });

--- a/app/src/components/request-strip.test.ts
+++ b/app/src/components/request-strip.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { RequestSample } from '../util/requests.js';
+import './request-strip.js';
+import { logTicks, type AtlasRequestStrip } from './request-strip.js';
+
+const sample = (over: Partial<RequestSample>): RequestSample => ({
+  id: 'concurrency1-r00000',
+  level: 1,
+  ttft_ms: 100,
+  e2e_ms: 1000,
+  completion_tokens: 256,
+  ok: true,
+  warmup: false,
+  ...over,
+});
+
+async function mount(props: Partial<AtlasRequestStrip>): Promise<AtlasRequestStrip> {
+  const el = document.createElement('atlas-request-strip') as AtlasRequestStrip;
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe('logTicks', () => {
+  it('ticks the decades across a wide span', () => {
+    expect(logTicks(1500, 90000)).toEqual([10000]);
+    expect(logTicks(100, 100000)).toEqual([100, 1000, 10000, 100000]);
+  });
+
+  it('fills 2× and 5× steps when everything sits in one decade', () => {
+    expect(logTicks(1000, 9000)).toEqual([1000, 2000, 5000]);
+  });
+
+  it('is empty for degenerate input', () => {
+    expect(logTicks(0, 10)).toEqual([]);
+    expect(logTicks(10, 5)).toEqual([]);
+  });
+});
+
+describe('atlas-request-strip', () => {
+  it('renders one dot per measured request with level markers, skipping warmups', async () => {
+    const el = await mount({
+      samples: [
+        sample({}),
+        sample({ id: 'concurrency1-w00000', warmup: true }),
+        sample({ id: 'concurrency16-r00000', level: 16, ttft_ms: 15000 }),
+        sample({ id: 'concurrency16-r00001', level: 16, ttft_ms: 16000 }),
+      ],
+    });
+    expect(el.querySelectorAll('circle.dot')).toHaveLength(3);
+    // one min–max range and one p50 caliper per level
+    expect(el.querySelectorAll('line.range')).toHaveLength(2);
+    expect(el.querySelectorAll('line.p50')).toHaveLength(2);
+    const levels = [...el.querySelectorAll('text.level')].map((t) => t.textContent?.trim());
+    expect(levels).toEqual(['1', '16']);
+    expect(el.querySelector('circle.dot title')?.textContent).toContain('TTFT');
+  });
+
+  it('marks failed requests and switches metric', async () => {
+    const el = await mount({
+      samples: [sample({}), sample({ id: 'concurrency1-r00001', ok: false, ttft_ms: 900 })],
+      metric: 'e2e',
+    });
+    // the failed request has no e2e problem here — both dots render on the e2e metric
+    expect(el.querySelectorAll('circle.dot')).toHaveLength(2);
+    expect(el.querySelectorAll('circle.failed')).toHaveLength(1);
+    expect(el.querySelector('circle.dot title')?.textContent).toContain('E2E');
+  });
+
+  it('renders nothing when the payload has no usable samples', async () => {
+    const el = await mount({ samples: [sample({ ttft_ms: null, e2e_ms: null })] });
+    expect(el.querySelector('svg')).toBeNull();
+  });
+});

--- a/app/src/components/request-strip.ts
+++ b/app/src/components/request-strip.ts
@@ -1,0 +1,138 @@
+/**
+ * Every request behind a sweep, as one dot: x = sweep level (ordinal), y = latency on a log
+ * scale. The aggregate curve says what the medians did; this strip shows the spread the
+ * medians came from — stragglers, bimodality, failures — which is exactly what percentiles
+ * hide. SVG rather than uPlot because the x axis is ordinal with jitter and every dot needs
+ * its own hit target; colours stay CSS variables so both themes work untouched.
+ */
+import { html, nothing, svg, type SVGTemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { fmtCompact, fmtInt, fmtMs } from '../util/format.js';
+import { quantile, samplesByLevel, type RequestSample } from '../util/requests.js';
+import { AtlasElement } from './base.js';
+
+export type StripMetric = 'ttft' | 'e2e';
+
+const MARGIN = { top: 12, right: 10, bottom: 24, left: 48 };
+
+function metricOf(s: RequestSample, metric: StripMetric): number | null {
+  const v = metric === 'ttft' ? s.ttft_ms : s.e2e_ms;
+  return v !== null && v > 0 ? v : null;
+}
+
+/** Log-decade ticks covering [lo, hi]; 2× and 5× steps fill in when a single decade spans it. */
+export function logTicks(lo: number, hi: number): number[] {
+  if (!(lo > 0) || !(hi >= lo)) return [];
+  const ticks: number[] = [];
+  const d0 = Math.floor(Math.log10(lo));
+  const d1 = Math.ceil(Math.log10(hi));
+  const mantissas = d1 - d0 <= 1 ? [1, 2, 5] : [1];
+  for (let d = d0; d <= d1; d++)
+    for (const m of mantissas) {
+      const v = m * 10 ** d;
+      if (v >= lo * 0.999 && v <= hi * 1.001) ticks.push(v);
+    }
+  return ticks;
+}
+
+@customElement('atlas-request-strip')
+export class AtlasRequestStrip extends AtlasElement {
+  @property({ attribute: false }) samples: RequestSample[] = [];
+  @property({ type: String }) metric: StripMetric = 'ttft';
+  @property({ type: Number }) height = 220;
+  @state() private width = 640;
+
+  private ro: ResizeObserver | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (typeof ResizeObserver !== 'undefined') {
+      this.ro = new ResizeObserver(() => {
+        if (this.clientWidth > 0 && this.clientWidth !== this.width) this.width = this.clientWidth;
+      });
+      this.ro.observe(this);
+    }
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.ro?.disconnect();
+  }
+
+  override render() {
+    const groups = [...samplesByLevel(this.samples).entries()]
+      .map(([level, list]) => ({
+        level,
+        list: list.filter((s) => metricOf(s, this.metric) !== null),
+      }))
+      .filter((g) => g.list.length > 0);
+    if (groups.length === 0) return nothing;
+
+    const values = groups.flatMap((g) => g.list.map((s) => metricOf(s, this.metric)!));
+    const lo = Math.min(...values);
+    const hi = Math.max(...values);
+    const w = this.width;
+    const h = this.height;
+    const plotW = Math.max(60, w - MARGIN.left - MARGIN.right);
+    const plotH = Math.max(60, h - MARGIN.top - MARGIN.bottom);
+    // Log y even when the span is small: sweeps that collapse do so by orders of magnitude.
+    const l0 = Math.log10(lo);
+    const l1 = Math.log10(hi);
+    const span = Math.max(l1 - l0, 0.1);
+    const y = (v: number) => MARGIN.top + plotH - ((Math.log10(v) - l0) / span) * plotH;
+    const step = plotW / groups.length;
+    const xc = (i: number) => MARGIN.left + step * (i + 0.5);
+    const jitterW = Math.min(step * 0.55, 46);
+
+    const dots: SVGTemplateResult[] = [];
+    const marks: SVGTemplateResult[] = [];
+    groups.forEach((g, i) => {
+      const vs = g.list.map((s) => metricOf(s, this.metric)!);
+      const p50 = quantile(vs, 0.5)!;
+      const min = Math.min(...vs);
+      const max = Math.max(...vs);
+      marks.push(
+        svg`<line class="range" x1=${xc(i)} y1=${y(min)} x2=${xc(i)} y2=${y(max)}></line>
+          <line class="p50" x1=${xc(i) - 9} y1=${y(p50)} x2=${xc(i) + 9} y2=${y(p50)}></line>`,
+      );
+      g.list.forEach((s, j) => {
+        // Deterministic golden-ratio jitter: stable across renders, no clumping at the guide.
+        const off = (((j * 0.618034) % 1) - 0.5) * jitterW;
+        const v = metricOf(s, this.metric)!;
+        dots.push(
+          svg`<circle class=${s.ok ? 'dot' : 'dot failed'} cx=${xc(i) + off} cy=${y(v)} r="3">
+              <title>${`${s.id} · ${this.metric === 'ttft' ? 'TTFT' : 'E2E'} ${fmtMs(v)} ms${s.completion_tokens !== null ? ` · ${fmtInt(s.completion_tokens)} tok` : ''}${s.ok ? '' : ' · failed'}`}</title>
+            </circle>`,
+        );
+      });
+    });
+
+    const ticks = logTicks(lo, hi);
+    const failed = groups.some((g) => g.list.some((s) => !s.ok));
+    return html`<svg
+        class="request-strip"
+        width=${w}
+        height=${h}
+        viewBox=${`0 0 ${w} ${h}`}
+        role="img"
+        aria-label=${`${values.length} requests, ${this.metric === 'ttft' ? 'time to first token' : 'end-to-end latency'} by level`}
+      >
+        ${ticks.map(
+          (t) =>
+            svg`<g>
+              <line class="grid" x1=${MARGIN.left} y1=${y(t)} x2=${w - MARGIN.right} y2=${y(t)}></line>
+              <text class="tick" x=${MARGIN.left - 6} y=${y(t) + 3}>${fmtCompact(t)}</text>
+            </g>`,
+        )}
+        ${groups.map(
+          (g, i) =>
+            svg`<text class="tick level" x=${xc(i)} y=${h - 8}>${fmtCompact(g.level)}</text>`,
+        )}
+        ${marks} ${dots}
+      </svg>
+      <div class="row-wrap xs muted request-strip-caption">
+        <span>${fmtInt(values.length)} measured requests · warmup excluded · log scale</span>
+        ${failed ? html`<span class="strip-key failed">● failed</span>` : nothing}
+      </div>`;
+  }
+}

--- a/app/src/components/sweep-chart.test.ts
+++ b/app/src/components/sweep-chart.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { SweepPoint } from '@atlas/core';
+import type { ChartPalette } from './chart.js';
+import { sweepChartBuild, sweepYTail, type SweepSeries } from './sweep-chart.js';
+
+const palette: ChartPalette = {
+  ink: '#111111',
+  muted: '#666666',
+  line: '#dddddd',
+  surface: '#ffffff',
+  accent: '#d1295e',
+  chart1: '#1b4fd6',
+  chart2: '#c25e00',
+  chart1Soft: 'rgba(27, 79, 214, 0.14)',
+  chart2Soft: 'rgba(194, 94, 0, 0.13)',
+};
+
+function pt(concurrency: number, ttft50: number, ttft95: number, tok: number): SweepPoint {
+  return {
+    concurrency,
+    metrics: { output_tok_s: tok, ttft_ms: { p50: ttft50, p95: ttft95 } },
+  };
+}
+
+const points = [
+  pt(1, 1600, 1900, 24),
+  pt(4, 2100, 2600, 58),
+  pt(16, 2700, 3400, 90),
+  pt(64, 70000, 112000, 105),
+];
+const one: SweepSeries[] = [{ label: 'this run', color: '#1b4fd6', points }];
+const two: SweepSeries[] = [...one, { label: 'max-num-seqs=2', color: '#c25e00', points }];
+
+describe('sweepChartBuild', () => {
+  it('adds a p50–p95 band column for a single latency series', () => {
+    const { opts, data } = sweepChartBuild(one, 'ttft', 'concurrency')(600, 'light', palette);
+    expect(data).toHaveLength(3); // x, p50, p95
+    expect(data[2]).toEqual([1900, 2600, 3400, 112000]);
+    expect(opts.bands).toHaveLength(1);
+    expect(opts.series).toHaveLength(3);
+    expect(opts.series[2]!.dash).toEqual([4, 4]);
+  });
+
+  it('keeps multi-series latency charts band-free — a band per arm would be unreadable', () => {
+    const { opts, data } = sweepChartBuild(two, 'ttft', 'concurrency')(600, 'light', palette);
+    expect(data).toHaveLength(3); // x + two arms, no tail column
+    expect(opts.bands).toBeUndefined();
+    expect(opts.legend?.show).toBe(true);
+  });
+
+  it('ribbon-fills throughput curves but not beyond two series', () => {
+    const single = sweepChartBuild(one, 'throughput', 'concurrency')(600, 'dark', palette);
+    expect(single.opts.series[1]!.fill).toBeTypeOf('function');
+    const many = sweepChartBuild(
+      [...two, { label: 'c', color: '#6aa300', points }],
+      'throughput',
+      'concurrency',
+    )(600, 'dark', palette);
+    expect(many.opts.series[1]!.fill).toBeUndefined();
+  });
+
+  it('ticks the measured levels exactly on a log concurrency axis', () => {
+    const { opts } = sweepChartBuild(one, 'throughput', 'concurrency')(600, 'light', palette);
+    const splits = opts.axes?.[0]?.splits;
+    expect(splits).toBeTypeOf('function');
+    expect((splits as () => number[])()).toEqual([1, 4, 16, 64]);
+  });
+
+  it('joins a cursor sync group when asked so paired panels share the crosshair', () => {
+    const { opts } = sweepChartBuild(one, 'ttft', 'concurrency', { sync: 'pair' })(
+      600,
+      'light',
+      palette,
+    );
+    expect(opts.cursor?.sync?.key).toBe('pair');
+  });
+});
+
+describe('sweepYTail', () => {
+  it('reads the p95 tail only for latency metrics', () => {
+    expect(sweepYTail(points[0]!, 'ttft')).toBe(1900);
+    expect(sweepYTail(points[0]!, 'throughput')).toBeNull();
+    expect(sweepYTail({ metrics: {} }, 'ttft')).toBeNull();
+  });
+});

--- a/app/src/components/sweep-chart.ts
+++ b/app/src/components/sweep-chart.ts
@@ -1,8 +1,15 @@
 /** Shared uPlot builders: sweep lines (x = concurrency | input_tokens), timeline lines, scatter. */
 import type uPlot from 'uplot';
 import type { SweepAxis, SweepPoint } from '@atlas/core';
-import { fmtCompact, fmtMs, fmtTokS } from '../util/format.js';
-import { axisDefaults, tooltipPlugin, type ChartBuild, type ChartPalette } from './chart.js';
+import { fmtCompact, fmtMs, fmtTokS, fmtTokens } from '../util/format.js';
+import { withAlpha } from '../util/colors.js';
+import {
+  axisDefaults,
+  ribbonFill,
+  tooltipPlugin,
+  type ChartBuild,
+  type ChartPalette,
+} from './chart.js';
 
 export interface SweepSeries {
   label: string;
@@ -10,7 +17,7 @@ export interface SweepSeries {
   points: SweepPoint[];
 }
 
-export type SweepMetric = 'throughput' | 'ttft' | 'tpot';
+export type SweepMetric = 'throughput' | 'ttft' | 'tpot' | 'prefill';
 
 export function sweepAxisOf(points: SweepPoint[]): SweepAxis {
   if (
@@ -36,11 +43,22 @@ export function sweepY(p: SweepPoint, metric: SweepMetric): number | null {
       m.output_tok_s ?? m.decode_tok_s_per_request?.mean ?? m.decode_tok_s_per_request?.p50 ?? null;
     return typeof v === 'number' ? v : null;
   }
+  if (metric === 'prefill') {
+    const v = m.prefill_tok_s ?? null;
+    return typeof v === 'number' ? v : null;
+  }
   if (metric === 'ttft') {
     const v = m.ttft_ms?.p50 ?? m.ttft_ms?.mean ?? null;
     return typeof v === 'number' ? v : null;
   }
   const v = m.tpot_ms?.p50 ?? m.tpot_ms?.mean ?? null;
+  return typeof v === 'number' ? v : null;
+}
+
+/** Tail of the same distribution, for the p50–p95 band. Throughput-style metrics have none. */
+export function sweepYTail(p: SweepPoint, metric: SweepMetric): number | null {
+  const d = metric === 'ttft' ? p.metrics.ttft_ms : metric === 'tpot' ? p.metrics.tpot_ms : null;
+  const v = d?.p95 ?? d?.p90 ?? null;
   return typeof v === 'number' ? v : null;
 }
 
@@ -55,14 +73,29 @@ const AXIS_LABEL: Record<SweepAxis, string> = {
   num_requests: 'requests',
 };
 
+const METRIC_LABEL: Record<SweepMetric, string> = {
+  throughput: 'tok/s',
+  prefill: 'prefill tok/s',
+  ttft: 'TTFT p50 (ms)',
+  tpot: 'TPOT p50 (ms)',
+};
+
+export interface SweepChartOpts {
+  logX?: boolean;
+  /** uPlot cursor-sync group; paired panels over the same x share one so the crosshair travels. */
+  sync?: string;
+  /** p50–p95 band on single-series latency charts (default on when the data has the tail). */
+  band?: boolean;
+}
+
 /** One metric across one or more sweeps, aligned on the union of x values. */
 export function sweepChartBuild(
   series: SweepSeries[],
   metric: SweepMetric,
   axis: SweepAxis,
-  opts: { logX?: boolean } = {},
+  opts: SweepChartOpts = {},
 ): ChartBuild {
-  return (_width, _theme, p: ChartPalette) => {
+  return (_width, theme, p: ChartPalette) => {
     const xs = [
       ...new Set(
         series.flatMap((s) =>
@@ -70,35 +103,58 @@ export function sweepChartBuild(
         ),
       ),
     ].sort((a, b) => a - b);
+    const at = (s: SweepSeries, x: number): SweepPoint =>
+      s.points.find((pt) => sweepX(pt, axis) === x) ?? { metrics: {} };
+    const band =
+      (opts.band ?? true) &&
+      series.length === 1 &&
+      (metric === 'ttft' || metric === 'tpot') &&
+      series[0]!.points.some((pt) => sweepYTail(pt, metric) !== null);
     const data: uPlot.AlignedData = [
       xs,
-      ...series.map((s) =>
-        xs.map((x) =>
-          sweepY(s.points.find((pt) => sweepX(pt, axis) === x) ?? { metrics: {} }, metric),
-        ),
-      ),
+      ...series.map((s) => xs.map((x) => sweepY(at(s, x), metric))),
+      ...(band ? [xs.map((x) => sweepYTail(at(series[0]!, x), metric))] : []),
     ];
-    const yLabel =
-      metric === 'throughput' ? 'tok/s' : metric === 'ttft' ? 'TTFT p50 (ms)' : 'TPOT p50 (ms)';
-    const fmtY = metric === 'throughput' ? fmtTokS : fmtMs;
+    const yLabel = METRIC_LABEL[metric];
+    const fmtY = metric === 'throughput' || metric === 'prefill' ? fmtTokS : fmtMs;
     const logX =
       opts.logX ??
       (axis === 'concurrency' && xs.length > 3 && xs[xs.length - 1]! / Math.max(1, xs[0]!) >= 16);
+    // Ribbon fills read well up to two curves; beyond that they stack into mud. A band chart
+    // keeps only the p50–p95 haze — ribbon plus band would double-fill the same area.
+    const fillAlpha = band || series.length > 2 ? 0 : theme === 'dark' ? 0.2 : 0.12;
     const uopts: uPlot.Options = {
       width: 600,
       height: 240,
-      legend: { show: series.length > 1 },
-      cursor: { points: { size: 8 } },
+      legend: { show: series.length > 1, live: false },
+      cursor: {
+        points: { size: 8 },
+        ...(opts.sync ? { sync: { key: opts.sync } } : {}),
+      },
       scales: {
         x: { time: false, distr: logX ? 3 : 1 },
         y: { range: (_u, min, max) => [Math.min(0, min), max * 1.08 || 1] },
       },
+      ...(band ? { bands: [{ series: [2, 1], fill: withAlpha(series[0]!.color, 0.14) }] } : {}),
       axes: [
         {
           ...axisDefaults(p, AXIS_LABEL[axis]),
-          values: (_u, vals) => vals.map((v) => fmtCompact(v)),
+          // Sweeps are run at a handful of exact levels (1, 2, 4 … 64): tick every one of
+          // them. The filter must pass them all through — uPlot's log-scale default keeps
+          // only decades and would blank most of the measured levels.
+          ...(logX && xs.length <= 12 ? { splits: () => xs, filter: (_u, splits) => splits } : {}),
+          // token counts read as powers of two (8K, 32K, 128K), not decimal compacts
+          values: (_u, vals) =>
+            vals.map((v) =>
+              axis === 'input_tokens' || axis === 'output_tokens' ? fmtTokens(v) : fmtCompact(v),
+            ),
         },
-        { ...axisDefaults(p, yLabel), values: (_u, vals) => vals.map((v) => fmtY(v)) },
+        {
+          ...axisDefaults(p, yLabel),
+          // ms values reach six digits (a 100 s TTFT) — give the tick text room.
+          size: metric === 'ttft' || metric === 'tpot' ? 54 : 44,
+          values: (_u, vals) => vals.map((v) => fmtY(v)),
+        },
       ],
       series: [
         { label: AXIS_LABEL[axis] },
@@ -106,21 +162,36 @@ export function sweepChartBuild(
           label: s.label,
           stroke: s.color,
           width: 2,
-          points: { show: true, size: 7, fill: p.surface, stroke: s.color, width: 2 },
+          ...(fillAlpha > 0 ? { fill: ribbonFill(withAlpha(s.color, fillAlpha)) } : {}),
+          points: { show: true, size: 7, fill: s.color, stroke: p.surface, width: 1.5 },
           spanGaps: true,
         })),
+        ...(band
+          ? [
+              {
+                label: 'p95',
+                stroke: withAlpha(series[0]!.color, 0.55),
+                width: 1,
+                dash: [4, 4],
+                points: { show: false },
+                spanGaps: true,
+              },
+            ]
+          : []),
       ],
       plugins: [
         tooltipPlugin((u, idx) => {
           const x = u.data[0][idx];
           const lines = series.map((s, i) => {
             const v = u.data[i + 1]?.[idx];
-            return v == null
-              ? null
-              : `<div><span style="display:inline-block;width:8px;height:8px;border-radius:2px;background:${s.color};margin-right:6px"></span>${escapeHtml(s.label)}: <b>${fmtY(v)}</b></div>`;
+            if (v == null) return null;
+            const tail = band ? u.data[series.length + 1]?.[idx] : null;
+            const val = band && tail != null ? `p50 ${fmtY(v)} · p95 ${fmtY(tail)}` : fmtY(v);
+            return `<div><span style="display:inline-block;width:8px;height:8px;border-radius:2px;background:${s.color};margin-right:6px"></span>${escapeHtml(s.label)}: <b>${val}</b></div>`;
           });
           if (lines.every((l) => l === null)) return null;
-          return `<div style="opacity:.7;margin-bottom:2px">${AXIS_LABEL[axis]} ${fmtCompact(x)}</div>${lines.filter(Boolean).join('')}`;
+          const fmtX = axis === 'input_tokens' || axis === 'output_tokens' ? fmtTokens : fmtCompact;
+          return `<div style="opacity:.7;margin-bottom:2px">${AXIS_LABEL[axis]} ${fmtX(x)}</div>${lines.filter(Boolean).join('')}`;
         }),
       ],
     };
@@ -157,13 +228,14 @@ export function ordinalLinesBuild(
   fmtY: (v: number) => string,
   flagged?: Set<string>,
 ): ChartBuild {
-  return (_w, _t, p) => {
+  return (_w, theme, p) => {
     const xs = labels.map((_, i) => i);
     const data: uPlot.AlignedData = [xs, ...series.map((s) => s.values)];
+    const fillAlpha = series.length <= 2 ? (theme === 'dark' ? 0.2 : 0.12) : 0;
     const uopts: uPlot.Options = {
       width: 600,
       height: 240,
-      legend: { show: series.length > 1 },
+      legend: { show: series.length > 1, live: false },
       cursor: { points: { size: 8 } },
       scales: {
         x: { time: false, range: [-0.4, Math.max(0.4, labels.length - 0.6)] },
@@ -183,7 +255,8 @@ export function ordinalLinesBuild(
           label: s.label,
           stroke: s.color,
           width: 2,
-          points: { show: true, size: 8, fill: p.surface, stroke: s.color, width: 2 },
+          ...(fillAlpha > 0 ? { fill: ribbonFill(withAlpha(s.color, fillAlpha)) } : {}),
+          points: { show: true, size: 8, fill: s.color, stroke: p.surface, width: 1.5 },
           spanGaps: true,
         })),
       ],

--- a/app/src/components/ui.ts
+++ b/app/src/components/ui.ts
@@ -1,5 +1,5 @@
 /** Stateless template helpers shared by every view. */
-import { html, nothing, render, type TemplateResult } from 'lit';
+import { html, nothing, render, svg, type TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import type { CoverageLevel, Distribution, VerificationLevel, WorkloadKind } from '@atlas/core';
@@ -274,6 +274,48 @@ export function hbar(
     </div>
     <span class="val">${text}</span>
   </div>`;
+}
+
+/**
+ * Inline sparkline for telemetry tiles: value against an implicit ordinal x, scaled to its
+ * own min–max so shape (rising power, flat utilisation) survives at 100×26. Gaps stay gaps.
+ */
+export function sparkline(
+  values: Array<number | null>,
+  opts: { width?: number; height?: number; colorVar?: string } = {},
+): TemplateResult {
+  const w = opts.width ?? 100;
+  const h = opts.height ?? 26;
+  const colorVar = opts.colorVar ?? '--chart-1';
+  const nums = values.filter(isNum);
+  if (nums.length === 0) return html`${nothing}`;
+  const min = Math.min(...nums);
+  const max = Math.max(...nums);
+  const pad = 3;
+  const span = max - min || 1;
+  const x = (i: number) => (values.length === 1 ? w / 2 : (i / (values.length - 1)) * (w - 2) + 1);
+  const y = (v: number) => h - pad - ((v - min) / span) * (h - pad * 2);
+  const segs: string[] = [];
+  values.forEach((v, i) => {
+    segs.push(isNum(v) ? `${segs.length && isNum(values[i - 1]) ? 'L' : 'M'}${x(i)} ${y(v)}` : '');
+  });
+  const path = segs.join(' ').trim();
+  const last = [...values].reverse().find(isNum);
+  const lastIdx = values.length - 1 - [...values].reverse().findIndex(isNum);
+  return html`<svg
+    class="sparkline"
+    width=${w}
+    height=${h}
+    viewBox=${`0 0 ${w} ${h}`}
+    aria-hidden="true"
+  >
+    ${
+      path
+        ? svg`<path d=${path} fill="none" stroke=${`var(${colorVar})`} stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>`
+        : nothing
+    }
+    ${isNum(last) ? svg`<circle cx=${x(lastIdx)} cy=${y(last)} r="2.5" fill=${`var(${colorVar})`}></circle>` : nothing}
+  </svg>`;
 }
 
 export function deltaTag(

--- a/app/src/styles/base.css
+++ b/app/src/styles/base.css
@@ -1731,3 +1731,188 @@ table.table {
   margin-right: 5px;
   vertical-align: -1px;
 }
+
+/* ------------------------------------------------------- operating map (run detail sweeps) */
+.chart-pair .eyebrow.plain {
+  margin-bottom: var(--sp-2);
+}
+.chart-pair .eyebrow.pair-lower {
+  margin-top: var(--sp-4);
+}
+
+/* per-request strip: every measured request as one dot on a log latency scale */
+.request-strip {
+  display: block;
+  width: 100%;
+}
+.request-strip .grid {
+  stroke: var(--line);
+  stroke-width: 1;
+  stroke-dasharray: 2 4;
+}
+.request-strip .tick {
+  fill: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-anchor: end;
+}
+.request-strip .tick.level {
+  text-anchor: middle;
+}
+.request-strip .range {
+  stroke: var(--chart-2-soft);
+  stroke-width: 2;
+}
+.request-strip .p50 {
+  stroke: var(--chart-2);
+  stroke-width: 2;
+}
+.request-strip .dot {
+  fill: var(--chart-2);
+  fill-opacity: 0.7;
+  transition: fill-opacity var(--t-fast) var(--ease);
+}
+.request-strip .dot:hover {
+  fill-opacity: 1;
+}
+.request-strip .dot.failed {
+  fill: var(--danger);
+  fill-opacity: 0.9;
+}
+/* the instrument glow — dark theme only, where a lit trace reads instead of smudging */
+:root[data-theme='dark'] .request-strip .p50,
+:root[data-theme='dark'] .request-strip .dot {
+  filter: drop-shadow(0 0 3px var(--chart-2-soft));
+}
+:root[data-theme='dark'] .request-strip .dot.failed {
+  filter: drop-shadow(0 0 3px var(--danger-soft));
+}
+.request-strip-caption {
+  margin-top: 4px;
+  justify-content: space-between;
+}
+.request-strip-caption .strip-key.failed {
+  color: var(--danger);
+}
+
+/* telemetry small multiples: what the machine did while the sweep ran */
+.telemetry-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(164px, 1fr));
+  gap: 1px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+.telemetry-tile {
+  background: var(--surface);
+  box-shadow: 0 0 0 1px var(--line);
+  padding: 10px 12px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-areas:
+    'k k'
+    'v spark'
+    'range spark';
+  gap: 2px 8px;
+  align-items: end;
+  min-width: 0;
+}
+.telemetry-tile .k {
+  grid-area: k;
+  font-size: var(--fs-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  font-weight: 600;
+}
+.telemetry-tile .v {
+  grid-area: v;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xl);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+}
+.telemetry-tile .v .unit {
+  font-size: var(--fs-xs);
+  font-family: var(--font-sans);
+  color: var(--muted);
+}
+.telemetry-tile .range {
+  grid-area: range;
+  font-size: var(--fs-2xs);
+  color: var(--faint);
+  font-family: var(--font-mono);
+}
+.telemetry-tile .sparkline {
+  grid-area: spark;
+}
+
+/* arms of one cell: same square, different flag set */
+.arm-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+.arm-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.arm-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.arm-head .chip {
+  cursor: default;
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  height: 22px;
+}
+.arm-run {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 2px 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  text-decoration: none;
+  color: inherit;
+  align-items: center;
+}
+.arm-run:hover {
+  border-color: var(--line-strong);
+  background: var(--surface-2);
+  text-decoration: none;
+}
+.arm-run .hl {
+  font-family: var(--font-mono);
+  font-size: var(--fs-md);
+  font-weight: 500;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  justify-content: flex-end;
+}
+.arm-run .hl .unit {
+  font-size: var(--fs-2xs);
+}
+.arm-run .meta {
+  grid-column: 1 / 2;
+}
+@media (max-width: 640px) {
+  .arm-run {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+  .arm-run .hl {
+    justify-content: flex-start;
+    grid-column: 1 / 2;
+  }
+}

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -99,6 +99,15 @@
   --vendor-cpu: #b07d3c;
   --vendor-other: #7a8494;
 
+  /* chart series — cobalt carries throughput/primary curves, signal orange carries latency.
+   * Own tokens so charts never borrow status colours (--warn stays reserved for warnings);
+   * the pair is CVD-validated against both surfaces. The -soft variants feed the ribbon
+   * gradient under each curve. */
+  --chart-1: #1b4fd6;
+  --chart-2: #c25e00;
+  --chart-1-soft: rgba(27, 79, 214, 0.14);
+  --chart-2-soft: rgba(194, 94, 0, 0.13);
+
   --grid-dot: rgba(18, 23, 34, 0.08);
   --selection: rgba(209, 41, 94, 0.18);
 
@@ -151,6 +160,12 @@
   --vendor-intel: #58a6ff;
   --vendor-cpu: #d6a266;
   --vendor-other: #9aa4b5;
+
+  /* darker steps of the same hues, re-validated against the dark surface */
+  --chart-1: #4478f0;
+  --chart-2: #d07c28;
+  --chart-1-soft: rgba(68, 120, 240, 0.2);
+  --chart-2-soft: rgba(208, 124, 40, 0.18);
 
   --grid-dot: rgba(231, 234, 240, 0.07);
   --selection: rgba(240, 86, 127, 0.3);

--- a/app/src/util/arms.test.ts
+++ b/app/src/util/arms.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { ResultRecord } from '@atlas/core';
+import type { IndexRow } from '../data/types.js';
+import { armDiff, armLabel, cellArms, prefillPoints } from './arms.js';
+
+function row(over: Partial<IndexRow>): IndexRow {
+  return {
+    run_id: 'r',
+    cell_id: 'cell-a',
+    config_id: 'cfg-1',
+    ...over,
+  } as IndexRow;
+}
+
+const rec = { cell_id: 'cell-a', config_id: 'cfg-1' } as ResultRecord;
+
+describe('cellArms', () => {
+  it('groups the cell by config with the current arm first', () => {
+    const index = [
+      row({ run_id: 'x1', config_id: 'cfg-2' }),
+      row({ run_id: 'x2', config_id: 'cfg-2' }),
+      row({ run_id: 'x3', config_id: 'cfg-1' }),
+      row({ run_id: 'other-cell', cell_id: 'cell-b', config_id: 'cfg-9' }),
+    ];
+    const arms = cellArms(index, rec);
+    expect(arms.map((a) => a.configId)).toEqual(['cfg-1', 'cfg-2']);
+    expect(arms[1]!.rows).toHaveLength(2);
+  });
+});
+
+describe('armDiff / armLabel', () => {
+  it('names an arm by exactly the flags that differ', () => {
+    const base = { 'max-num-seqs': 2, 'gpu-memory-utilization': 0.85 };
+    const arm = { 'max-num-seqs': 64, 'gpu-memory-utilization': 0.85 };
+    expect(armDiff(base, arm)).toEqual(['max-num-seqs=64']);
+    expect(armLabel(base, arm, 'fallback')).toBe('max-num-seqs=64');
+  });
+
+  it('marks flags the arm does not set at all', () => {
+    expect(armDiff({ 'enable-prefix-caching': true }, {})).toEqual(['enable-prefix-caching=unset']);
+  });
+
+  it('falls back for identical configs and truncates long diffs', () => {
+    expect(armLabel({ a: 1 }, { a: 1 }, 'by somebody')).toBe('by somebody');
+    const label = armLabel({}, { a: 1, b: 2, c: 3 }, 'x');
+    expect(label).toBe('a=1 b=2 +1');
+  });
+});
+
+describe('prefillPoints', () => {
+  const prefill = (len: number, tok: number, started = '2026-08-28T00:00:00Z'): ResultRecord =>
+    ({
+      kind: 'prefill',
+      workload: { id: `prefill-${len}`, resolved_params: { input_tokens: len } },
+      metrics: { prefill_tok_s: tok },
+      provenance: { started_at: started },
+    }) as unknown as ResultRecord;
+
+  it('orders by context length and keeps the newest run per length', () => {
+    const pts = prefillPoints([
+      prefill(32768, 2230),
+      prefill(8192, 3100),
+      prefill(8192, 2900, '2026-08-29T00:00:00Z'),
+      { kind: 'serving' } as ResultRecord,
+    ]);
+    expect(pts.map((p) => p.input_tokens)).toEqual([8192, 32768]);
+    expect(pts[0]!.metrics.prefill_tok_s).toBe(2900);
+  });
+});

--- a/app/src/util/arms.ts
+++ b/app/src/util/arms.ts
@@ -1,0 +1,70 @@
+/**
+ * "Arms" of a heatmap cell: the same model × quant × hardware × engine-minor measured under
+ * different configurations (different `config_id`). The interesting comparison is almost
+ * always between arms — same silicon, one flag apart — so these helpers name each arm by
+ * exactly what was changed.
+ */
+import type { Args, MetricBlock, ResultRecord, SweepPoint } from '@atlas/core';
+import type { IndexRow } from '../data/types.js';
+import { argsDiff } from './diff.js';
+
+export interface CellArm {
+  configId: string;
+  rows: IndexRow[];
+}
+
+/** Sibling runs in the record's cell, grouped by config: the current arm first, then by size. */
+export function cellArms(index: IndexRow[], rec: ResultRecord): CellArm[] {
+  const by = new Map<string, IndexRow[]>();
+  for (const r of index) {
+    if (r.cell_id !== rec.cell_id) continue;
+    const list = by.get(r.config_id);
+    if (list) list.push(r);
+    else by.set(r.config_id, [r]);
+  }
+  return [...by.entries()]
+    .map(([configId, rows]) => ({ configId, rows }))
+    .sort((a, b) => {
+      if (a.configId === rec.config_id) return -1;
+      if (b.configId === rec.config_id) return 1;
+      return b.rows.length - a.rows.length;
+    });
+}
+
+/**
+ * What sets this arm apart from the base run, as `flag=value` chips. Empty when nothing
+ * differs — then the arm is a reproduction and the caller labels it by contributor instead.
+ */
+export function armDiff(base: Args, arm: Args): string[] {
+  return argsDiff([base, arm])
+    .filter((row) => row.differs)
+    .map((row) => `${row.name}=${row.values[1] ?? 'unset'}`);
+}
+
+/** Short series label for an arm: the differing flags, or a fallback identity. */
+export function armLabel(base: Args, arm: Args, fallback: string): string {
+  const diff = armDiff(base, arm);
+  if (diff.length === 0) return fallback;
+  if (diff.length <= 2) return diff.join(' ');
+  return `${diff.slice(0, 2).join(' ')} +${diff.length - 2}`;
+}
+
+/**
+ * One configuration's prefill runs as sweep points over context length. The x comes from the
+ * workload's resolved `input_tokens` — the registry defines the lengths, not this code. When
+ * the same length was run twice the newest wins.
+ */
+export function prefillPoints(recs: ResultRecord[]): SweepPoint[] {
+  const byLen = new Map<number, { rec: ResultRecord; metrics: MetricBlock }>();
+  for (const rec of recs) {
+    if (rec.kind !== 'prefill' || !rec.metrics) continue;
+    const len = rec.workload?.resolved_params?.input_tokens;
+    if (typeof len !== 'number') continue;
+    const prev = byLen.get(len);
+    if (!prev || (rec.provenance.started_at ?? '') > (prev.rec.provenance.started_at ?? ''))
+      byLen.set(len, { rec, metrics: rec.metrics });
+  }
+  return [...byLen.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([len, e]) => ({ input_tokens: len, metrics: e.metrics }));
+}

--- a/app/src/util/colors.ts
+++ b/app/src/util/colors.ts
@@ -19,16 +19,17 @@ export function vendorColor(vendor: string | null | undefined): string {
   return cssVar(`--${vendorClass(vendor)}`, cssVar('--vendor-other'));
 }
 
-/** Fixed categorical order for chart series: assigned by entity, never cycled. */
+/** Fixed categorical order for chart series: assigned by entity, never cycled. Leads with the
+ * two validated chart accents; status colours (--warn etc.) are never series colours. */
 const SERIES_VARS = [
-  '--seq-4',
-  '--vendor-amd',
-  '--vendor-nvidia',
-  '--warn',
+  '--chart-1',
+  '--chart-2',
   '--vendor-apple',
+  '--vendor-nvidia',
   '--accent',
   '--vendor-cpu',
   '--vendor-intel',
+  '--vendor-amd',
 ];
 export function seriesColor(i: number): string {
   return cssVar(SERIES_VARS[i % SERIES_VARS.length]!);

--- a/app/src/util/requests.test.ts
+++ b/app/src/util/requests.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { ResultRecord } from '@atlas/core';
+import { levelFromId, quantile, requestSamples, samplesByLevel } from './requests.js';
+
+function recWith(payload: unknown): ResultRecord {
+  return { raw: { payload } } as unknown as ResultRecord;
+}
+
+const req = (id: string, over: Record<string, unknown> = {}) => ({
+  id,
+  status: 'ok',
+  warmup: false,
+  ttft_ms: 100,
+  e2e_ms: 1000,
+  completion_tokens: 256,
+  ...over,
+});
+
+describe('levelFromId', () => {
+  it('parses the level regardless of the axis name the harness used', () => {
+    expect(levelFromId('concurrency16-r00042')).toBe(16);
+    expect(levelFromId('concurrency1-w00000')).toBe(1);
+    expect(levelFromId('input8192-r3')).toBe(8192);
+  });
+
+  it('returns null when the id does not encode a level', () => {
+    expect(levelFromId('mix-0319')).toBeNull();
+    expect(levelFromId('r00042')).toBeNull();
+  });
+});
+
+describe('requestSamples', () => {
+  it('extracts typed samples and tolerates missing numeric fields', () => {
+    const rec = recWith({
+      requests: [req('concurrency2-r00000'), req('concurrency2-r00001', { ttft_ms: 'nope' })],
+    });
+    const s = requestSamples(rec);
+    expect(s).toHaveLength(2);
+    expect(s[0]).toMatchObject({ level: 2, ttft_ms: 100, e2e_ms: 1000, ok: true, warmup: false });
+    expect(s[1]!.ttft_ms).toBeNull();
+  });
+
+  it('yields nothing for absent, foreign or malformed payloads', () => {
+    expect(requestSamples(recWith(undefined))).toEqual([]);
+    expect(requestSamples(recWith({ engine_endpoint: {} }))).toEqual([]);
+    expect(requestSamples(recWith({ requests: 'not-a-list' }))).toEqual([]);
+    expect(requestSamples(recWith({ requests: [{ no_id: true }, 42] }))).toEqual([]);
+  });
+});
+
+describe('samplesByLevel', () => {
+  it('groups measured samples by ascending level and drops warmups', () => {
+    const rec = recWith({
+      requests: [
+        req('concurrency8-r00000'),
+        req('concurrency1-w00000', { warmup: true }),
+        req('concurrency1-r00000'),
+        req('concurrency8-r00001'),
+        req('mix-0001'), // no level encoded — cannot be placed on the x axis
+      ],
+    });
+    const by = samplesByLevel(requestSamples(rec));
+    expect([...by.keys()]).toEqual([1, 8]);
+    expect(by.get(8)).toHaveLength(2);
+    expect(by.get(1)).toHaveLength(1);
+  });
+});
+
+describe('quantile', () => {
+  it('interpolates and clamps', () => {
+    expect(quantile([3, 1, 2], 0.5)).toBe(2);
+    expect(quantile([1, 2, 3, 4], 0.5)).toBe(2.5);
+    expect(quantile([5], 0.95)).toBe(5);
+    expect(quantile([], 0.5)).toBeNull();
+    expect(quantile([1, 9], 2)).toBe(9);
+  });
+});

--- a/app/src/util/requests.ts
+++ b/app/src/util/requests.ts
@@ -1,0 +1,75 @@
+/**
+ * Per-request samples out of `raw.payload.requests` — the atlas-bench harness records one
+ * entry per request (`{ id: "concurrency16-r00042", ttft_ms, e2e_ms, ... }`). The payload is
+ * untyped by contract (`Record<string, unknown>`), so everything here guards at runtime and
+ * an absent or foreign payload simply yields no samples.
+ */
+import type { ResultRecord } from '@atlas/core';
+import { isNum } from './format.js';
+
+export interface RequestSample {
+  id: string;
+  /** Sweep level parsed from the id prefix (`concurrency16-…` → 16); null when not encoded. */
+  level: number | null;
+  ttft_ms: number | null;
+  e2e_ms: number | null;
+  completion_tokens: number | null;
+  ok: boolean;
+  warmup: boolean;
+}
+
+function isRec(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+const num = (v: unknown): number | null => (isNum(v) ? v : null);
+
+/** `concurrency16-r00042` → 16; `input8192-r3` → 8192. Axis name is whatever the harness used. */
+export function levelFromId(id: string): number | null {
+  const m = /^[a-z_]*?(\d+)-/.exec(id);
+  return m ? Number(m[1]) : null;
+}
+
+export function requestSamples(rec: ResultRecord): RequestSample[] {
+  const payload = rec.raw?.payload;
+  if (!isRec(payload) || !Array.isArray(payload.requests)) return [];
+  const out: RequestSample[] = [];
+  for (const r of payload.requests) {
+    if (!isRec(r) || typeof r.id !== 'string') continue;
+    out.push({
+      id: r.id,
+      level: levelFromId(r.id),
+      ttft_ms: num(r.ttft_ms),
+      e2e_ms: num(r.e2e_ms),
+      completion_tokens: num(r.completion_tokens),
+      ok: r.status === 'ok',
+      warmup: r.warmup === true,
+    });
+  }
+  return out;
+}
+
+/**
+ * Measured (non-warmup) samples grouped by sweep level, levels ascending. Warmup requests are
+ * excluded because they time engine compilation, not the configuration.
+ */
+export function samplesByLevel(samples: RequestSample[]): Map<number, RequestSample[]> {
+  const by = new Map<number, RequestSample[]>();
+  for (const s of samples) {
+    if (s.warmup || s.level === null) continue;
+    const list = by.get(s.level);
+    if (list) list.push(s);
+    else by.set(s.level, [s]);
+  }
+  return new Map([...by.entries()].sort((a, b) => a[0] - b[0]));
+}
+
+/** Linear-interpolated quantile of an unsorted list; null when empty. */
+export function quantile(values: number[], q: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const pos = (sorted.length - 1) * Math.min(1, Math.max(0, q));
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  return sorted[lo]! + (sorted[hi]! - sorted[lo]!) * (pos - lo);
+}

--- a/app/src/views/run-view.ts
+++ b/app/src/views/run-view.ts
@@ -1,10 +1,12 @@
 import { html, nothing, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { renderServeCommand } from '@atlas/core';
-import type { EngineVersion, ResultRecord } from '@atlas/core';
+import type { EngineVersion, ResultRecord, SweepAxis, SweepPoint } from '@atlas/core';
 import { addButton } from '../components/add-modal.js';
 import '../components/chart.js';
+import '../components/request-strip.js';
 import '../components/run-picker.js';
+import type { StripMetric } from '../components/request-strip.js';
 import { icon } from '../components/icons.js';
 import {
   sweepAxisOf,
@@ -13,10 +15,12 @@ import {
   sweepX,
   sweepY,
   type SweepMetric,
+  type SweepSeries,
 } from '../components/sweep-chart.js';
 import {
   codeBlock,
   copyBtn,
+  deltaTag,
   emptyState,
   engineLink,
   hardwareLink,
@@ -28,17 +32,22 @@ import {
   modelLink,
   skeletonBlock,
   skeletonLines,
+  sparkline,
   verifBadge,
   when,
   who,
   workloadLink,
 } from '../components/ui.js';
+import type { IndexRow } from '../data/types.js';
 import { href, modelHref, navigate } from '../router.js';
 import { store } from '../store.js';
-import { cssVar } from '../util/colors.js';
+import { armDiff, armLabel, cellArms, prefillPoints } from '../util/arms.js';
+import { cssVar, seriesColor } from '../util/colors.js';
 import { absDateTime } from '../util/dates.js';
-import { fmtInt, fmtMs, fmtNum, fmtPct, fmtTokS, shortSha } from '../util/format.js';
-import { blockCards } from '../util/metrics.js';
+import { metricDelta } from '../util/diff.js';
+import { fmtGB, fmtInt, fmtMs, fmtNum, fmtPct, fmtTokS, fmtW, shortSha } from '../util/format.js';
+import { blockCards, headlineMetric } from '../util/metrics.js';
+import { requestSamples } from '../util/requests.js';
 import { fmtDefault, isDefault } from '../components/param-form.js';
 import { modelRefFor } from './explore-view.js';
 import { ViewElement } from './view-base.js';
@@ -49,21 +58,60 @@ export class AtlasRunView extends ViewElement {
   @state() private rec: ResultRecord | null | undefined = undefined;
   @state() private vf: EngineVersion | null = null;
   @state() private itemFilter: 'all' | 'correct' | 'incorrect' = 'all';
-  @state() private sweepMetric: SweepMetric = 'throughput';
+  @state() private stripMetric: StripMetric = 'ttft';
+  @state() private siblings = new Map<string, ResultRecord | null>();
   private loadedFor = '';
 
   protected override willUpdate(_c: PropertyValues): void {
     if (this.runId && this.runId !== this.loadedFor && store.registry.value) {
       this.loadedFor = this.runId;
       this.rec = undefined;
+      this.siblings = new Map();
       const row = store.rowById(this.runId);
       void store.run(row ?? { run_id: this.runId }).then((rec) => {
         if (this.loadedFor !== this.runId) return;
         this.rec = rec;
-        if (rec)
+        if (rec) {
           void store.engineVersion(rec.engine.id, rec.engine.version).then((vf) => (this.vf = vf));
+          this.loadSiblings(rec);
+        }
       });
     }
+  }
+
+  /**
+   * The full records of the cell's other runs: they carry the args (to name each arm by what
+   * actually differs) and the sweep points (to overlay the curves). Cells are small, so a
+   * handful of lazy fetches — the store caches them for the compare view anyway.
+   */
+  private loadSiblings(rec: ResultRecord): void {
+    const runId = this.runId;
+    // Big cells can hold dozens of runs; fetch the ones the page actually draws from first:
+    // same-workload arms (curve overlay), then this config's prefill family (context curve),
+    // then one run per other config (arm naming needs its args).
+    const score = (r: IndexRow): number =>
+      r.workload_id === rec.workload_id
+        ? 0
+        : r.kind === 'prefill' && r.config_id === rec.config_id
+          ? 1
+          : r.config_id !== rec.config_id
+            ? 2
+            : 3;
+    const rows = [...this.siblingRows(rec)].sort((a, b) => score(a) - score(b)).slice(0, 12);
+    for (const row of rows) {
+      void store.run(row).then((sib) => {
+        if (this.loadedFor !== runId) return;
+        this.siblings = new Map(this.siblings).set(row.run_id, sib);
+      });
+    }
+  }
+
+  private siblingRows(rec: ResultRecord): IndexRow[] {
+    return store.index.value.filter((r) => r.cell_id === rec.cell_id && r.run_id !== rec.run_id);
+  }
+
+  private loadedSiblings(): ResultRecord[] {
+    return [...this.siblings.values()].filter((r): r is ResultRecord => !!r);
   }
 
   private repoUrl(): string {
@@ -181,6 +229,7 @@ export class AtlasRunView extends ViewElement {
                 : nothing
           }
           ${rec.sweep?.length ? this.sweep(rec) : nothing}
+          ${rec.kind === 'prefill' ? this.prefillCurve(rec) : nothing} ${this.arms(rec)}
           ${rec.scores ? this.scores(rec) : nothing}
           ${rec.failures?.length ? this.failures(rec) : nothing}
           ${rec.gotchas?.length ? this.gotchas(rec) : nothing} ${this.args(rec, serve)}
@@ -309,45 +358,94 @@ export class AtlasRunView extends ViewElement {
     </div>`;
   }
 
+  /**
+   * The sweep as an operating map: throughput and latency vertically paired over one synced
+   * x axis (never a dual-axis chart), so the point where aggregate tok/s keeps climbing while
+   * TTFT collapses is visible without reading a single number. Arms of the same cell that ran
+   * the same sweep are overlaid, named by the flags that differ.
+   */
   private sweep(rec: ResultRecord): TemplateResult {
     const pts = rec.sweep!;
     const axis = sweepAxisOf(pts);
-    const metrics: SweepMetric[] = (['throughput', 'ttft', 'tpot'] as SweepMetric[]).filter((m) =>
-      sweepHasMetric(pts, m),
+    const series = this.sweepSeriesFor(rec);
+    const throughput = sweepHasMetric(pts, 'throughput');
+    const latency: SweepMetric | null = sweepHasMetric(pts, 'ttft')
+      ? 'ttft'
+      : sweepHasMetric(pts, 'tpot')
+        ? 'tpot'
+        : null;
+    const sync = `sweep-${rec.run_id}`;
+    const samples = requestSamples(rec);
+    const stripMetrics: StripMetric[] = (['ttft', 'e2e'] as StripMetric[]).filter((m) =>
+      samples.some((s) => !s.warmup && (m === 'ttft' ? s.ttft_ms : s.e2e_ms) !== null),
     );
-    const metric = metrics.includes(this.sweepMetric)
-      ? this.sweepMetric
-      : (metrics[0] ?? 'throughput');
-    const color = cssVar('--seq-4');
+    const stripMetric = stripMetrics.includes(this.stripMetric)
+      ? this.stripMetric
+      : (stripMetrics[0] ?? 'ttft');
+    const throttled = pts.some((p) => p.metrics.thermal_throttle_detected);
     return html`<section>
       <div class="section-title">
         <h2>
           ${axis === 'concurrency' ? 'Parallelism sweep' : axis === 'input_tokens' ? 'Depth sweep' : 'Sweep'}
         </h2>
-        <span class="meta">${pts.length} points</span>
-        <span class="spacer"></span>
-        <div class="seg sm">
-          ${metrics.map((m) => html`<button aria-pressed=${m === metric} @click=${() => (this.sweepMetric = m)}>${m === 'throughput' ? 'tok/s' : m === 'ttft' ? 'TTFT' : 'TPOT'}</button>`)}
-        </div>
+        <span class="meta"
+          >${pts.length}
+          points${series.length > 1 ? ` · ${series.length - 1} other arm${series.length === 2 ? '' : 's'} of this cell overlaid` : ''}</span
+        >
+        ${throttled ? html`<span class="tag danger">thermal throttle</span>` : nothing}
       </div>
-      <div class="card">
-        <atlas-chart
-          .build=${sweepChartBuild([{ label: rec.run_id.slice(0, 8), color, points: pts }], metric, axis)}
-          .height=${240}
-          .key=${metric}
-        ></atlas-chart>
+      <div class="card chart-pair">
         ${
-          axis === 'concurrency' && metrics.includes('ttft') && metric === 'throughput'
-            ? html`<div class="mt-3">
-                <div class="eyebrow plain mb-2">TTFT p50 at each point</div>
+          throughput
+            ? html`<div class="eyebrow plain">Aggregate throughput</div>
                 <atlas-chart
-                  .build=${sweepChartBuild([{ label: 'TTFT', color: cssVar('--warn'), points: pts }], 'ttft', axis)}
-                  .height=${160}
-                ></atlas-chart>
-              </div>`
+                  .build=${sweepChartBuild(series, 'throughput', axis, { sync })}
+                  .height=${240}
+                  .key=${`t${series.length}`}
+                ></atlas-chart>`
+            : nothing
+        }
+        ${
+          latency
+            ? html`<div class="eyebrow plain pair-lower">
+                  ${latency === 'ttft' ? 'Time to first token' : 'Time per output token'}
+                  <span class="muted">— p50${series.length === 1 ? ', p95 band' : ''}</span>
+                </div>
+                <atlas-chart
+                  .build=${sweepChartBuild(series, latency, axis, { sync })}
+                  .height=${190}
+                  .key=${`l${series.length}`}
+                ></atlas-chart>`
             : nothing
         }
       </div>
+      ${
+        samples.length && stripMetrics.length
+          ? html`<div class="card mt-3">
+              <div class="row mb-2">
+                <div class="eyebrow plain">Every request</div>
+                <span class="spacer"></span>
+                <div class="seg sm">
+                  ${stripMetrics.map(
+                    (m) =>
+                      html`<button
+                        aria-pressed=${m === stripMetric}
+                        @click=${() => (this.stripMetric = m)}
+                      >
+                        ${m === 'ttft' ? 'TTFT' : 'E2E'}
+                      </button>`,
+                  )}
+                </div>
+              </div>
+              <atlas-request-strip
+                .samples=${samples}
+                .metric=${stripMetric}
+                .height=${230}
+              ></atlas-request-strip>
+            </div>`
+          : nothing
+      }
+      ${this.telemetry(pts, axis)}
       <div class="table-wrap mt-3">
         <table class="table cards">
           <thead>
@@ -386,6 +484,202 @@ export class AtlasRunView extends ViewElement {
             )}
           </tbody>
         </table>
+      </div>
+    </section>`;
+  }
+
+  /** This run plus every loaded arm that ran the same sweep, labelled by what differs. */
+  private sweepSeriesFor(rec: ResultRecord): SweepSeries[] {
+    const series: SweepSeries[] = [
+      { label: 'this run', color: cssVar('--chart-1'), points: rec.sweep! },
+    ];
+    for (const sib of this.loadedSiblings()) {
+      if (!sib.sweep?.length || sib.workload_id !== rec.workload_id) continue;
+      series.push({
+        label: armLabel(rec.args, sib.args, `by ${sib.provenance.github_login}`),
+        color: seriesColor(series.length),
+        points: sib.sweep,
+      });
+    }
+    return series;
+  }
+
+  /**
+   * What the machine did while the sweep ran. Small multiples, one per sensor — never a
+   * second y axis on the main chart. VRAM is null by nature on unified-memory parts, so RAM
+   * stands in when that is what was measured.
+   */
+  private telemetry(pts: SweepPoint[], axis: SweepAxis): TemplateResult | typeof nothing {
+    const ordered = [...pts].sort((a, b) => (sweepX(a, axis) ?? 0) - (sweepX(b, axis) ?? 0));
+    const tiles = [
+      {
+        label: 'GPU util',
+        unit: '%',
+        fmt: (v: number) => fmtNum(v, 0),
+        vals: ordered.map((p) => p.metrics.gpu_util_avg_pct ?? null),
+      },
+      {
+        label: 'Avg power',
+        unit: 'W',
+        fmt: fmtW,
+        vals: ordered.map((p) => p.metrics.power_avg_w ?? null),
+      },
+      ordered.some((p) => p.metrics.vram_peak_gb != null)
+        ? {
+            label: 'Peak VRAM',
+            unit: 'GB',
+            fmt: fmtGB,
+            vals: ordered.map((p) => p.metrics.vram_peak_gb ?? null),
+          }
+        : {
+            label: 'Peak RAM',
+            unit: 'GB',
+            fmt: fmtGB,
+            vals: ordered.map((p) => p.metrics.ram_peak_gb ?? null),
+          },
+      {
+        label: 'Max temp',
+        unit: '°C',
+        fmt: (v: number) => fmtNum(v, 0),
+        vals: ordered.map((p) => p.metrics.temp_max_c ?? null),
+      },
+    ].filter((t) => t.vals.some((v) => v != null));
+    if (tiles.length === 0) return nothing;
+    return html`<div class="telemetry-grid mt-3">
+      ${tiles.map((t) => {
+        const nums = t.vals.filter((v): v is number => v != null);
+        const last = nums[nums.length - 1]!;
+        const min = Math.min(...nums);
+        const max = Math.max(...nums);
+        return html`<div class="telemetry-tile" title=${`${t.label} across the sweep levels`}>
+          <span class="k">${t.label}</span>
+          <span class="v">${t.fmt(last)}<span class="unit">${t.unit}</span></span>
+          ${sparkline(t.vals, { width: 96, height: 26 })}
+          <span class="range">${min === max ? 'flat' : `${t.fmt(min)}–${t.fmt(max)}`}</span>
+        </div>`;
+      })}
+    </div>`;
+  }
+
+  /**
+   * Prefill flatness: the same configuration run at every registered context length. The x
+   * values come from the workloads' resolved `input_tokens`, so a new prefill workload in the
+   * registry extends this chart with no code change.
+   */
+  private prefillCurve(rec: ResultRecord): TemplateResult | typeof nothing {
+    const family = [rec, ...this.loadedSiblings()].filter((r) => r.config_id === rec.config_id);
+    const points = prefillPoints(family);
+    if (points.length < 2) return nothing;
+    const series: SweepSeries[] = [{ label: 'prefill tok/s', color: cssVar('--chart-1'), points }];
+    return html`<section>
+      <div class="section-title">
+        <h2>Prefill across context length</h2>
+        <span class="meta">${points.length} lengths, same configuration — flat is the ideal</span>
+      </div>
+      <div class="card">
+        <atlas-chart
+          .build=${sweepChartBuild(series, 'prefill', 'input_tokens', { logX: true })}
+          .height=${220}
+          .key=${points.length}
+        ></atlas-chart>
+      </div>
+    </section>`;
+  }
+
+  /**
+   * The cell's other arms: same model × quant × hardware × engine-minor, measured under a
+   * different flag set (or reproduced by somebody else). This is the comparison the atlas
+   * exists for, so it is one click, not a search.
+   */
+  private arms(rec: ResultRecord): TemplateResult | typeof nothing {
+    const rows = this.siblingRows(rec);
+    if (rows.length === 0) return nothing;
+    const groups = cellArms(store.index.value, rec).filter(
+      (g) => !(g.configId === rec.config_id && g.rows.every((r) => r.run_id === rec.run_id)),
+    );
+    const currentRow = store.rowById(rec.run_id);
+    return html`<section>
+      <div class="section-title">
+        <h2>Same cell, other runs</h2>
+        <span class="meta">${rows.length} in this model × hardware × engine-minor square</span>
+      </div>
+      <div class="arm-list">
+        ${groups.map((g) => {
+          const sibRec = g.rows
+            .map((r) => this.siblings.get(r.run_id))
+            .find((r): r is ResultRecord => !!r);
+          const sameConfig = g.configId === rec.config_id;
+          const chips = sameConfig ? [] : sibRec ? armDiff(rec.args, sibRec.args) : null;
+          // The same workload is the apples-to-apples comparison — surface it first, cap the
+          // rest: a fully-swept cell holds dozens of runs and this is a summary, not a table.
+          const all = g.rows
+            .filter((r) => r.run_id !== rec.run_id)
+            .sort(
+              (a, b) =>
+                Number(b.workload_id === rec.workload_id) -
+                Number(a.workload_id === rec.workload_id),
+            );
+          const runs = all.slice(0, 6);
+          if (runs.length === 0) return nothing;
+          return html`<div class="arm-group">
+            <div class="arm-head">
+              ${
+                sameConfig
+                  ? html`<span class="tag">same config</span>
+                      <span class="xs muted"
+                        >this exact fingerprint — repeats and other workloads</span
+                      >`
+                  : html`<span class="tag accent">different config</span> ${
+                        chips === null
+                          ? html`<span class="xs muted">config ${hashChip(g.configId)}</span>`
+                          : chips.length
+                            ? chips
+                                .slice(0, 4)
+                                .map((c) => html`<span class="chip mono">${c}</span>`)
+                            : html`<span class="xs muted">differs only in canonical form</span>`
+                      }
+                      ${chips && chips.length > 4 ? html`<span class="xs muted">+${chips.length - 4} more</span>` : nothing}`
+              }
+            </div>
+            ${runs.map((r) => {
+              const hl = headlineMetric(r, store.site.coverage.key_metrics);
+              const comparable = currentRow && r.workload_id === rec.workload_id && hl;
+              const base = comparable ? hl.def.fromRow(currentRow) : null;
+              const delta =
+                comparable && base !== null ? metricDelta(base, hl.value, hl.def.better) : null;
+              return html`<a class="arm-run" href=${href('run', r.run_id)}>
+                <span class="row" style="gap:6px;min-width:0">
+                  ${kindTag(r.kind)}
+                  <span class="mono xs ellipsis">${r.workload_id}</span>
+                </span>
+                <span class="hl">
+                  ${hl ? html`${hl.def.fmt(hl.value)}<span class="unit">${hl.def.unit}</span> <span class="xs muted">${hl.def.short}</span>` : html`<span class="faint">–</span>`}
+                  ${delta ? deltaTag(delta) : nothing}
+                </span>
+                <span class="meta xs muted">
+                  ${r.provenance.login} ·
+                  ${when(r.provenance.submitted_at ?? r.provenance.started_at)}
+                </span>
+                <span
+                  class="btn btn-xs"
+                  @click=${(e: Event) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    navigate(`#/compare?runs=${rec.run_id},${r.run_id}`);
+                  }}
+                  >${icon('compare')} Compare</span
+                >
+              </a>`;
+            })}
+            ${
+              all.length > runs.length
+                ? html`<span class="xs muted"
+                    >+${all.length - runs.length} more runs of this configuration</span
+                  >`
+                : nothing
+            }
+          </div>`;
+        })}
       </div>
     </section>`;
   }


### PR DESCRIPTION
The charts were reading a fraction of what a result file contains. Every sweep run carries `raw.payload.requests[]` — up to 400 per-request rows, each with its own TTFT and end-to-end time — and the site rendered only the aggregate. Several cells now also exist at more than one configuration, and comparing the arms of one cell meant opening two tabs.

### The operating map

The main addition. Aggregate throughput and TTFT as two panels over one cursor-synced concurrency axis.

Deliberately **not** a dual-axis chart. Two y-scales on one plot invites reading a crossing point that means nothing. Paired panels show the real tension honestly — throughput keeps climbing while time-to-first-token collapses — and the app still never says which point is "best". That stays the reader's call, because this is a coverage map and not a leaderboard.

### Also

- **`request-strip`** — one dot per measured request, ordinal x by concurrency level, log y, with a p50 caliper and a min–max hairline. Percentiles hide the bimodality that appears at high concurrency; this shows it. Failures render in the danger colour with a legend key.
- **Cell arms** — sibling runs of the same cell are fetched lazily, overlaid on the sweep charts labelled by *exactly the flag that differs* (e.g. `enable-prefix-caching=false`), and grouped below with headline metric and better/worse deltas.
- **Prefill across context length** — the same config's runs at 8k / 32k / 128k become one curve, where flat is the ideal.
- **Telemetry small multiples** — GPU util, average power, peak VRAM-or-RAM, max temperature, with ranges across sweep levels. RAM stands in where `vram_peak_gb` is null, which is every unified-memory part by nature.

### Colour

Two chart-series tokens were added rather than repainting the app's identity: `--chart-1` (cobalt, throughput) and `--chart-2` (signal orange, latency), each with a `-soft` variant for the gradient ribbons. Both pairs were checked for contrast against their surfaces in light and dark. Status colours (`--warn` and friends) are no longer reused as series colours, so "orange" now means one thing.

### Nothing is special-cased

Per CONTRIBUTING's "registries are data": the request-id parser reads any `<axis><level>-` prefix rather than the literal `concurrency`; prefill x values come from the workloads' resolved `input_tokens`; arm labels come from diffing the recorded `args`. No engine or model id appears in a conditional anywhere.

### Incidental fix

`chart.ts` had a latent crash: uPlot calls the legend before the plot bbox exists, so a gradient fill built from it threw `createLinearGradient` on non-finite coordinates. Guarded.

### Checks

`pnpm test` 347 passed / 1 skipped · `pnpm typecheck` clean · `pnpm validate` 0 errors (254 warnings, all pre-existing and data-side) · `eslint .` clean. New utilities and components each ship co-located tests. Verified at 375 px: `scrollWidth 360 ≤ 375`, no horizontal page scroll.

### Not done here

`prettier --check .` fails on 348 files **at the pre-change baseline too** — formatter-version drift across data JSON and some older views. Every file touched by this branch passes; reformatting the repository belongs in its own commit rather than buried in a feature diff.

`--vendor-apple` and `--vendor-cpu` fail the chroma floor and a few deep-order adjacencies remain weak for colour-vision deficiency. Those hues carry vendor identity across the heatmap and dots, so this branch only reordered around them; retuning them is a design decision, not a drive-by.
