### PR TITLE
chore: stop prettier policing machine-written data, and format the rest

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,18 @@ node_modules
 dist
 app/public/data
 pnpm-lock.yaml
+
+# Registry and result data is machine-written and schema-governed: atlas-bench emits result
+# files, tools/ingest emits engine versions, and the schemas define the shape. Prettier has no
+# authority over any of it, reformatting it churns files whose owner is a contributor rather
+# than this repository, and the next harness run would undo the change regardless. READMEs in
+# these directories are prose and stay formatted.
+results/**/*.json
+models/**/*.json
+hardware/*.json
+engines/**/*.json
+datasets/**/*.json
+datasets/**/*.jsonl
+schemas/**/*.json
+workloads/*.json
+site/*.json

--- a/app/index.html
+++ b/app/index.html
@@ -4,11 +4,17 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Inference Atlas</title>
-    <meta name="description" content="A community-owned map of LLM inference engine configurations. Colour means evidence, not speed." />
+    <meta
+      name="description"
+      content="A community-owned map of LLM inference engine configurations. Colour means evidence, not speed."
+    />
     <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#f5f6f8" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0e1116" media="(prefers-color-scheme: dark)" />
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230e1116'/%3E%3Cg fill='%23e6e9ef'%3E%3Crect x='5' y='5' width='6' height='6' rx='1'/%3E%3Crect x='13' y='5' width='6' height='6' rx='1' fill='%237dd3fc'/%3E%3Crect x='21' y='5' width='6' height='6' rx='1' opacity='.25'/%3E%3Crect x='5' y='13' width='6' height='6' rx='1' opacity='.25'/%3E%3Crect x='13' y='13' width='6' height='6' rx='1' fill='%2322c55e'/%3E%3Crect x='21' y='13' width='6' height='6' rx='1' opacity='.25'/%3E%3Crect x='5' y='21' width='6' height='6' rx='1' opacity='.25'/%3E%3Crect x='13' y='21' width='6' height='6' rx='1' opacity='.25'/%3E%3Crect x='21' y='21' width='6' height='6' rx='1' fill='%23e8467c'/%3E%3C/g%3E%3C/svg%3E" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230e1116'/%3E%3Cg fill='%23e6e9ef'%3E%3Crect x='5' y='5' width='6' height='6' rx='1'/%3E%3Crect x='13' y='5' width='6' height='6' rx='1' fill='%237dd3fc'/%3E%3Crect x='21' y='5' width='6' height='6' rx='1' opacity='.25'/%3E%3Crect x='5' y='13' width='6' height='6' rx='1' opacity='.25'/%3E%3Crect x='13' y='13' width='6' height='6' rx='1' fill='%2322c55e'/%3E%3Crect x='21' y='13' width='6' height='6' rx='1' opacity='.25'/%3E%3Crect x='5' y='21' width='6' height='6' rx='1' opacity='.25'/%3E%3Crect x='13' y='21' width='6' height='6' rx='1' opacity='.25'/%3E%3Crect x='21' y='21' width='6' height='6' rx='1' fill='%23e8467c'/%3E%3C/g%3E%3C/svg%3E"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/app/src/app-shell.ts
+++ b/app/src/app-shell.ts
@@ -122,7 +122,9 @@ export class AtlasApp extends AtlasElement {
       case 'parallelism':
         return html`<atlas-parallelism-view></atlas-parallelism-view>`;
       case 'models':
-        return html`<atlas-models-view .itemId=${modelIdFromSegments(r.segments)}></atlas-models-view>`;
+        return html`<atlas-models-view
+          .itemId=${modelIdFromSegments(r.segments)}
+        ></atlas-models-view>`;
       case 'hardware':
         return html`<atlas-hardware-view .itemId=${b ?? null}></atlas-hardware-view>`;
       case 'engines':

--- a/app/src/components/cell-drawer.ts
+++ b/app/src/components/cell-drawer.ts
@@ -137,30 +137,30 @@ export class AtlasCellDrawer extends AtlasElement {
                         </div>
                         ${runs.map((r) => this.runRow(r))}
                         ${
-                        missingW.length
-                          ? html`<div class="row-wrap" style="gap:4px">
-                              <span class="xs muted">Missing:</span>
-                              ${missingW.slice(0, 6).map((w) =>
-                                addButton(this.specFor(pc, [w.id]), {
-                                  label: w.id,
-                                  size: 'xs',
-                                  title: `Add ${w.name}`,
-                                }),
-                              )}
-                              ${
-                                missingW.length > 6
-                                  ? addButton(
-                                      this.specFor(
-                                        pc,
-                                        missingW.map((w) => w.id),
-                                      ),
-                                      { label: `all ${missingW.length}`, size: 'xs' },
-                                    )
-                                  : nothing
-                              }
-                            </div>`
-                          : nothing
-                      }
+                          missingW.length
+                            ? html`<div class="row-wrap" style="gap:4px">
+                                <span class="xs muted">Missing:</span>
+                                ${missingW.slice(0, 6).map((w) =>
+                                  addButton(this.specFor(pc, [w.id]), {
+                                    label: w.id,
+                                    size: 'xs',
+                                    title: `Add ${w.name}`,
+                                  }),
+                                )}
+                                ${
+                                  missingW.length > 6
+                                    ? addButton(
+                                        this.specFor(
+                                          pc,
+                                          missingW.map((w) => w.id),
+                                        ),
+                                        { label: `all ${missingW.length}`, size: 'xs' },
+                                      )
+                                    : nothing
+                                }
+                              </div>`
+                            : nothing
+                        }
                       </div>`;
                     })}
                   </div>

--- a/app/src/router.test.ts
+++ b/app/src/router.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { buildHash, href, modelHref, modelIdFromSegments, parseHash, qlist, qnum } from './router.js';
+import {
+  buildHash,
+  href,
+  modelHref,
+  modelIdFromSegments,
+  parseHash,
+  qlist,
+  qnum,
+} from './router.js';
 
 describe('router', () => {
   it('parses paths and queries', () => {
@@ -33,7 +41,9 @@ describe('router', () => {
     expect(modelHref('google/gemma-4-E2B-it')).toBe('#/models/google/gemma-4-E2B-it');
     expect(modelHref('Qwen/Qwen3.8-27B')).toBe('#/models/Qwen/Qwen3.8-27B');
     expect(
-      modelIdFromSegments(parseHash(modelHref('nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16')).segments),
+      modelIdFromSegments(
+        parseHash(modelHref('nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16')).segments,
+      ),
     ).toBe('nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16');
   });
   it('builds hashes and hrefs', () => {

--- a/app/src/views/compare-view.ts
+++ b/app/src/views/compare-view.ts
@@ -336,13 +336,13 @@ export class AtlasCompareView extends ViewElement {
                     html`<div class="mb-2">
                       <div class="xs muted">${c}</div>
                       ${withScores.map((x) => {
-                      const v = x.r.scores!.by_category?.[c];
-                      return hbar(
-                        x.r.run_id.slice(0, 8),
-                        v && v.total ? v.correct / v.total : null,
-                        v ? `${v.correct}/${v.total}` : '–',
-                      );
-                    })}
+                        const v = x.r.scores!.by_category?.[c];
+                        return hbar(
+                          x.r.run_id.slice(0, 8),
+                          v && v.total ? v.correct / v.total : null,
+                          v ? `${v.correct}/${v.total}` : '–',
+                        );
+                      })}
                     </div>`,
                 )}
               </div>`

--- a/app/src/views/engines-view.ts
+++ b/app/src/views/engines-view.ts
@@ -352,17 +352,17 @@ export class AtlasEnginesView extends ViewElement {
                                 <span class="count">${diff.defaultChanged.length}</span>
                               </div>
                               ${
-                              diff.defaultChanged.length
-                                ? diff.defaultChanged.map(
-                                    (d) =>
-                                      html`<div class="mono xs">
-                                        ${d.name}:
-                                        <span class="muted">${JSON.stringify(d.from)}</span> →
-                                        <b>${JSON.stringify(d.to)}</b>
-                                      </div>`,
-                                  )
-                                : html`<span class="xs muted">none</span>`
-                            }
+                                diff.defaultChanged.length
+                                  ? diff.defaultChanged.map(
+                                      (d) =>
+                                        html`<div class="mono xs">
+                                          ${d.name}:
+                                          <span class="muted">${JSON.stringify(d.from)}</span> →
+                                          <b>${JSON.stringify(d.to)}</b>
+                                        </div>`,
+                                    )
+                                  : html`<span class="xs muted">none</span>`
+                              }
                               ${diff.typeChanged.map((d) => html`<div class="mono xs">${d.name}: type ${d.from} → ${d.to}</div>`)}
                             </div>
                           </div>

--- a/app/src/views/evals-view.ts
+++ b/app/src/views/evals-view.ts
@@ -107,7 +107,10 @@ export class AtlasEvalsView extends ViewElement {
                   store.index.value.length === 0
                     ? 'The suites are pinned and waiting. Show every registered model/quant — each empty cell opens a ready-made packet.'
                     : 'Loosen the filters or show every registered model/quant.',
-                action: html`<button class="btn btn-primary" @click=${() => setQuery({ all: true })}>
+                action: html`<button
+                  class="btn btn-primary"
+                  @click=${() => setQuery({ all: true })}
+                >
                   Show every registered model/quant
                 </button>`,
               })
@@ -132,45 +135,45 @@ export class AtlasEvalsView extends ViewElement {
                             ><span class="muted">/${p.quant}</span>
                           </td>
                           ${suites.map((s) => {
-                        const b = best(p.model, p.quant, s.id);
-                        if (!b) {
-                          const sel = resolveSelection(
-                            { engine, model: p.model, quant: p.quant, hardware },
-                            { requireAll: true },
-                          );
-                          return html`<td class="center" style="padding:2px 6px">
-                            ${
-                              sel.engine && sel.hardware
-                                ? addButton(
-                                    {
-                                      engine_id: sel.engine,
-                                      engine_version: sel.version,
-                                      model_id: p.model,
-                                      quant_id: p.quant,
-                                      hardware_id: sel.hardware,
-                                      workload_ids: [s.id],
-                                    },
-                                    {
-                                      label: '',
-                                      size: 'xs',
-                                      title: `Add ${s.id} for ${p.model}/${p.quant}`,
-                                    },
-                                  )
-                                : html`<span class="faint">–</span>`
+                            const b = best(p.model, p.quant, s.id);
+                            if (!b) {
+                              const sel = resolveSelection(
+                                { engine, model: p.model, quant: p.quant, hardware },
+                                { requireAll: true },
+                              );
+                              return html`<td class="center" style="padding:2px 6px">
+                                ${
+                                  sel.engine && sel.hardware
+                                    ? addButton(
+                                        {
+                                          engine_id: sel.engine,
+                                          engine_version: sel.version,
+                                          model_id: p.model,
+                                          quant_id: p.quant,
+                                          hardware_id: sel.hardware,
+                                          workload_ids: [s.id],
+                                        },
+                                        {
+                                          label: '',
+                                          size: 'xs',
+                                          title: `Add ${s.id} for ${p.model}/${p.quant}`,
+                                        },
+                                      )
+                                    : html`<span class="faint">–</span>`
+                                }
+                              </td>`;
                             }
-                          </td>`;
-                        }
-                        const step = seqStep(b.metrics.accuracy);
-                        const dark = step !== null && step >= 4;
-                        return html`<td
-                          class="center num clickable"
-                          style="background:var(--seq-${step});color:${dark ? 'var(--surface)' : 'var(--ink)'};cursor:pointer"
-                          title=${`${b.engine.id} ${b.engine.version} on ${b.hardware.id} — click to open`}
-                          @click=${() => navigate(href('run', b.run_id))}
-                        >
-                          ${fmtPct(b.metrics.accuracy, 1)}
-                        </td>`;
-                      })}
+                            const step = seqStep(b.metrics.accuracy);
+                            const dark = step !== null && step >= 4;
+                            return html`<td
+                              class="center num clickable"
+                              style="background:var(--seq-${step});color:${dark ? 'var(--surface)' : 'var(--ink)'};cursor:pointer"
+                              title=${`${b.engine.id} ${b.engine.version} on ${b.hardware.id} — click to open`}
+                              @click=${() => navigate(href('run', b.run_id))}
+                            >
+                              ${fmtPct(b.metrics.accuracy, 1)}
+                            </td>`;
+                          })}
                           <td class="num">
                             ${sc < 0 ? html`<span class="null">–</span>` : fmtPct(sc, 1)}
                           </td>

--- a/app/src/views/hardware-view.ts
+++ b/app/src/views/hardware-view.ts
@@ -352,14 +352,14 @@ export class AtlasHardwareView extends ViewElement {
             ${
               bw
                 ? html`At ${bw} GB/s, a single stream cannot decode faster than its weights can be
-                  read once per token. <b>Read / token</b> is what a token actually costs, which is
-                  below the checkpoint size whenever a model activates only part of itself — an MoE
-                  routing to a few experts, or a dense model like gemma-4-E2B whose Per-Layer
-                  Embeddings are looked up rather than multiplied. The ceiling is bandwidth over
-                  that figure. A measurement above it is marked: decoding more than one token per
-                  pass (speculative decoding) is the legitimate way past, and the other explanation
-                  is that the model's active-parameter figure is wrong. Measured numbers are the
-                  best single-stream decode recorded on this device.`
+                    read once per token. <b>Read / token</b> is what a token actually costs, which
+                    is below the checkpoint size whenever a model activates only part of itself — an
+                    MoE routing to a few experts, or a dense model like gemma-4-E2B whose Per-Layer
+                    Embeddings are looked up rather than multiplied. The ceiling is bandwidth over
+                    that figure. A measurement above it is marked: decoding more than one token per
+                    pass (speculative decoding) is the legitimate way past, and the other
+                    explanation is that the model's active-parameter figure is wrong. Measured
+                    numbers are the best single-stream decode recorded on this device.`
                 : 'No bandwidth figure is registered for this device, so no ceiling can be computed — a pull request with the vendor figure would fix that.'
             }
           </p>
@@ -388,7 +388,8 @@ export class AtlasHardwareView extends ViewElement {
                             </td>
                             <td class="num">${fmtNum(x.checkpoint, 1)} GB</td>
                             <td class="num">
-                              ${fmtNum(x.weight, 1)} GB${
+                              ${fmtNum(x.weight, 1)}
+                              GB${
                                 x.weight < x.checkpoint * 0.995
                                   ? html`<span class="muted small"> active</span>`
                                   : nothing

--- a/app/src/views/models-view.ts
+++ b/app/src/views/models-view.ts
@@ -203,7 +203,9 @@ export class AtlasModelsView extends ViewElement {
             <p class="lede mt-2">${m.notes ?? ''}</p>
           </div>
           <div class="head-actions">
-            <a class="btn btn-sm" href=${`#/?rows=quant&cols=hardware&model=${encodeURIComponent(m.id)}`}
+            <a
+              class="btn btn-sm"
+              href=${`#/?rows=quant&cols=hardware&model=${encodeURIComponent(m.id)}`}
               >${icon('grid')} On the atlas</a
             >
             <a class="btn btn-sm" href=${`#/results?model=${encodeURIComponent(m.id)}`}

--- a/app/src/views/parallelism-view.ts
+++ b/app/src/views/parallelism-view.ts
@@ -169,11 +169,11 @@ export class AtlasParallelismView extends ViewElement {
                               ${who(r.provenance.github_login, { userId: r.provenance.github_user_id, size: 'sm' })}
                             </td>
                             ${[1, 2, 4, 8, 16, 32, 64].map((c) => {
-                            const e = at(c);
-                            return html`<td class="num" data-label=${`c=${c}`}>
-                              ${e && e.y !== null ? html`${fmtTokS(e.y)}<br /><span class="xs muted">${e.eff === null ? '' : fmtPct(e.eff, 0)}</span>` : html`<span class="null">–</span>`}
-                            </td>`;
-                          })}
+                              const e = at(c);
+                              return html`<td class="num" data-label=${`c=${c}`}>
+                                ${e && e.y !== null ? html`${fmtTokS(e.y)}<br /><span class="xs muted">${e.eff === null ? '' : fmtPct(e.eff, 0)}</span>` : html`<span class="null">–</span>`}
+                              </td>`;
+                            })}
                             <td class="num" data-label="eff">
                               ${last?.eff == null ? '–' : fmtPct(last.eff, 0)}
                             </td>

--- a/app/src/views/results-view.ts
+++ b/app/src/views/results-view.ts
@@ -282,15 +282,17 @@ export class AtlasResultsView extends ViewElement {
                               type="checkbox"
                               .checked=${cols.includes(c)}
                               @change=${(e: Event) => {
-                              const on = (e.target as HTMLInputElement).checked;
-                              const keys = COLS.filter((x) =>
-                                x === c ? on : cols.includes(x),
-                              ).map((x) => x.key);
-                              setQuery({
-                                cols:
-                                  keys.join(',') === DEFAULT_COLS.join(',') ? null : keys.join(','),
-                              });
-                            }}
+                                const on = (e.target as HTMLInputElement).checked;
+                                const keys = COLS.filter((x) =>
+                                  x === c ? on : cols.includes(x),
+                                ).map((x) => x.key);
+                                setQuery({
+                                  cols:
+                                    keys.join(',') === DEFAULT_COLS.join(',')
+                                      ? null
+                                      : keys.join(','),
+                                });
+                              }}
                             />
                             ${c.label}</label
                           >`,
@@ -368,19 +370,19 @@ export class AtlasResultsView extends ViewElement {
                         ? nothing
                         : html`<div class="rg-head" style="grid-template-columns:${template}">
                             ${cols.map(
-                          (c) =>
-                            html`<button
-                              type="button"
-                              class="c ${c.num ? 'num' : ''} ${sort.key === c.key ? 'active' : ''}"
-                              style="border:0;background:none"
-                              aria-sort=${sort.key === c.key ? (sort.dir === 'asc' ? 'ascending' : 'descending') : nothing}
-                              title=${c.metric ? `${c.metric.label}${c.metric.unit ? ` (${c.metric.unit})` : ''}` : c.label}
-                              @click=${() => setQuery({ sort: serializeSort(toggleSort(sort, c.key, c.num ? 'desc' : 'asc')) })}
-                            >
-                              ${c.label}${c.metric?.unit ? html`<span class="unit">${c.metric.unit}</span>` : nothing}
-                              ${sortIcon(sort.key === c.key, sort.dir)}
-                            </button>`,
-                        )}
+                              (c) =>
+                                html`<button
+                                  type="button"
+                                  class="c ${c.num ? 'num' : ''} ${sort.key === c.key ? 'active' : ''}"
+                                  style="border:0;background:none"
+                                  aria-sort=${sort.key === c.key ? (sort.dir === 'asc' ? 'ascending' : 'descending') : nothing}
+                                  title=${c.metric ? `${c.metric.label}${c.metric.unit ? ` (${c.metric.unit})` : ''}` : c.label}
+                                  @click=${() => setQuery({ sort: serializeSort(toggleSort(sort, c.key, c.num ? 'desc' : 'asc')) })}
+                                >
+                                  ${c.label}${c.metric?.unit ? html`<span class="unit">${c.metric.unit}</span>` : nothing}
+                                  ${sortIcon(sort.key === c.key, sort.dir)}
+                                </button>`,
+                            )}
                           </div>`
                     }
                     ${

--- a/app/src/views/timeline-view.ts
+++ b/app/src/views/timeline-view.ts
@@ -206,24 +206,24 @@ export class AtlasTimelineView extends ViewElement {
                             ${series.map((s) => html`<td class="num" data-label=${s.label}>${s.values[i] === null ? html`<span class="null">–</span>` : metric.fmt(s.values[i])}</td>`)}
                             <td class="right" data-label="">
                               ${
-                              rows.some((r) => r.engine.version === v)
-                                ? html`<a
-                                    class="btn btn-xs"
-                                    href=${`#/results?engine=${sel.engine}&version=${v}&model=${encodeURIComponent(sel.model ?? '')}&quant=${sel.quant}&hardware=${sel.hardware}`}
-                                    >runs ${icon('arrowRight')}</a
-                                  >`
-                                : addButton(
-                                    {
-                                      engine_id: sel.engine,
-                                      engine_version: v,
-                                      model_id: sel.model,
-                                      quant_id: sel.quant,
-                                      hardware_id: sel.hardware,
-                                      workload_ids: workloads,
-                                    },
-                                    { label: 'Add', size: 'xs' },
-                                  )
-                            }
+                                rows.some((r) => r.engine.version === v)
+                                  ? html`<a
+                                      class="btn btn-xs"
+                                      href=${`#/results?engine=${sel.engine}&version=${v}&model=${encodeURIComponent(sel.model ?? '')}&quant=${sel.quant}&hardware=${sel.hardware}`}
+                                      >runs ${icon('arrowRight')}</a
+                                    >`
+                                  : addButton(
+                                      {
+                                        engine_id: sel.engine,
+                                        engine_version: v,
+                                        model_id: sel.model,
+                                        quant_id: sel.quant,
+                                        hardware_id: sel.hardware,
+                                        workload_ids: workloads,
+                                      },
+                                      { label: 'Add', size: 'xs' },
+                                    )
+                              }
                             </td>
                           </tr>`,
                       )}

--- a/bench/README.md
+++ b/bench/README.md
@@ -46,7 +46,7 @@ uv run atlas-bench submit --dir ../results/vllm/Qwen/Qwen3.8-27B/nvidia-gb10-dgx
 
 ## Attaching to a server with its own model names
 
-`model.id` is an identity; the name a *server* answers to is a separate string. LM Studio
+`model.id` is an identity; the name a _server_ answers to is a separate string. LM Studio
 serves the repo `google/gemma-4-E2B-it` under the key `google/gemma-4-e2b`; vLLM answers to
 whatever `--served-model-name` said. Put that key in **`model.served_model_id`** (the older
 spelling `served_name` is still accepted):
@@ -54,17 +54,23 @@ spelling `served_name` is still accepted):
 ```jsonc
 {
   "packet_version": 1,
-  "engine": { "id": "lmstudio", "version": "0.4.21", "install": { "method": "app" },
-              "base_url": "http://localhost:1234/v1" },
-  "model":  { "id": "google/gemma-4-E2B-it",      // identity: hashed, pathed, validated
-              "quant_id": "mlx-4bit",
-              "hf_id": "google/gemma-4-E2B-it",
-              "served_model_id": "google/gemma-4-e2b",   // transport: the OpenAI `model` field
-              "dtype": "auto" },
+  "engine": {
+    "id": "lmstudio",
+    "version": "0.4.21",
+    "install": { "method": "app" },
+    "base_url": "http://localhost:1234/v1",
+  },
+  "model": {
+    "id": "google/gemma-4-E2B-it", // identity: hashed, pathed, validated
+    "quant_id": "mlx-4bit",
+    "hf_id": "google/gemma-4-E2B-it",
+    "served_model_id": "google/gemma-4-e2b", // transport: the OpenAI `model` field
+    "dtype": "auto",
+  },
   "hardware": { "id": "apple-m2-max-32gb", "count": 1 },
   "args": {},
   "workloads": ["eval-format-v1"],
-  "request": { "temperature": 0, "seed": 42 }
+  "request": { "temperature": 0, "seed": 42 },
 }
 ```
 
@@ -74,16 +80,16 @@ uv run atlas-bench run --spec task.json --base-url http://localhost:1234/v1 --ou
 
 What the harness does with it:
 
-* sends `served_model_id` verbatim as the `model` field, and warns
+- sends `served_model_id` verbatim as the `model` field, and warns
   (`served-model-not-advertised`) if `/v1/models` does not list it — it still sends it, since
   some servers load on demand;
-* without one, it looks for `model.id` in `/v1/models` **case-insensitively**, and only then
+- without one, it looks for `model.id` in `/v1/models` **case-insensitively**, and only then
   falls back to the first advertised model — saying so (`served-model-guessed`) when more
   than one is loaded;
-* records the resolved key, everything `/v1/models` advertised, the base URL and whether the
+- records the resolved key, everything `/v1/models` advertised, the base URL and whether the
   server was already running in `raw.payload.engine_endpoint`, so a run against the wrong
   model can be spotted after the fact;
-* records `serve_command: null` in attach mode. The harness did not start that server and
+- records `serve_command: null` in attach mode. The harness did not start that server and
   does not claim to know how it was started. (`atlas-bench serve` still prints and runs a
   real command, and with the `lms` CLI present the LM Studio adapter can `lms load` the key.)
 
@@ -107,15 +113,15 @@ without an adapter falls back to attach mode.
 
 ## Commands
 
-| command | what it does |
-|---|---|
-| `hwinfo [--json] [--registry-dir DIR]` | captures GPU/CPU/RAM/OS from `nvidia-smi` / `rocm-smi` / `system_profiler` / `lscpu`, computes the sanitized fingerprint, prints the matched `hardware_id` **or `null` plus a ready-to-fill `hardware/<id>.json` draft** |
-| `serve --spec task.json [--engine-adapter-only]` | starts the engine via its adapter and waits for health |
-| `run --spec task.json [--base-url URL] [--out DIR] [--dry-run]` | runs every workload in the packet, writes result files, prints a summary table |
-| `validate FILE...` | local pre-flight: schema, recomputed ids, filename/path, referential integrity, plausibility (a port of `packages/core/src/plausibility.ts`, so passing here means passing `pnpm validate`) |
-| `submit --dir DIR [--draft]` | branch `result/<engine>-<model>-<hardware>-<short>`, commits **only** result files, `gh pr create --label results` |
-| `packet --cell ...` | prints the agent task packet (SPEC §7) for a cell |
-| `wrap raw.json --spec task.json` | wraps `vllm bench serve` / SGLang `bench_serving` JSON into a result file |
+| command                                                         | what it does                                                                                                                                                                                                             |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `hwinfo [--json] [--registry-dir DIR]`                          | captures GPU/CPU/RAM/OS from `nvidia-smi` / `rocm-smi` / `system_profiler` / `lscpu`, computes the sanitized fingerprint, prints the matched `hardware_id` **or `null` plus a ready-to-fill `hardware/<id>.json` draft** |
+| `serve --spec task.json [--engine-adapter-only]`                | starts the engine via its adapter and waits for health                                                                                                                                                                   |
+| `run --spec task.json [--base-url URL] [--out DIR] [--dry-run]` | runs every workload in the packet, writes result files, prints a summary table                                                                                                                                           |
+| `validate FILE...`                                              | local pre-flight: schema, recomputed ids, filename/path, referential integrity, plausibility (a port of `packages/core/src/plausibility.ts`, so passing here means passing `pnpm validate`)                              |
+| `submit --dir DIR [--draft]`                                    | branch `result/<engine>-<model>-<hardware>-<short>`, commits **only** result files, `gh pr create --label results`                                                                                                       |
+| `packet --cell ...`                                             | prints the agent task packet (SPEC §7) for a cell                                                                                                                                                                        |
+| `wrap raw.json --spec task.json`                                | wraps `vllm bench serve` / SGLang `bench_serving` JSON into a result file                                                                                                                                                |
 
 Useful `run` flags: `--gotcha "text"` (repeatable), `--notes "ambient 22C, box idle"`,
 `--no-telemetry`, `--tokenizer <hf-id>`, `--login <github-login>`.
@@ -130,19 +136,19 @@ directory is, and what the result path is built from.
 
 Consequences you will notice:
 
-* registries nest one level deeper: `models/<owner>/<name>/{model.json,quants/<q>.json}`;
-* result paths do too: `results/<engine>/<owner>/<name>/<hardware>/<run_id>.json`;
-* `model.json.hf_id` must equal `id`, and so must a result's `model.hf_id`. The **weights**
+- registries nest one level deeper: `models/<owner>/<name>/{model.json,quants/<q>.json}`;
+- result paths do too: `results/<engine>/<owner>/<name>/<hardware>/<run_id>.json`;
+- `model.json.hf_id` must equal `id`, and so must a result's `model.hf_id`. The **weights**
   repo is a different thing and lives in the quant record — usually somebody else's account,
   `lmstudio-community/gemma-4-E2B-it-MLX-4bit`. That is what an engine is handed to serve
   (a packet may carry it as `model.quant_hf_id`); serving the base repo when the packet says
   `mlx-4bit` would benchmark different weights than the result claims;
-* two model directories that differ only by case are a validation error — on macOS and
+- two model directories that differ only by case are a validation error — on macOS and
   Windows they are one directory and one of them silently wins;
-* git branches cannot hold a slash, so `submit` uses a **slug** — lowercased, every character
+- git branches cannot hold a slash, so `submit` uses a **slug** — lowercased, every character
   outside `[a-z0-9.-]` replaced by `-` (`Qwen/Qwen3.8-27B` → `qwen-qwen3.8-27b`). The slug is
   used for branch names and nothing else; it is never written into a result file.
-* `--cell` takes the model id as two segments:
+- `--cell` takes the model id as two segments:
   `lmstudio@0.4.21/google/gemma-4-E2B-it/mlx-4bit/apple-m2-max-32gb`.
 
 ## How results are named
@@ -151,11 +157,11 @@ Consequences you will notice:
 results/<engine_id>/<owner>/<name>/<hardware_id>/<run_id>.json
 ```
 
-* `config_id` = `sha256(canonical)[:16]` where *canonical* is the normalized non-default
+- `config_id` = `sha256(canonical)[:16]` where _canonical_ is the normalized non-default
   engine configuration (SPEC §3)
-* `cell_id` = `sha256("model|quant|hardware|count|engine|engine_minor")[:12]`
-* `run_id` = `<config_id>--<workload_id>--<sha256("<login>|<started_at>")[:6]>`
-* the filename is exactly `<run_id>.json` — the validator recomputes all of it
+- `cell_id` = `sha256("model|quant|hardware|count|engine|engine_minor")[:12]`
+- `run_id` = `<config_id>--<workload_id>--<sha256("<login>|<started_at>")[:6]>`
+- the filename is exactly `<run_id>.json` — the validator recomputes all of it
 
 The canonical string is built by `atlas_bench/canonical.py`, a byte-for-byte port of
 `packages/core/src/canonical.ts`: aliases resolved, defaults dropped, values normalized
@@ -173,15 +179,15 @@ tokenizer is never assumed for an arbitrary model.
 
 Metric definitions (also in `atlas_bench/metrics.py`):
 
-| metric | formula |
-|---|---|
-| `output_tok_s` | Σ completion tokens (ok) / wall-clock duration |
-| `total_tok_s` | Σ (prompt + completion) tokens / duration |
-| `req_s` | successful requests / duration |
-| `prefill_tok_s` | Σ input tokens / (Σ TTFT / concurrency) |
-| `ttft_ms` | first content delta − request start |
-| `tpot_ms` | (e2e − ttft) / (completion tokens − 1), per request |
-| `itl_ms` | gaps between consecutive content deltas, pooled |
+| metric                     | formula                                             |
+| -------------------------- | --------------------------------------------------- |
+| `output_tok_s`             | Σ completion tokens (ok) / wall-clock duration      |
+| `total_tok_s`              | Σ (prompt + completion) tokens / duration           |
+| `req_s`                    | successful requests / duration                      |
+| `prefill_tok_s`            | Σ input tokens / (Σ TTFT / concurrency)             |
+| `ttft_ms`                  | first content delta − request start                 |
+| `tpot_ms`                  | (e2e − ttft) / (completion tokens − 1), per request |
+| `itl_ms`                   | gaps between consecutive content deltas, pooled     |
 | `decode_tok_s_per_request` | (completion tokens − 1) / (e2e − ttft), per request |
 
 A request whose whole completion arrived in a single delta reports no `tpot_ms` and no
@@ -200,13 +206,13 @@ host RAM. On macOS `powermetrics` needs root, so unless the harness already runs
 
 ## Workloads
 
-| kind | what it does |
-|---|---|
-| `serving` | fixed concurrency, fixed input/output lengths; `dataset_buckets` filters the prompt lengths |
-| `sweep` | repeats the serving measurement along `concurrency` (or `input_tokens`) and **stops escalating** when `success_rate` drops below the threshold, recording the failure |
-| `prefill` | large input, one output token → `prefill_tok_s` and TTFT; haystack-backed workloads send real documents, not filler |
-| `longctx` | needle-in-a-haystack per (context length, depth); headline metrics = longest fully successful context |
-| `eval` | dataset accuracy → `scores` with `by_category` / `by_difficulty` / `items` |
+| kind      | what it does                                                                                                                                                          |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `serving` | fixed concurrency, fixed input/output lengths; `dataset_buckets` filters the prompt lengths                                                                           |
+| `sweep`   | repeats the serving measurement along `concurrency` (or `input_tokens`) and **stops escalating** when `success_rate` drops below the threshold, recording the failure |
+| `prefill` | large input, one output token → `prefill_tok_s` and TTFT; haystack-backed workloads send real documents, not filler                                                   |
+| `longctx` | needle-in-a-haystack per (context length, depth); headline metrics = longest fully successful context                                                                 |
+| `eval`    | dataset accuracy → `scores` with `by_category` / `by_difficulty` / `items`                                                                                            |
 
 Workload parameters the runners read, beyond the obvious ones:
 `dataset_buckets`, `dataset_categories`, `dataset_target_tokens`, `timeout_s`, `reasoning`
@@ -221,7 +227,7 @@ An eval's output cap is `eval.max_output_tokens`.
 - **`shared_prefix` is sent as a leading system message.** Dropping it turns a prefix-caching
   measurement into a different workload.
 - **Long-context rows carry the question only.** `haystack-v1` and `eval-longctx-v1` store
-  *recipes*; the document is rebuilt with the dataset's own `build.py` and the rebuild is
+  _recipes_; the document is rebuilt with the dataset's own `build.py` and the rebuild is
   checked against the recorded `sha256`. Sending the question alone is not a smaller
   measurement, it is a wrong one.
 - **The row's own `scorer` wins** over the workload's `eval.scorer`, which is only a default —
@@ -235,7 +241,7 @@ An eval's output cap is `eval.max_output_tokens`.
   numbers are still reported.
 - For `kind: eval`, all three names an eval workload's `metrics_required` lists —
   `accuracy`, `avg_latency_ms` and `success_rate` — live in `scores`. `success_rate` is the
-  share of requests that *completed at all*, independent of whether the answers were right,
+  share of requests that _completed at all_, independent of whether the answers were right,
   and it is mirrored in the reduced request-layer `metrics` block. A malformed answer, a
   refusal or a preamble where one word was asked for is a wrong answer (it lowers
   `accuracy`); a timeout, a 5xx or a context overflow is a failed request (it lowers
@@ -276,7 +282,7 @@ agent block filled in. `github_user_id`, `commit` and `pr` are left `null` — C
 
 Rules that the harness enforces rather than trusts:
 
-- it refuses to submit when a *tracked* file outside `results/` has been modified (untracked
+- it refuses to submit when a _tracked_ file outside `results/` has been modified (untracked
   scratch files such as your `task.json`, or a brand-new `hardware/<id>.json`, are fine — the
   commit only ever contains the files passed to `git add`)
 - it refuses to run without a resolvable GitHub login (`run_id` depends on it)
@@ -285,12 +291,12 @@ Rules that the harness enforces rather than trusts:
 
 ## Environment
 
-| variable | effect |
-|---|---|
-| `ATLAS_REPO` | checkout to read registries from and write results into (otherwise discovered by walking up from the cwd, or `--registry-dir`) |
-| `ATLAS_GITHUB_LOGIN` | provenance login when `gh` is not authenticated |
-| `ATLAS_AGENT_NAME`, `ATLAS_AGENT_MODEL` | set `provenance.method` to `agent` and fill the agent block |
-| `HF_HOME` | host path mounted into the vLLM / SGLang / TGI containers |
+| variable                                | effect                                                                                                                         |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `ATLAS_REPO`                            | checkout to read registries from and write results into (otherwise discovered by walking up from the cwd, or `--registry-dir`) |
+| `ATLAS_GITHUB_LOGIN`                    | provenance login when `gh` is not authenticated                                                                                |
+| `ATLAS_AGENT_NAME`, `ATLAS_AGENT_MODEL` | set `provenance.method` to `agent` and fill the agent block                                                                    |
+| `HF_HOME`                               | host path mounted into the vLLM / SGLang / TGI containers                                                                      |
 
 ## Development
 

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -12,23 +12,23 @@ comparable when they saw the same bytes.
 
 ## Index
 
-| id | kind | rows | size | generator | default scorer |
-|---|---|---:|---:|---|---|
-| `prompts-mixed-v1` | prompts | 600 | 3.14 MB | `gen_prompts_mixed.py` | – |
-| `prompts-shared-prefix-v1` | prompts | 100 | 2.88 MB | `gen_prompts_shared_prefix.py` | – |
-| `prompts-code-v1` | prompts | 150 | 449 KB | `gen_prompts_code.py` | – |
-| `haystack-v1` | haystack | 32 | 1007 KB | `gen_haystack.py` | – |
-| `eval-math-v1` | eval | 130 | 40 KB | `gen_eval_math.py` | `numeric` |
-| `eval-reasoning-v1` | eval | 120 | 56 KB | `gen_eval_reasoning.py` | `exact` |
-| `eval-code-v1` | eval | 140 | 164 KB | `gen_eval_code.py` | `code_exec` |
-| `eval-knowledge-v1` | eval | 130 | 49 KB | `gen_eval_knowledge.py` | `mc` |
-| `eval-instruction-v1` | eval | 104 | 65 KB | `gen_eval_instruction.py` | `instruction` |
-| `eval-json-v1` | eval | 110 | 62 KB | `gen_eval_json.py` | `json` |
-| `eval-tools-v1` | eval | 80 | 149 KB | `gen_eval_tools.py` | `json` |
-| `eval-vision-v1` | eval | 60 | 141 KB | `gen_eval_vision.py` | `exact` (+ images) |
-| `eval-multilingual-v1` | eval | 80 | 39 KB | `gen_eval_multilingual.py` | `contains` |
-| `eval-longctx-v1` | eval | 100 | 100 KB | `gen_eval_longctx.py` | `needle` |
-| `eval-format-v1` | eval | 30 | 8 KB | `gen_eval_format.py` | `exact` |
+| id                         | kind     | rows |    size | generator                      | default scorer     |
+| -------------------------- | -------- | ---: | ------: | ------------------------------ | ------------------ |
+| `prompts-mixed-v1`         | prompts  |  600 | 3.14 MB | `gen_prompts_mixed.py`         | –                  |
+| `prompts-shared-prefix-v1` | prompts  |  100 | 2.88 MB | `gen_prompts_shared_prefix.py` | –                  |
+| `prompts-code-v1`          | prompts  |  150 |  449 KB | `gen_prompts_code.py`          | –                  |
+| `haystack-v1`              | haystack |   32 | 1007 KB | `gen_haystack.py`              | –                  |
+| `eval-math-v1`             | eval     |  130 |   40 KB | `gen_eval_math.py`             | `numeric`          |
+| `eval-reasoning-v1`        | eval     |  120 |   56 KB | `gen_eval_reasoning.py`        | `exact`            |
+| `eval-code-v1`             | eval     |  140 |  164 KB | `gen_eval_code.py`             | `code_exec`        |
+| `eval-knowledge-v1`        | eval     |  130 |   49 KB | `gen_eval_knowledge.py`        | `mc`               |
+| `eval-instruction-v1`      | eval     |  104 |   65 KB | `gen_eval_instruction.py`      | `instruction`      |
+| `eval-json-v1`             | eval     |  110 |   62 KB | `gen_eval_json.py`             | `json`             |
+| `eval-tools-v1`            | eval     |   80 |  149 KB | `gen_eval_tools.py`            | `json`             |
+| `eval-vision-v1`           | eval     |   60 |  141 KB | `gen_eval_vision.py`           | `exact` (+ images) |
+| `eval-multilingual-v1`     | eval     |   80 |   39 KB | `gen_eval_multilingual.py`     | `contains`         |
+| `eval-longctx-v1`          | eval     |  100 |  100 KB | `gen_eval_longctx.py`          | `needle`           |
+| `eval-format-v1`           | eval     |   30 |    8 KB | `gen_eval_format.py`           | `exact`            |
 
 Licence for all of the above: **MIT**. Total, including the generator scripts:
 about 8.7 MB against a 25 MB budget, which `_gen/check.py` prints and enforces.
@@ -61,25 +61,25 @@ and Japanese the real count runs roughly 2–4× higher. Workloads name a nomina
 ```jsonc
 {
   "id": "mix-0001",
-  "topic": "science",            // one of the dataset's topics
-  "bucket": "m",                 // xs | s | m | l | xl | xxl, see below
-  "lang": "en",                  // natural language of the prompt
-  "approx_tokens": 597,          // chars/4, includes shared_prefix when set
+  "topic": "science", // one of the dataset's topics
+  "bucket": "m", // xs | s | m | l | xl | xxl, see below
+  "lang": "en", // natural language of the prompt
+  "approx_tokens": 597, // chars/4, includes shared_prefix when set
   "messages": [{ "role": "user", "content": "..." }],
-  "shared_prefix": null          // string | null
+  "shared_prefix": null, // string | null
 }
 ```
 
 Length buckets are inclusive ranges on `approx_tokens`:
 
-| bucket | tokens | typical content |
-|---|---|---|
-| `xs` | 16–64 | a single question |
-| `s` | 65–256 | a short context plus a task |
-| `m` | 257–1024 | a page of a document plus a task |
-| `l` | 1025–4096 | a long report, source file or transcript |
-| `xl` | 4097–16384 | a big document |
-| `xxl` | 16385–65536 | a very big document |
+| bucket | tokens      | typical content                          |
+| ------ | ----------- | ---------------------------------------- |
+| `xs`   | 16–64       | a single question                        |
+| `s`    | 65–256      | a short context plus a task              |
+| `m`    | 257–1024    | a page of a document plus a task         |
+| `l`    | 1025–4096   | a long report, source file or transcript |
+| `xl`   | 4097–16384  | a big document                           |
+| `xxl`  | 16385–65536 | a very big document                      |
 
 **`shared_prefix` is a contract**: when it is non-null the harness must send it as
 a leading system message, `[{role: "system", content: shared_prefix}, *messages]`.
@@ -95,14 +95,14 @@ system message naming the language.
 {
   "id": "math-0001",
   "category": "arithmetic",
-  "difficulty": "easy",          // easy | medium | hard
-  "prompt": "...",               // or "messages": [...] when a system turn matters
-  "answer": "42",                // string | number | object, per scorer
+  "difficulty": "easy", // easy | medium | hard
+  "prompt": "...", // or "messages": [...] when a system turn matters
+  "answer": "42", // string | number | object, per scorer
   "scorer": "numeric",
-  "choices": ["...", "..."],     // mc rows only; answer is the letter label
-  "tests": "assert f(1) == 2",   // code_exec rows only
-  "image": "images/vis-0001.png",// vision rows only, relative to the dataset dir
-  "meta": { }                    // per-scorer extras, see below
+  "choices": ["...", "..."], // mc rows only; answer is the letter label
+  "tests": "assert f(1) == 2", // code_exec rows only
+  "image": "images/vis-0001.png", // vision rows only, relative to the dataset dir
+  "meta": {}, // per-scorer extras, see below
 }
 ```
 
@@ -115,16 +115,18 @@ dataset default; `eval-reasoning-v1` mixes `mc` and `exact`, and
 ```jsonc
 {
   "id": "hay-8k-d50",
-  "kind": "single",              // single | multi
+  "kind": "single", // single | multi
   "target_tokens": 8192,
   "seed": 7008292,
   "algorithm": "haystack-v1",
   "needles": [{ "depth": 0.5, "text": "...", "answer": "48213", "line_number": 143 }],
   "question": "...",
   "answer": "48213",
-  "chars": 32771, "lines": 331, "approx_tokens": 8193,
-  "sha256": "…",                 // digest of the materialised document
-  "static_file": "static/hay-8k-d50.txt"   // null above 32k tokens
+  "chars": 32771,
+  "lines": 331,
+  "approx_tokens": 8193,
+  "sha256": "…", // digest of the materialised document
+  "static_file": "static/hay-8k-d50.txt", // null above 32k tokens
 }
 ```
 
@@ -140,17 +142,17 @@ Applied in this order to the raw model output, before any scorer except
    capture of the **last** such line and use only that;
 4. strip surrounding whitespace, matching quotes, and a single trailing `.` or `!`.
 
-| scorer | `answer` | rule |
-|---|---|---|
-| `exact` | string | case-insensitive after collapsing whitespace; `meta.answer_aliases` also accepted |
-| `numeric` | numeric string | parse the last number in the output (thousands separators, leading currency symbol and trailing `%` stripped); correct within `max(meta.tolerance or 1e-6, 1e-9·|expected|)` |
-| `mc` | `"A"`…`"D"` | accept the bare letter, `A)`, `(A)`, `A.` or the full text of the correct choice |
-| `contains` | `{all: [...], any: [...]}` | casefolded substring match, no diacritic folding. An entry may be a **list of alternatives** that passes when any one is found |
-| `json` | expected value | parse the output as JSON; `meta.match` is `subset` (default) or `exact`; arrays compare elementwise in order; numbers compare numerically |
-| `code_exec` | reference solution (unused) | run `extracted_code + "\n\n" + tests` in a subprocess, no network, throwaway cwd, `meta.timeout_s` (default 10) |
-| `needle` | string | casefolded substring test after removing spaces, commas and hyphens from both sides |
-| `instruction` | rule set | evaluate the DSL below against the **raw** output |
-| `vision` | – | attach `row.image` as a base64 data URL image part next to the prompt, then apply the row's own scorer |
+| scorer        | `answer`                    | rule                                                                                                                                                             |
+| ------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `exact`       | string                      | case-insensitive after collapsing whitespace; `meta.answer_aliases` also accepted                                                                                |
+| `numeric`     | numeric string              | parse the last number in the output (thousands separators, leading currency symbol and trailing `%` stripped); correct within `max(meta.tolerance or 1e-6, 1e-9· | expected | )`  |
+| `mc`          | `"A"`…`"D"`                 | accept the bare letter, `A)`, `(A)`, `A.` or the full text of the correct choice                                                                                 |
+| `contains`    | `{all: [...], any: [...]}`  | casefolded substring match, no diacritic folding. An entry may be a **list of alternatives** that passes when any one is found                                   |
+| `json`        | expected value              | parse the output as JSON; `meta.match` is `subset` (default) or `exact`; arrays compare elementwise in order; numbers compare numerically                        |
+| `code_exec`   | reference solution (unused) | run `extracted_code + "\n\n" + tests` in a subprocess, no network, throwaway cwd, `meta.timeout_s` (default 10)                                                  |
+| `needle`      | string                      | casefolded substring test after removing spaces, commas and hyphens from both sides                                                                              |
+| `instruction` | rule set                    | evaluate the DSL below against the **raw** output                                                                                                                |
+| `vision`      | –                           | attach `row.image` as a base64 data URL image part next to the prompt, then apply the row's own scorer                                                           |
 
 One item is correct or it is not; there is no partial credit.
 `accuracy = correct / total`. A request that failed (timeout, 5xx,
@@ -196,32 +198,32 @@ Shared definitions, all normative:
 - **sentences** — split on `[.!?]+` followed by whitespace or end of text
 - **bullets** — lines whose `lstrip()` starts with a marker followed by a space
 
-| rule | parameters | passes when |
-|---|---|---|
-| `word_count` | `min?`, `max?` | the word count is in range |
-| `char_count` | `min?`, `max?` | `len(text.strip())` is in range |
-| `sentence_count` | `min?`, `max?` | the sentence count is in range |
-| `line_count` | `min?`, `max?` | the non-empty line count is in range |
-| `paragraph_count` | `min?`, `max?` | the paragraph count is in range |
-| `bullet_count` | `min?`, `max?`, `markers?`, `only_bullets?` | the bullet count is in range; with `only_bullets` every line must be a bullet |
-| `numbered_list` | `count` | line-leading numbers are exactly `1..count` in order |
-| `contains_all` | `values[]`, `case_sensitive?` | every value occurs (an entry may be a list of alternatives) |
-| `contains_none` | `values[]`, `case_sensitive?` | no value occurs |
-| `contains_any` | `values[]`, `min_matches?`, `case_sensitive?` | at least `min_matches` values occur |
-| `starts_with` | `value`, `case_sensitive?` | `text.strip()` starts with it |
-| `ends_with` | `value`, `case_sensitive?` | `text.strip()` ends with it |
-| `all_caps` | – | at least one letter, every cased letter upper case |
-| `all_lower` | – | at least one letter, every cased letter lower case |
-| `no_commas` | – | no `,` anywhere |
-| `regex` | `pattern`, `flags?` (`ims`), `mode?` | `search`, or `fullmatch` against `text.strip()` |
-| `not_regex` | `pattern`, `flags?` | the pattern is not found |
-| `json_only` | – | the whole output parses as JSON once a surrounding fence is removed |
-| `json_path_equals` | `path`, `value` | the dotted path (numeric segments index arrays) equals the value |
-| `is_number` | – | `text.strip()` with `,` removed parses as a float |
-| `word_repeat` | `value`, `min?`, `max?`, `case_sensitive?` | the word occurs that many times |
-| `max_words_per_line` | `max` | no line exceeds it |
-| `every_line_starts_with` | `value` | every non-empty line starts with it after `lstrip()` |
-| `unique_lines` | – | no two non-empty lines are identical |
+| rule                     | parameters                                    | passes when                                                                   |
+| ------------------------ | --------------------------------------------- | ----------------------------------------------------------------------------- |
+| `word_count`             | `min?`, `max?`                                | the word count is in range                                                    |
+| `char_count`             | `min?`, `max?`                                | `len(text.strip())` is in range                                               |
+| `sentence_count`         | `min?`, `max?`                                | the sentence count is in range                                                |
+| `line_count`             | `min?`, `max?`                                | the non-empty line count is in range                                          |
+| `paragraph_count`        | `min?`, `max?`                                | the paragraph count is in range                                               |
+| `bullet_count`           | `min?`, `max?`, `markers?`, `only_bullets?`   | the bullet count is in range; with `only_bullets` every line must be a bullet |
+| `numbered_list`          | `count`                                       | line-leading numbers are exactly `1..count` in order                          |
+| `contains_all`           | `values[]`, `case_sensitive?`                 | every value occurs (an entry may be a list of alternatives)                   |
+| `contains_none`          | `values[]`, `case_sensitive?`                 | no value occurs                                                               |
+| `contains_any`           | `values[]`, `min_matches?`, `case_sensitive?` | at least `min_matches` values occur                                           |
+| `starts_with`            | `value`, `case_sensitive?`                    | `text.strip()` starts with it                                                 |
+| `ends_with`              | `value`, `case_sensitive?`                    | `text.strip()` ends with it                                                   |
+| `all_caps`               | –                                             | at least one letter, every cased letter upper case                            |
+| `all_lower`              | –                                             | at least one letter, every cased letter lower case                            |
+| `no_commas`              | –                                             | no `,` anywhere                                                               |
+| `regex`                  | `pattern`, `flags?` (`ims`), `mode?`          | `search`, or `fullmatch` against `text.strip()`                               |
+| `not_regex`              | `pattern`, `flags?`                           | the pattern is not found                                                      |
+| `json_only`              | –                                             | the whole output parses as JSON once a surrounding fence is removed           |
+| `json_path_equals`       | `path`, `value`                               | the dotted path (numeric segments index arrays) equals the value              |
+| `is_number`              | –                                             | `text.strip()` with `,` removed parses as a float                             |
+| `word_repeat`            | `value`, `min?`, `max?`, `case_sensitive?`    | the word occurs that many times                                               |
+| `max_words_per_line`     | `max`                                         | no line exceeds it                                                            |
+| `every_line_starts_with` | `value`                                       | every non-empty line starts with it after `lstrip()`                          |
+| `unique_lines`           | –                                             | no two non-empty lines are identical                                          |
 
 Each row also carries `meta.example_pass`, a compliant answer written by the
 generator and verified against the rules — proof that the rule set is satisfiable.

--- a/datasets/_gen/README.md
+++ b/datasets/_gen/README.md
@@ -29,31 +29,31 @@ uv run datasets/_gen/check.py
 
 ## Which script owns which directory
 
-| script | produces | notes |
-|---|---|---|
-| `gen_prompts_mixed.py` | `prompts-mixed-v1/` | 600 prompts, 11 topics × 6 length buckets |
-| `gen_prompts_shared_prefix.py` | `prompts-shared-prefix-v1/` | 100 prompts over 4 long system prompts |
-| `gen_prompts_code.py` | `prompts-code-v1/` | 150 coding prompts in 5 languages |
-| `gen_haystack.py` | `haystack-v1/` | 32 recipes + static files ≤ 32k tokens |
-| `gen_eval_math.py` | `eval-math-v1/` | answers computed, never typed |
-| `gen_eval_reasoning.py` | `eval-reasoning-v1/` | puzzles brute-forced for a unique solution |
-| `gen_eval_code.py` | `eval-code-v1/` | reference solutions run against their own tests |
-| `gen_eval_knowledge.py` | `eval-knowledge-v1/` | MC, correct letter balanced over A–D |
-| `gen_eval_instruction.py` | `eval-instruction-v1/` | rule DSL, each item verified against a compliant example |
-| `gen_eval_json.py` | `eval-json-v1/` | expected objects computed from the same data as the prompt |
-| `gen_eval_tools.py` | `eval-tools-v1/` | expected arguments validated against the tool schema |
-| `gen_eval_vision.py` | `eval-vision-v1/` | draws every PNG; needs Pillow |
-| `gen_eval_multilingual.py` | `eval-multilingual-v1/` | native text lives in `_multilingual.py` |
-| `gen_eval_longctx.py` | `eval-longctx-v1/` | recipes verified against `haystack-v1/build.py` |
-| `gen_eval_format.py` | `eval-format-v1/` | hand-written, 30 items |
+| script                         | produces                    | notes                                                      |
+| ------------------------------ | --------------------------- | ---------------------------------------------------------- |
+| `gen_prompts_mixed.py`         | `prompts-mixed-v1/`         | 600 prompts, 11 topics × 6 length buckets                  |
+| `gen_prompts_shared_prefix.py` | `prompts-shared-prefix-v1/` | 100 prompts over 4 long system prompts                     |
+| `gen_prompts_code.py`          | `prompts-code-v1/`          | 150 coding prompts in 5 languages                          |
+| `gen_haystack.py`              | `haystack-v1/`              | 32 recipes + static files ≤ 32k tokens                     |
+| `gen_eval_math.py`             | `eval-math-v1/`             | answers computed, never typed                              |
+| `gen_eval_reasoning.py`        | `eval-reasoning-v1/`        | puzzles brute-forced for a unique solution                 |
+| `gen_eval_code.py`             | `eval-code-v1/`             | reference solutions run against their own tests            |
+| `gen_eval_knowledge.py`        | `eval-knowledge-v1/`        | MC, correct letter balanced over A–D                       |
+| `gen_eval_instruction.py`      | `eval-instruction-v1/`      | rule DSL, each item verified against a compliant example   |
+| `gen_eval_json.py`             | `eval-json-v1/`             | expected objects computed from the same data as the prompt |
+| `gen_eval_tools.py`            | `eval-tools-v1/`            | expected arguments validated against the tool schema       |
+| `gen_eval_vision.py`           | `eval-vision-v1/`           | draws every PNG; needs Pillow                              |
+| `gen_eval_multilingual.py`     | `eval-multilingual-v1/`     | native text lives in `_multilingual.py`                    |
+| `gen_eval_longctx.py`          | `eval-longctx-v1/`          | recipes verified against `haystack-v1/build.py`            |
+| `gen_eval_format.py`           | `eval-format-v1/`           | hand-written, 30 items                                     |
 
 Shared, not a generator:
 
-| file | role |
-|---|---|
-| `_lib.py` | seeded text machinery: topic banks, template filler, document/code/transcript composers, dataset.json helpers, the scorer vocabulary |
-| `_multilingual.py` | natively written German, French, Spanish, Italian, Portuguese, Arabic, Chinese, Japanese and Turkish text |
-| `check.py` | validates every dataset; exit code 1 on any problem |
+| file               | role                                                                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `_lib.py`          | seeded text machinery: topic banks, template filler, document/code/transcript composers, dataset.json helpers, the scorer vocabulary |
+| `_multilingual.py` | natively written German, French, Spanish, Italian, Portuguese, Arabic, Chinese, Japanese and Turkish text                            |
+| `check.py`         | validates every dataset; exit code 1 on any problem                                                                                  |
 
 Two reference implementations live **with their data**, not here, because the
 Python harness in `bench/` has to import them:

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2,7 +2,7 @@
 
 **A community owned map of LLM inference engine configurations, hosted entirely on GitHub Pages.**
 
-Working title. Alternatives: *ServeBench*, *ConfigAtlas*, *The Serving Grid*, *tok/s.dev*.
+Working title. Alternatives: _ServeBench_, _ConfigAtlas_, _The Serving Grid_, _tok/s.dev_.
 
 Status: original design document (vision). The binding implementation contract is `docs/SPEC.md`.
 
@@ -10,13 +10,13 @@ Status: original design document (vision). The binding implementation contract i
 
 ## 1. One paragraph summary
 
-Inference Atlas is a static web app that renders the *configuration space* of LLM serving engines (vLLM, SGLang, llama.cpp, TensorRT-LLM, MLX, TGI) as a browsable, searchable map. Every cell in that map is a combination of model, hardware, engine version, engine flags and workload. Cells that somebody has already benchmarked show real numbers, attributed to the GitHub user who ran them and the commit that added them. Cells nobody has tested show up as gaps, and the app hands you everything you need to fill the gap yourself: the exact shell command, a machine readable task packet for a coding agent, the output schema, and a one click path to a pull request. All data lives as JSON files in the same repository that serves the site. There is no backend, no database and no server cost.
+Inference Atlas is a static web app that renders the _configuration space_ of LLM serving engines (vLLM, SGLang, llama.cpp, TensorRT-LLM, MLX, TGI) as a browsable, searchable map. Every cell in that map is a combination of model, hardware, engine version, engine flags and workload. Cells that somebody has already benchmarked show real numbers, attributed to the GitHub user who ran them and the commit that added them. Cells nobody has tested show up as gaps, and the app hands you everything you need to fill the gap yourself: the exact shell command, a machine readable task packet for a coding agent, the output schema, and a one click path to a pull request. All data lives as JSON files in the same repository that serves the site. There is no backend, no database and no server cost.
 
 ---
 
 ## 2. The problem
 
-Benchmark numbers for local inference are scattered across blog posts, Reddit threads, GitHub issues and Discord screenshots. They are almost never reproducible, because the thing that determines the result is not the model and not the GPU, it is the *combination*:
+Benchmark numbers for local inference are scattered across blog posts, Reddit threads, GitHub issues and Discord screenshots. They are almost never reproducible, because the thing that determines the result is not the model and not the GPU, it is the _combination_:
 
 - engine and exact engine version (vLLM 0.26.1 vs 0.27.1 can differ by double digit percentages)
 - quantization format and whether the hardware has a native kernel path for it
@@ -41,7 +41,7 @@ Every benchmark run is reduced to a deterministic hash of its normalized configu
 
 ### 3.2 Coverage as the primary view
 
-The landing view is not a top ten list. It is a heatmap of the space, where colour means *evidence*, not speed. Grey means nobody has tried this. That inverts the usual incentive: contributors are pulled towards gaps rather than towards re-benchmarking whatever is trending.
+The landing view is not a top ten list. It is a heatmap of the space, where colour means _evidence_, not speed. Grey means nobody has tried this. That inverts the usual incentive: contributors are pulled towards gaps rather than towards re-benchmarking whatever is trending.
 
 ### 3.3 The agent task packet
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -15,7 +15,7 @@ disagree, this file wins.
    someone else fails validation. This is what makes merge conflicts structurally
    impossible and makes every contributor the owner of their own numbers.
 3. **Provenance is mandatory and verifiable.** Each result records the GitHub login
-   (numeric user id resolved in CI), and the build step derives the *adding commit hash*
+   (numeric user id resolved in CI), and the build step derives the _adding commit hash_
    and PR number from `git log` so they cannot be faked.
 4. **Everything is configurable through data.** Hardware, engines, engine versions and
    flags, models, quantizations, workloads, datasets, eval suites, scoring weights, site
@@ -73,14 +73,14 @@ TypeScript strict, Vitest, ESLint flat config (light), Prettier. Python side use
 
 Top-level scripts (root `package.json`):
 
-| script | does |
-|---|---|
-| `pnpm validate` | validates every JSON file in the registries + results against schemas, recomputes ids, runs plausibility + ownership checks (same code CI runs) |
-| `pnpm build:data` | compiles registries + results into `app/public/data/*` (index, shards, contributors, coverage, manifest) |
-| `pnpm dev` | `build:data` then Vite dev server for `app/` |
-| `pnpm build` | `build:data` + Vite production build into `app/dist` |
-| `pnpm test` | vitest across packages + tools + app unit tests |
-| `pnpm packet -- <spec>` | prints an agent packet for a cell (same generator the app uses) |
+| script                  | does                                                                                                                                            |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm validate`         | validates every JSON file in the registries + results against schemas, recomputes ids, runs plausibility + ownership checks (same code CI runs) |
+| `pnpm build:data`       | compiles registries + results into `app/public/data/*` (index, shards, contributors, coverage, manifest)                                        |
+| `pnpm dev`              | `build:data` then Vite dev server for `app/`                                                                                                    |
+| `pnpm build`            | `build:data` + Vite production build into `app/dist`                                                                                            |
+| `pnpm test`             | vitest across packages + tools + app unit tests                                                                                                 |
+| `pnpm packet -- <spec>` | prints an agent packet for a cell (same generator the app uses)                                                                                 |
 
 ## 2. Identifiers
 
@@ -88,17 +88,17 @@ All ids except `model_id` are lowercase kebab-case `[a-z0-9][a-z0-9.-]*`. `model
 Hugging Face repo id verbatim (see below). Registry ids are chosen by humans and stable forever
 (renaming = new id + `aliases`).
 
-| id | where | rule |
-|---|---|---|
-| `hardware_id` | `hardware/<id>.json` | e.g. `nvidia-rtx-4090`, `nvidia-gb10-dgx-spark`, `apple-m2-max-32gb`, `apple-m3-ultra-96gb` (Apple SoC ids include memory because it is the binding constraint) |
-| `engine_id` | `engines/<id>/` | `vllm`, `sglang`, `llamacpp`, `ollama`, `mlx-lm`, `tensorrt-llm`, `tgi`, `lmstudio`, `exllamav3` |
-| `model_id` | `models/<owner>/<name>/` | **The Hugging Face repo id, verbatim and case-preserved**: `Qwen/Qwen3.8-27B`, `google/gemma-4-E2B-it`, `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16`. Pattern `^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$` (exactly one `/`). A fine-tune or re-upload by somebody else is a different HF repo and therefore a different model. `model.json.hf_id` must equal `id`. Directory path = id (two levels). The validator rejects two model dirs that differ only by case. |
-| `quant_id` | `models/<model-id>/quants/<quant-id>.json` | `bf16`, `fp8`, `nvfp4`, `awq-int4`, `gptq-int4`, `gguf-q4-k-m`, `gguf-q5-k-m`, `gguf-q8-0`, `mlx-4bit`, `mlx-8bit`, `exl3-4.0bpw`. Unique within the model; the quant record's `hf_id` is the full HF repo that holds the weights (official or community, e.g. `lmstudio-community/gemma-4-E2B-it-MLX-4bit`). Full ref = `<model-id>/<quant-id>`. |
-| `workload_id` | `workloads/<id>.json` | versioned suffix mandatory: `serve-chat-c8-i1k-o256-v1`, `sweep-parallel-1-32-v1`, `eval-math-v1`, `eval-code-v1`, `eval-vision-v1`, `longctx-needle-32k-v1`, `prefill-32k-v1`. Immutable once published. |
-| `cell_id` | computed | `sha256("model_id|quant_id|hardware_id|hw_count|engine_id|engine_minor")[:12]` where `engine_minor` = first two semver components (`0.27`). One square on the coverage map. |
-| `config_id` | computed | canonical non-default engine args (see §3) → `sha256(canonical)[:16]` |
-| `run_id` | computed | `<config_id>--<workload_id>--<sha256(github_login + "|" + started_at)[:6]>` |
-| result filename | `results/<engine>/<owner>/<name>/<hardware>/<run_id>.json` | exactly `run_id + ".json"`; `<owner>/<name>` is the model_id |
+| id              | where                                                      | rule                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hardware_id`   | `hardware/<id>.json`                                       | e.g. `nvidia-rtx-4090`, `nvidia-gb10-dgx-spark`, `apple-m2-max-32gb`, `apple-m3-ultra-96gb` (Apple SoC ids include memory because it is the binding constraint)                                                                                                                                                                                                                                                                                                                          |
+| `engine_id`     | `engines/<id>/`                                            | `vllm`, `sglang`, `llamacpp`, `ollama`, `mlx-lm`, `tensorrt-llm`, `tgi`, `lmstudio`, `exllamav3`                                                                                                                                                                                                                                                                                                                                                                                         |
+| `model_id`      | `models/<owner>/<name>/`                                   | **The Hugging Face repo id, verbatim and case-preserved**: `Qwen/Qwen3.8-27B`, `google/gemma-4-E2B-it`, `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16`. Pattern `^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$` (exactly one `/`). A fine-tune or re-upload by somebody else is a different HF repo and therefore a different model. `model.json.hf_id` must equal `id`. Directory path = id (two levels). The validator rejects two model dirs that differ only by case. |
+| `quant_id`      | `models/<model-id>/quants/<quant-id>.json`                 | `bf16`, `fp8`, `nvfp4`, `awq-int4`, `gptq-int4`, `gguf-q4-k-m`, `gguf-q5-k-m`, `gguf-q8-0`, `mlx-4bit`, `mlx-8bit`, `exl3-4.0bpw`. Unique within the model; the quant record's `hf_id` is the full HF repo that holds the weights (official or community, e.g. `lmstudio-community/gemma-4-E2B-it-MLX-4bit`). Full ref = `<model-id>/<quant-id>`.                                                                                                                                        |
+| `workload_id`   | `workloads/<id>.json`                                      | versioned suffix mandatory: `serve-chat-c8-i1k-o256-v1`, `sweep-parallel-1-32-v1`, `eval-math-v1`, `eval-code-v1`, `eval-vision-v1`, `longctx-needle-32k-v1`, `prefill-32k-v1`. Immutable once published.                                                                                                                                                                                                                                                                                |
+| `cell_id`       | computed                                                   | `sha256("model_id                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | quant_id              | hardware_id | hw_count | engine_id | engine_minor")[:12]`where`engine_minor` = first two semver components (`0.27`). One square on the coverage map. |
+| `config_id`     | computed                                                   | canonical non-default engine args (see §3) → `sha256(canonical)[:16]`                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `run_id`        | computed                                                   | `<config_id>--<workload_id>--<sha256(github_login + "                                                                                                                                                                                                                                                                                                                                                                                                                                    | " + started_at)[:6]>` |
+| result filename | `results/<engine>/<owner>/<name>/<hardware>/<run_id>.json` | exactly `run_id + ".json"`; `<owner>/<name>` is the model_id                                                                                                                                                                                                                                                                                                                                                                                                                             |
 
 `hw_count` = number of devices (1 for single GPU / one Mac). Multi-node is out of scope v1.
 
@@ -129,54 +129,100 @@ recomputes it and fails on mismatch.
 ## 4. Data shapes (summaries — schemas are authoritative)
 
 ### hardware/<id>.json
+
 ```jsonc
 {
   "schema_version": 1,
   "id": "nvidia-gb10-dgx-spark",
   "name": "NVIDIA DGX Spark (GB10)",
   "vendor": "nvidia",
-  "kind": "soc",                       // gpu | soc | cpu | accelerator
+  "kind": "soc", // gpu | soc | cpu | accelerator
   "aliases": ["asus-ascent-gx10", "gb10"],
-  "memory_gb": 128, "memory_type": "LPDDR5x", "memory_bandwidth_gbs": 273,
-  "compute": { "arch": "blackwell", "sm": "12.1", "fp16_tflops": 250, "fp8_tflops": 500, "fp4_tflops": 1000 },
-  "tdp_w": 140, "release_year": 2025, "msrp_usd": 3999, "typical_cloud_usd_per_h": null,
-  "form_factor": "desktop", "notes": "...",
-  "detect": {                          // how the harness maps a machine to this id, no guessing
-    "nvidia_smi_name": ["NVIDIA GB10"],
-    "apple_chip": [], "cpu_model": [], "lspci": []
+  "memory_gb": 128,
+  "memory_type": "LPDDR5x",
+  "memory_bandwidth_gbs": 273,
+  "compute": {
+    "arch": "blackwell",
+    "sm": "12.1",
+    "fp16_tflops": 250,
+    "fp8_tflops": 500,
+    "fp4_tflops": 1000,
   },
-  "links": { "vendor": "...", "wiki": "..." }
+  "tdp_w": 140,
+  "release_year": 2025,
+  "msrp_usd": 3999,
+  "typical_cloud_usd_per_h": null,
+  "form_factor": "desktop",
+  "notes": "...",
+  "detect": {
+    // how the harness maps a machine to this id, no guessing
+    "nvidia_smi_name": ["NVIDIA GB10"],
+    "apple_chip": [],
+    "cpu_model": [],
+    "lspci": [],
+  },
+  "links": { "vendor": "...", "wiki": "..." },
 }
 ```
 
 ### engines/<id>/meta.json
+
 ```jsonc
 {
   "schema_version": 1,
-  "id": "vllm", "name": "vLLM", "repo": "https://github.com/vllm-project/vllm", "docs": "...",
-  "api": "openai",                     // openai | ollama | custom — what the harness talks to
+  "id": "vllm",
+  "name": "vLLM",
+  "repo": "https://github.com/vllm-project/vllm",
+  "docs": "...",
+  "api": "openai", // openai | ollama | custom — what the harness talks to
   "default_port": 8000,
-  "platforms": ["linux-cuda", "linux-rocm"],       // + macos-metal, linux-cpu
-  "quant_formats": ["bf16","fp8","nvfp4","awq-int4","gptq-int4","compressed-tensors","bitsandbytes","gguf"],
-  "install": [ { "method": "docker", "image": "vllm/vllm-openai:v{version}", "arch": ["x86_64","aarch64"] },
-               { "method": "pip", "package": "vllm=={version}" } ],
-  "serve": { "command_template": "vllm serve {model_ref} {flags}", "model_ref": "hf_id",
-             "flag_style": "--{name} {value}", "bool_style": "--{name}" },
+  "platforms": ["linux-cuda", "linux-rocm"], // + macos-metal, linux-cpu
+  "quant_formats": [
+    "bf16",
+    "fp8",
+    "nvfp4",
+    "awq-int4",
+    "gptq-int4",
+    "compressed-tensors",
+    "bitsandbytes",
+    "gguf",
+  ],
+  "install": [
+    { "method": "docker", "image": "vllm/vllm-openai:v{version}", "arch": ["x86_64", "aarch64"] },
+    { "method": "pip", "package": "vllm=={version}" },
+  ],
+  "serve": {
+    "command_template": "vllm serve {model_ref} {flags}",
+    "model_ref": "hf_id",
+    "flag_style": "--{name} {value}",
+    "bool_style": "--{name}",
+  },
   "health": { "path": "/health", "models_path": "/v1/models" },
-  "bench_harness": "atlas-bench",      // we always use our harness; engine-native harness optional
-  "drop_params": ["model","host","port","api-key","served-model-name","download-dir","revision","hf-token"],
+  "bench_harness": "atlas-bench", // we always use our harness; engine-native harness optional
+  "drop_params": [
+    "model",
+    "host",
+    "port",
+    "api-key",
+    "served-model-name",
+    "download-dir",
+    "revision",
+    "hf-token",
+  ],
   "param_aliases": { "tp": "tensor-parallel-size", "pp": "pipeline-parallel-size" },
   "version_source": { "kind": "github-releases", "tag_prefix": "v" },
-  "versions_available": ["0.26.1", "0.27.1"]        // must match files in versions/
+  "versions_available": ["0.26.1", "0.27.1"], // must match files in versions/
 }
 ```
 
 ### engines/<id>/versions/<version>.json
+
 Same as DESIGN §6.1 (`params[]` with name, type, default, choices, range, help, aliases,
 group, impact). `overlay.json` = `{ "params": { "<name>": { "group": "...", "impact": "high|medium|low" } } }`
 merged at build time.
 
 ### models/<owner>/<name>/model.json
+
 ```jsonc
 { "schema_version": 1, "id": "Qwen/Qwen3.8-27B", "name": "Qwen3.8-27B", "hf_id": "Qwen/Qwen3.8-27B",
   "family": "qwen3.8", "vendor": "alibaba", "params_b": 27, "active_params_b": 27, "architecture": "Qwen3_5ForConditionalGeneration",
@@ -185,38 +231,96 @@ merged at build time.
 ```
 
 ### models/<owner>/<name>/quants/<quant-id>.json
+
 ```jsonc
-{ "schema_version": 1, "id": "fp8", "model_id": "Qwen/Qwen3.8-27B", "format": "fp8", "bits": 8,
-  "hf_id": "Qwen/Qwen3.8-27B-FP8", "revision": null, "files": [], "size_gb": 28.5,
-  "engines": ["vllm","sglang"], "source": "official", "notes": "" }
+{
+  "schema_version": 1,
+  "id": "fp8",
+  "model_id": "Qwen/Qwen3.8-27B",
+  "format": "fp8",
+  "bits": 8,
+  "hf_id": "Qwen/Qwen3.8-27B-FP8",
+  "revision": null,
+  "files": [],
+  "size_gb": 28.5,
+  "engines": ["vllm", "sglang"],
+  "source": "official",
+  "notes": "",
+}
 ```
+
 GGUF quants: `"files": ["Qwen3.8-27B-Q5_K_M.gguf"]`, `"engines": ["llamacpp","ollama","lmstudio"]`,
 `"ollama_tag": "qwen3.8:27b-q5_K_M"`.
 
 ### workloads/<id>.json
+
 ```jsonc
-{ "schema_version": 1, "id": "serve-chat-c8-i1k-o256-v1", "name": "...", "kind": "serving",
+{
+  "schema_version": 1,
+  "id": "serve-chat-c8-i1k-o256-v1",
+  "name": "...",
+  "kind": "serving",
   // serving | sweep | prefill | longctx | eval
-  "description": "...", "dataset_id": "prompts-mixed-v1",
-  "params": { "concurrency": 8, "num_requests": 200, "input_tokens": 1024, "output_tokens": 256,
-              "seed": 42, "warmup_requests": 10, "temperature": 0, "repeat": 3 },
-  "sweep": null,                                    // sweep kind: { "concurrency": [1,2,4,8,16,32] }
-  "eval": null,                                     // eval kind: { "suite": "math", "scorer": "exact|mc|code-exec|json|judge|contains|needle", "pass_threshold": ... }
-  "metrics_required": ["ttft_ms","tpot_ms","output_tok_s","prefill_tok_s","success_rate"],
-  "immutable": true, "created": "2026-08-23", "supersedes": null }
+  "description": "...",
+  "dataset_id": "prompts-mixed-v1",
+  "params": {
+    "concurrency": 8,
+    "num_requests": 200,
+    "input_tokens": 1024,
+    "output_tokens": 256,
+    "seed": 42,
+    "warmup_requests": 10,
+    "temperature": 0,
+    "repeat": 3,
+  },
+  "sweep": null, // sweep kind: { "concurrency": [1,2,4,8,16,32] }
+  "eval": null, // eval kind: { "suite": "math", "scorer": "exact|mc|code-exec|json|judge|contains|needle", "pass_threshold": ... }
+  "metrics_required": ["ttft_ms", "tpot_ms", "output_tok_s", "prefill_tok_s", "success_rate"],
+  "immutable": true,
+  "created": "2026-08-23",
+  "supersedes": null,
+}
 ```
 
 ### datasets/<id>/dataset.json
+
 ```jsonc
-{ "schema_version": 1, "id": "prompts-mixed-v1", "name": "...", "kind": "prompts",  // prompts | eval | images | haystack
-  "licence": "MIT", "files": ["prompts.jsonl"], "count": 600,
-  "topics": ["code","math","science","history","law","medicine","creative","business","multilingual","everyday"],
-  "length_buckets": { "xs": [16,64], "s": [65,256], "m": [257,1024], "l": [1025,4096], "xl": [4097,16384], "xxl": [16385,65536] },
-  "schema": { "fields": ["id","topic","bucket","approx_tokens","messages"] } }
+{
+  "schema_version": 1,
+  "id": "prompts-mixed-v1",
+  "name": "...",
+  "kind": "prompts", // prompts | eval | images | haystack
+  "licence": "MIT",
+  "files": ["prompts.jsonl"],
+  "count": 600,
+  "topics": [
+    "code",
+    "math",
+    "science",
+    "history",
+    "law",
+    "medicine",
+    "creative",
+    "business",
+    "multilingual",
+    "everyday",
+  ],
+  "length_buckets": {
+    "xs": [16, 64],
+    "s": [65, 256],
+    "m": [257, 1024],
+    "l": [1025, 4096],
+    "xl": [4097, 16384],
+    "xxl": [16385, 65536],
+  },
+  "schema": { "fields": ["id", "topic", "bucket", "approx_tokens", "messages"] },
+}
 ```
+
 Eval rows: `{ "id", "category", "difficulty", "prompt"|"messages", "answer", "scorer", "choices"?, "tests"?, "image"? }`.
 
 ### results/…/<run_id>.json (one run = one config × one workload)
+
 ```jsonc
 {
   "schema_version": 1,
@@ -277,9 +381,10 @@ aggregates). Per-item eval results keep at most `predicted` truncated to 500 cha
 ## 5. Ownership & provenance enforcement (validate.yml + `tools/validate`)
 
 On every PR:
+
 1. Schema-validate every changed JSON file (ajv 2020-12).
 2. Recompute `config_id`, `cell_id`, `run_id`, `args_canonical`; filename must equal `run_id.json`; path must match `results/<engine>/<owner>/<name>/<hardware>/` where `<owner>/<name>` is the model_id verbatim.
-3. **Ownership:** for each changed file under `results/`: `provenance.github_login` must equal the PR author login (`github.event.pull_request.user.login`), both for added and modified files, and for a modified file the *previous* version's login must also equal the author. Deleting another person's file is rejected. (Maintainers can bypass with label `maintainer-override`.)
+3. **Ownership:** for each changed file under `results/`: `provenance.github_login` must equal the PR author login (`github.event.pull_request.user.login`), both for added and modified files, and for a modified file the _previous_ version's login must also equal the author. Deleting another person's file is rejected. (Maintainers can bypass with label `maintainer-override`.)
 4. Referential integrity: engine/model/quant/hardware/workload ids must exist; `quant.engines` must include the engine; engine version file exists (warning otherwise).
 5. Plausibility: `output_tok_s_per_request <= memory_bandwidth_gbs / weight_gb * 1.5` (MoE uses active weights), `vram_peak_gb <= memory_gb`, non-negative latencies, `success_rate ∈ [0,1]`, `requests_ok + requests_failed == requests_total`.
 6. Duplicate `run_id` → fail. Same `cell_id+config_id+workload_id` with metric deviation > 25 % from the median of existing → warning + `needs-review` label comment.
@@ -303,13 +408,14 @@ engines/<id>/<version>.json     param schemas with overlay merged
 runs/<engine>/<owner>/<name>/<hardware>/<run_id>.json   full result files (copied, with stamped provenance)
 gaps.json            ranked list of untested/wanted cells (registry × workload cross product scored by site.config wanted weights + requests)
 ```
+
 The app fetches `manifest.json` first, then `registry.json` + `index.json` + `coverage.json`;
 full runs are fetched lazily per run. Base path = Vite `base` from env `VITE_BASE` (default `/`).
 
 ## 7. The "Add measurement" packet (app + `tools/packet`)
 
 Every gap (cell × workload, or "new hardware"/"new model"/"new engine") has an **Add** button →
-modal with tabs: *Agent prompt (Markdown)*, *Packet (JSON)*, *Shell*, *Issue*. The Markdown
+modal with tabs: _Agent prompt (Markdown)_, _Packet (JSON)_, _Shell_, _Issue_. The Markdown
 prompt is self-contained and instructs the agent to:
 
 1. Clone `https://github.com/<owner>/<repo>` (from `site/config.json.repo`), `cd`, read `AGENTS.md`.
@@ -373,7 +479,7 @@ or where reality disagreed with it. Each one is binding until superseded here.
 
 2. **`additionalProperties: false` everywhere except `dataset.schema.json`.** Typos should
    fail, so every top-level record and every `metrics` / `provenance` / `verification` block
-   is closed. Dataset records are the exception: each dataset *kind* carries its own metadata
+   is closed. Dataset records are the exception: each dataset _kind_ carries its own metadata
    (haystack depths and target token counts, prefix-group structure, per-topic counts,
    generator seeds) and enumerating them would mean a schema change per dataset. The dataset
    contract is its required fields; the rest is documentation. `dataset.notes` additionally
@@ -382,7 +488,7 @@ or where reality disagreed with it. Each one is binding until superseded here.
 3. **Fingerprint steps 2 and 3 are fused.** §3 lists "drop defaults" before "normalize
    values". Comparing raw values would make `"0.90"` differ from a default of `0.9` and
    `"True"` differ from a default of `true`. So the value and the default are both normalized
-   with the same rules and the resulting *strings* are compared. This can only merge
+   with the same rules and the resulting _strings_ are compared. This can only merge
    configurations that really are identical.
 
 4. **Value normalization is typed by the version file.** `"1"` folds to `true` only when the
@@ -396,7 +502,7 @@ or where reality disagreed with it. Each one is binding until superseded here.
    `mem-fraction-static`, `block-size`) carry `default: null` in the version files. A null
    default never matches, so an explicitly passed value always survives into the fingerprint.
    That can split two configurations that were in fact identical; it can never merge two that
-   were not, which is the safe direction. A `null` *value* in `args`, by contrast, means the
+   were not, which is the safe direction. A `null` _value_ in `args`, by contrast, means the
    flag was not passed and is dropped.
 
 6. **`resolved` includes the pseudo-params.** `canonicalizeArgs` returns exactly the pairs
@@ -420,7 +526,7 @@ or where reality disagreed with it. Each one is binding until superseded here.
    one pass over the weights. The bound is therefore multiplied by the tokens per forward
    pass — the measured `metrics.accepted_tokens_per_step` if present, otherwise the
    configured draft length + 1, otherwise a generous 4 when a speculative method is
-   configured without a count. The separate low-efficiency *warning* is measured against the
+   configured without a count. The separate low-efficiency _warning_ is measured against the
    plain bound, because speculative decoding changes what is possible, not what "leaving
    bandwidth on the table" means.
 
@@ -434,7 +540,7 @@ or where reality disagreed with it. Each one is binding until superseded here.
 11. **Coverage level precedence: disputed > stale > reproduced > single.** A wrong number is
     worse than an old one, and a cell reproduced on an engine three minors ago tells you
     nothing about today. Disputes are only computed within one `config_id` + `workload_id`
-    group and only across two or more distinct logins — different flags are *supposed* to give
+    group and only across two or more distinct logins — different flags are _supposed_ to give
     different numbers, and one person running something twice is not a dispute. Thresholds
     come from `site.coverage` (`stale_minors_behind` 2, `disputed_deviation_pct` 25,
     `reproduced_min_logins` 2). `computeCoverage` returns only cells that have runs; a cell id
@@ -473,7 +579,7 @@ or where reality disagreed with it. Each one is binding until superseded here.
 16. **Golden vector file shape.** `schemas/fixtures/fingerprint-vectors.json` and
     `id-vectors.json` are objects, not bare arrays: `{ "$comment", "spec", "vectors": [...] }`
     for fingerprints and `{ "$comment", "spec", "cell_id": [...], "run_id": [...],
-    "engine_minor": [...], "result_path": [...] }` for ids. Each fingerprint vector is
+"engine_minor": [...], "result_path": [...] }` for ids. Each fingerprint vector is
     `{ name, description?, equivalence_group?, input, expected }`, where `input` is exactly
     the argument object `canonicalizeArgs` takes (snake_case, so TypeScript and Python can eat
     the fixture unchanged) and vectors sharing an `equivalence_group` must produce the same

--- a/docs/reference-measurements.md
+++ b/docs/reference-measurements.md
@@ -8,6 +8,7 @@ reproduction targets. Model names below predate the "model_id = Hugging Face rep
 ## Machines
 
 ### NVIDIA DGX Spark / ASUS Ascent GX10 — `nvidia-gb10-dgx-spark`
+
 - GB10 Grace Blackwell superchip, 128 GB LPDDR5x unified (≈121 GiB visible to the OS), ~273 GB/s
   memory bandwidth, sm_121 (runs sm_120 cubins), CUDA 13 host, Ubuntu 24.04 aarch64, 20-core
   Grace CPU (10× X925 + 10× A725). Docker with CDI GPU access.
@@ -17,15 +18,18 @@ reproduction targets. Model names below predate the "model_id = Hugging Face rep
   (4.5 measured = 92 %).
 
 ### Mac Studio (2023) — `apple-m2-max-32gb`
+
 - Apple M2 Max, 32 GB unified, 400 GB/s, macOS 26, LM Studio on :1234 (MLX + llama.cpp backends).
   No Atlas-grade measurements recorded yet → seed it as a registered hardware with gaps only.
 
 ## Measurements (DGX Spark)
 
 ### vLLM 0.27.1 · Qwen3.8-27B · FP8 (`Qwen/Qwen3.8-27B-FP8`) · 2026-08-16
+
 Args: `--max-model-len 262144 --gpu-memory-utilization 0.44 --enable-prefix-caching
 --speculative-config '{"method":"mtp","num_speculative_tokens":3}' --reasoning-parser qwen3
 --tool-call-parser qwen3_xml` (plus served-model-name etc. which are dropped).
+
 - single-stream decode: **18.9 tok/s on code, 14.1 tok/s on prose** (with MTP-3);
   **7.88 tok/s without MTP** (both code and prose).
 - MTP acceptance per draft position 82 % / 66 % / 48 %, mean 2.96 tokens per forward pass.
@@ -39,41 +43,49 @@ Args: `--max-model-len 262144 --gpu-memory-utilization 0.44 --enable-prefix-cach
 - Note: embed engine (Qwen3-Embedding-8B, ~10 GiB) resident alongside during measurement.
 
 ### vLLM 0.27.1 · Qwen3.8-27B · BF16 (`Qwen/Qwen3.8-27B`) · 2026-08-14
+
 - BF16 weights 51.9 GiB; 76.3 GiB footprint at 256K. Decode ≈ 4.5 tok/s (bandwidth bound).
 
 ### vLLM 0.27.1 · Nemotron-3.5-Lightning-30B-A3B · NVFP4 · 2026-08-14/16
+
 Args: `--max-model-len 1048576 --gpu-memory-utilization 0.22` + MTP (DSpark) spec decode.
+
 - decode **115 tok/s** single stream (with spec decode). KV pool 1,481,935 tokens at 1M ctx.
 - 318,924 KV tokens per GiB (whole 1M window = 3.3 GiB).
 
 ### vLLM 0.27.1 and 0.26.1 · Nemotron-3.5-Lightning-30B-A3B · BF16 · 2026-08-11
+
 - `--max-model-len 262144`, no spec decode: **~29 tok/s** short-context decode on both versions
   (first request after boot ~9 tok/s = warmup). KV pool 1.19–1.22 M tokens. Mamba SSM cache fp32.
 
 ### llama.cpp (build 2026-08-07+) · Ling-3.0-flash · GGUF Q5_K_M · 2026-08-10
+
 `~/ling/serve-ling-256k.sh`, context 262144 (GGUF metadata patched from 131072).
 Decode tok/s (256-token generations) vs real prompt tokens:
-| prompt tokens | tok/s |
-|---|---|
-| 8 | 34.6 |
-| 26,475 | 34.6 |
-| 52,921 | 33.2 |
-| 117,565 | 29.4 |
-| 146,950 | 29.4 |
-| 237,095 | 25.5 (needle at 90 % depth returned correct) |
+
+| prompt tokens | tok/s                                        |
+| ------------- | -------------------------------------------- |
+| 8             | 34.6                                         |
+| 26,475        | 34.6                                         |
+| 52,921        | 33.2                                         |
+| 117,565       | 29.4                                         |
+| 146,950       | 29.4                                         |
+| 237,095       | 25.5 (needle at 90 % depth returned correct) |
+
 - Cold prefill at 237K = 493 s (481 tok/s); shallower prefill 1,000–2,800 tok/s.
 - ~90 GB resident.
 
 ### vLLM fork (`vllm-ling-v3`) · Ling-3.0-flash · int4 · 2026-08-10 · `--max-model-len 262144`
+
 | prompt tokens | tok/s |
-|---|---|
-| 8 | 18.6 |
-| 26,475 | 6.4 |
-| 52,921 | 3.7 |
-| 117,565 | 1.8 |
-| 146,950 | 1.5 |
-- Gotcha: the depth penalty comes from *declaring* 256K max-model-len; at a 16K config the same
+| ------------- | ----- |
+| 8             | 18.6  |
+| 26,475        | 6.4   |
+| 52,921        | 3.7   |
+| 117,565       | 1.8   |
+| 146,950       | 1.5   |
+
+- Gotcha: the depth penalty comes from _declaring_ 256K max-model-len; at a 16K config the same
   quant does 38.7 tok/s short. Extending cudagraph capture sizes changed nothing.
 - Gotcha: Triton JIT needs Python.h — use a uv-managed CPython when there is no sudo.
 - Gotcha: `VLLM_USE_PRECOMPILED=1` works on aarch64/GB10.
-

--- a/packages/core/src/plausibility.test.ts
+++ b/packages/core/src/plausibility.test.ts
@@ -96,9 +96,9 @@ describe('speculative decoding raises the bound', () => {
   });
 
   it('prefers a measured acceptance rate over the configured draft length', () => {
-    expect(tokensPerForwardPass({ 'dspark-tokens': 5 }, { accepted_tokens_per_step: 2.4 } as never)).toBe(
-      2.4,
-    );
+    expect(
+      tokensPerForwardPass({ 'dspark-tokens': 5 }, { accepted_tokens_per_step: 2.4 } as never),
+    ).toBe(2.4);
   });
 });
 

--- a/workloads/README.md
+++ b/workloads/README.md
@@ -7,7 +7,7 @@ shape summarised in SPEC §4.
 A result is only comparable to another result when both name the same
 `workload_id`. That is the whole reason this directory exists: the model, the
 quantization, the engine and the flags are recorded in the result, and the
-*question that was asked of them* is recorded here.
+_question that was asked of them_ is recorded here.
 
 ## Immutability
 
@@ -37,13 +37,13 @@ tokens).
 
 ## Kinds
 
-| kind | what it measures | runner | required shape |
-|---|---|---|---|
-| `serving` | steady-state throughput and latency at a fixed concurrency | `serving` | `sweep` and `eval` are null |
-| `sweep` | one axis walked, a metric block per point | `sweep` | `sweep` has exactly one axis |
-| `prefill` | time to first token on a long input, almost no decode | `prefill` | tiny `output_tokens` |
-| `longctx` | behaviour as the prompt grows, with a retrieval check | `longctx` | may carry a `sweep` and/or an `eval` block |
-| `eval` | capability, scored per item | `eval` | `eval` and `dataset_id` required |
+| kind      | what it measures                                           | runner    | required shape                             |
+| --------- | ---------------------------------------------------------- | --------- | ------------------------------------------ |
+| `serving` | steady-state throughput and latency at a fixed concurrency | `serving` | `sweep` and `eval` are null                |
+| `sweep`   | one axis walked, a metric block per point                  | `sweep`   | `sweep` has exactly one axis               |
+| `prefill` | time to first token on a long input, almost no decode      | `prefill` | tiny `output_tokens`                       |
+| `longctx` | behaviour as the prompt grows, with a retrieval check      | `longctx` | may carry a `sweep` and/or an `eval` block |
+| `eval`    | capability, scored per item                                | `eval`    | `eval` and `dataset_id` required           |
 
 `metrics_required` lists the metric paths a result must carry non-null. Dotted
 paths address into a distribution (`ttft_ms.p50`). For `kind: eval` the three
@@ -54,35 +54,35 @@ were right.
 
 ## All workloads
 
-| id | kind | dataset | shape |
-|---|---|---|---|
-| `serve-single-i256-o256-v1` | serving | `prompts-mixed-v1` | c1, n=50, in≈256, out=256 |
-| `serve-short-c16-i128-o128-v1` | serving | `prompts-mixed-v1` | c16, n=320, in≈128, out=128 |
-| `serve-chat-c8-i1k-o256-v1` | serving | `prompts-mixed-v1` | c8, n=200, in≈1k, out=256 |
-| `serve-chat-c32-i1k-o256-v1` | serving | `prompts-mixed-v1` | c32, n=400, in≈1k, out=256 |
-| `serve-chat-c64-i1k-o256-v1` | serving | `prompts-mixed-v1` | c64, n=640, in≈1k, out=256 |
-| `serve-long-c4-i8k-o512-v1` | serving | `prompts-mixed-v1` | c4, n=40, in≈8k, out=512 |
-| `serve-code-c8-i2k-o1k-v1` | serving | `prompts-code-v1` | c8, n=160, in≈2k, out=1k |
-| `serve-prefix-c16-v1` | serving | `prompts-shared-prefix-v1` | c16, n=200, grouped by prefix |
-| `sweep-parallel-1-32-i512-o256-v1` | sweep | `prompts-mixed-v1` | concurrency 1,2,4,8,16,32 |
-| `sweep-parallel-1-64-i1k-o256-v1` | sweep | `prompts-mixed-v1` | concurrency 1,2,4,8,16,32,64 |
-| `prefill-8k-v1` | prefill | `haystack-v1` | c1, n=10, in=8k, out=16 |
-| `prefill-32k-v1` | prefill | `haystack-v1` | c1, n=10, in=32k, out=16 |
-| `prefill-128k-v1` | prefill | `haystack-v1` | c1, n=10, in=128k, out=16 |
-| `longctx-depth-sweep-v1` | longctx | `haystack-v1` | input_tokens 1k…256k, out=256, needle checked |
-| `longctx-needle-32k-v1` | longctx | `eval-longctx-v1` | c1, n=6, in=32k, needle scored |
-| `longctx-needle-128k-v1` | longctx | `eval-longctx-v1` | c1, n=6, in=128k, needle scored |
-| `eval-math-v1` | eval | `eval-math-v1` | `numeric`, max_out 4096 |
-| `eval-reasoning-v1` | eval | `eval-reasoning-v1` | `exact` (rows may be `mc`), max_out 2048 |
-| `eval-code-v1` | eval | `eval-code-v1` | `code-exec`, max_out 4096 |
-| `eval-knowledge-v1` | eval | `eval-knowledge-v1` | `mc`, max_out 2048 |
-| `eval-instruction-v1` | eval | `eval-instruction-v1` | `instruction`, max_out 2048 |
-| `eval-json-v1` | eval | `eval-json-v1` | `json`, max_out 2048 |
-| `eval-tools-v1` | eval | `eval-tools-v1` | `json` on `tool_calls[0]`, max_out 2048 |
-| `eval-vision-v1` | eval | `eval-vision-v1` | `vision`, max_out 2048 |
-| `eval-multilingual-v1` | eval | `eval-multilingual-v1` | `contains`, max_out 2048 |
-| `eval-longctx-v1` | eval | `eval-longctx-v1` | `needle`, max_out 1024, c1 |
-| `eval-format-v1` | eval | `eval-format-v1` | `exact`, max_out 256 |
+| id                                 | kind    | dataset                    | shape                                         |
+| ---------------------------------- | ------- | -------------------------- | --------------------------------------------- |
+| `serve-single-i256-o256-v1`        | serving | `prompts-mixed-v1`         | c1, n=50, in≈256, out=256                     |
+| `serve-short-c16-i128-o128-v1`     | serving | `prompts-mixed-v1`         | c16, n=320, in≈128, out=128                   |
+| `serve-chat-c8-i1k-o256-v1`        | serving | `prompts-mixed-v1`         | c8, n=200, in≈1k, out=256                     |
+| `serve-chat-c32-i1k-o256-v1`       | serving | `prompts-mixed-v1`         | c32, n=400, in≈1k, out=256                    |
+| `serve-chat-c64-i1k-o256-v1`       | serving | `prompts-mixed-v1`         | c64, n=640, in≈1k, out=256                    |
+| `serve-long-c4-i8k-o512-v1`        | serving | `prompts-mixed-v1`         | c4, n=40, in≈8k, out=512                      |
+| `serve-code-c8-i2k-o1k-v1`         | serving | `prompts-code-v1`          | c8, n=160, in≈2k, out=1k                      |
+| `serve-prefix-c16-v1`              | serving | `prompts-shared-prefix-v1` | c16, n=200, grouped by prefix                 |
+| `sweep-parallel-1-32-i512-o256-v1` | sweep   | `prompts-mixed-v1`         | concurrency 1,2,4,8,16,32                     |
+| `sweep-parallel-1-64-i1k-o256-v1`  | sweep   | `prompts-mixed-v1`         | concurrency 1,2,4,8,16,32,64                  |
+| `prefill-8k-v1`                    | prefill | `haystack-v1`              | c1, n=10, in=8k, out=16                       |
+| `prefill-32k-v1`                   | prefill | `haystack-v1`              | c1, n=10, in=32k, out=16                      |
+| `prefill-128k-v1`                  | prefill | `haystack-v1`              | c1, n=10, in=128k, out=16                     |
+| `longctx-depth-sweep-v1`           | longctx | `haystack-v1`              | input_tokens 1k…256k, out=256, needle checked |
+| `longctx-needle-32k-v1`            | longctx | `eval-longctx-v1`          | c1, n=6, in=32k, needle scored                |
+| `longctx-needle-128k-v1`           | longctx | `eval-longctx-v1`          | c1, n=6, in=128k, needle scored               |
+| `eval-math-v1`                     | eval    | `eval-math-v1`             | `numeric`, max_out 4096                       |
+| `eval-reasoning-v1`                | eval    | `eval-reasoning-v1`        | `exact` (rows may be `mc`), max_out 2048      |
+| `eval-code-v1`                     | eval    | `eval-code-v1`             | `code-exec`, max_out 4096                     |
+| `eval-knowledge-v1`                | eval    | `eval-knowledge-v1`        | `mc`, max_out 2048                            |
+| `eval-instruction-v1`              | eval    | `eval-instruction-v1`      | `instruction`, max_out 2048                   |
+| `eval-json-v1`                     | eval    | `eval-json-v1`             | `json`, max_out 2048                          |
+| `eval-tools-v1`                    | eval    | `eval-tools-v1`            | `json` on `tool_calls[0]`, max_out 2048       |
+| `eval-vision-v1`                   | eval    | `eval-vision-v1`           | `vision`, max_out 2048                        |
+| `eval-multilingual-v1`             | eval    | `eval-multilingual-v1`     | `contains`, max_out 2048                      |
+| `eval-longctx-v1`                  | eval    | `eval-longctx-v1`          | `needle`, max_out 1024, c1                    |
+| `eval-format-v1`                   | eval    | `eval-format-v1`           | `exact`, max_out 256                          |
 
 ## Conventions a runner must honour
 


### PR DESCRIPTION
`prettier --check` has been failing on **348 files**, which means nobody could use it as a gate and CI never ran it.

**328 of those are JSON data** — under `results/`, `models/`, `engines/`, `hardware/`, `datasets/`, `schemas/`, `workloads/` and `site/`.

Prettier should not own those files:

- They are written by `atlas-bench` and `tools/ingest`, and their shape is defined by the schemas.
- Reformatting them churns files whose owner is a **contributor**, not this repository. CI's own ownership check would reject exactly that on a pull request.
- The next harness run would undo it regardless.

So they are now ignored — **by extension rather than by directory**, so the READMEs living in those directories are still formatted as prose.

That leaves **20 real files**: 12 TypeScript, 7 Markdown, and `index.html`. Those are formatted here. `prettier --check` is now clean and can be trusted as a gate — worth wiring into CI in a follow-up, which was not possible before this.

Whitespace only, no behaviour change. `pnpm test` (347 passed / 1 skipped), `typecheck`, `validate` (0 errors) and `eslint` all pass unchanged.