### PR TITLE
fix: CI could not report a failing validation, and multi-device derived metrics were 2x

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -61,13 +61,17 @@ jobs:
           # own ELIFECYCLE block to the same stdout, which left the file as JSON plus trailing
           # text and made the read below throw a SyntaxError. The findings were then never
           # posted -- exactly on the pull requests that needed them most.
+          #
+          # The path is absolute because `pnpm --filter <pkg> exec` runs with the cwd set to
+          # that package, so a relative --json-out would land in tools/ while every reader
+          # below looks in the workspace root.
           set +e
           pnpm --filter @atlas/tools exec tsx src/validate.ts \
             --changed ${{ steps.changed.outputs.files }} \
             --pr-author '${{ github.event.pull_request.user.login }}' \
             --base '${{ steps.changed.outputs.base }}' \
             ${{ contains(github.event.pull_request.labels.*.name, 'maintainer-override') && '--allow-override' || '' }} \
-            --json-out validate.json
+            --json-out "$GITHUB_WORKSPACE/validate.json"
           echo "exit=$?" >> "$GITHUB_OUTPUT"
           set -e
           node -e "const r=require('./validate.json');console.log(r.markdown)"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -57,13 +57,17 @@ jobs:
       - name: Validate
         id: validate
         run: |
+          # --json-out, not `--json > validate.json`: on a failing validation pnpm appends its
+          # own ELIFECYCLE block to the same stdout, which left the file as JSON plus trailing
+          # text and made the read below throw a SyntaxError. The findings were then never
+          # posted -- exactly on the pull requests that needed them most.
           set +e
           pnpm --filter @atlas/tools exec tsx src/validate.ts \
             --changed ${{ steps.changed.outputs.files }} \
             --pr-author '${{ github.event.pull_request.user.login }}' \
             --base '${{ steps.changed.outputs.base }}' \
             ${{ contains(github.event.pull_request.labels.*.name, 'maintainer-override') && '--allow-override' || '' }} \
-            --json > validate.json
+            --json-out validate.json
           echo "exit=$?" >> "$GITHUB_OUTPUT"
           set -e
           node -e "const r=require('./validate.json');console.log(r.markdown)"

--- a/bench/atlas_bench/result.py
+++ b/bench/atlas_bench/result.py
@@ -142,6 +142,7 @@ def derived_metrics(
     hardware: dict[str, Any] | None,
     model: dict[str, Any] | None = None,
     quant: dict[str, Any] | None = None,
+    hw_count: int = 1,
 ) -> dict[str, Any]:
     """Compute ``result.derived`` (SPEC §4).
 
@@ -152,6 +153,14 @@ def derived_metrics(
       hardware's peak bandwidth; 1.0 means the run saturated memory
     * ``memory_headroom_gb`` — registered memory minus measured peak VRAM
     * ``cost_per_1m_output_tokens_usd`` — only when the hardware has a cloud price
+
+    ``hw_count`` scales the *registered* figures, because bandwidth and memory are per
+    device and a tensor-parallel run has all of them. Without it a two-device result reports
+    twice the bandwidth efficiency it achieved, which is how the repository's first
+    multi-device contribution came out. ``packages/core/src/plausibility.ts`` already scales
+    the same way (``bandwidthCeiling``, the VRAM limit and the TDP check all take
+    ``hwCount``); this is the Python side catching up. Measured figures — power, VRAM — are
+    never scaled: they are what the meter said.
     """
     out: dict[str, Any] = {
         "cost_per_1m_output_tokens_usd": None,
@@ -166,7 +175,9 @@ def derived_metrics(
     power = metrics.get("power_avg_w")
     if output_tok_s and power:
         out["tokens_per_watt"] = round(output_tok_s / power, 4)
-    bandwidth = (hardware or {}).get("memory_bandwidth_gbs")
+    devices = max(1, int(hw_count or 1))
+    per_device_bandwidth = (hardware or {}).get("memory_bandwidth_gbs")
+    bandwidth = per_device_bandwidth * devices if per_device_bandwidth else None
     decode = (metrics.get("decode_tok_s_per_request") or {}).get("mean")
     reference = decode if decode else output_tok_s
     if bandwidth and reference:
@@ -177,7 +188,7 @@ def derived_metrics(
     memory_gb = (hardware or {}).get("memory_gb")
     vram_peak = metrics.get("vram_peak_gb")
     if memory_gb and vram_peak:
-        out["memory_headroom_gb"] = round(float(memory_gb) - float(vram_peak), 3)
+        out["memory_headroom_gb"] = round(float(memory_gb) * devices - float(vram_peak), 3)
     price = (hardware or {}).get("typical_cloud_usd_per_h")
     if price and output_tok_s:
         tokens_per_hour = output_tok_s * 3600
@@ -347,7 +358,9 @@ def build_result(inputs: ResultInputs) -> dict[str, Any]:
         record["scores"] = outcome.scores
     record["failures"] = outcome.failures
     record["gotchas"] = auto_gotchas(inputs, metrics)
-    record["derived"] = derived_metrics(metrics, hardware_record, model_record, quant)
+    record["derived"] = derived_metrics(
+        metrics, hardware_record, model_record, quant, spec.hardware.count
+    )
     record["raw"] = {
         "harness": HARNESS_NAME,
         "harness_version": __version__,

--- a/bench/tests/test_result.py
+++ b/bench/tests/test_result.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from atlas_bench.registry import Registry
 from atlas_bench.result import (
     PAYLOAD_LIMIT_BYTES,
@@ -171,3 +173,37 @@ def test_resolve_login_prefers_the_explicit_value(monkeypatch) -> None:
     monkeypatch.setenv("ATLAS_GITHUB_LOGIN", "from-env")
     assert resolve_login("explicit") == "explicit"
     assert resolve_login(None) == "from-env"
+
+
+def test_derived_metrics_scales_registered_figures_by_hardware_count() -> None:
+    """Bandwidth and memory are per device; a tensor-parallel run has all of them.
+
+    Without this the repository's first multi-device result reported twice the bandwidth
+    efficiency it actually achieved. packages/core/src/plausibility.ts already scales the
+    same way, so the two implementations agreeing is the point.
+    """
+    metrics = {
+        "output_tok_s": 50.0,
+        "decode_tok_s_per_request": {"mean": 50.0},
+        "vram_peak_gb": 100.0,
+    }
+    hardware = {"memory_bandwidth_gbs": 273.0, "memory_gb": 128.0}
+    model = {"moe": False}
+    quant = {"size_gb": 10.0}
+
+    one = derived_metrics(metrics, hardware, model, quant, hw_count=1)
+    two = derived_metrics(metrics, hardware, model, quant, hw_count=2)
+
+    # Twice the aggregate bandwidth for the same achieved throughput is half the efficiency.
+    assert two["bandwidth_efficiency"] == pytest.approx(one["bandwidth_efficiency"] / 2)
+    assert two["tok_s_per_gb_bandwidth"] == pytest.approx(one["tok_s_per_gb_bandwidth"] / 2)
+    # Two devices' worth of registered memory, against one measured peak.
+    assert one["memory_headroom_gb"] == pytest.approx(28.0)
+    assert two["memory_headroom_gb"] == pytest.approx(156.0)
+    # Measured figures are never scaled: power is what the meter said.
+    assert two["tokens_per_watt"] == one["tokens_per_watt"]
+    # The default stays single-device.
+    assert (
+        derived_metrics(metrics, hardware, model, quant)["bandwidth_efficiency"]
+        == (one["bandwidth_efficiency"])
+    )

--- a/tools/src/validate.ts
+++ b/tools/src/validate.ts
@@ -5,6 +5,7 @@
  *   pnpm validate                                   # everything, locally
  *   pnpm validate --changed a.json b.json           # report only these files
  *   pnpm validate --pr-author octocat --base origin/main --json
+ *   pnpm validate --json-out report.json              # report to a file, not stdout
  *
  * What it does, in order: schema-check every JSON file against the schema its *path*
  * implies, recompute every derived id, check referential integrity and physics, look for
@@ -18,7 +19,7 @@
  *
  * Exit code 1 on any error, or on any warning with `--strict`.
  */
-import { realpathSync } from 'node:fs';
+import { realpathSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
 import type { SiteConfig } from '@atlas/core';
@@ -253,11 +254,12 @@ function crossCheck(repo: ReturnType<typeof loadRepo>, reporter: Reporter): void
 
 /* ----------------------------------------------------------------------- CLI */
 
-function main(argv: string[]): number {
+export function main(argv: string[]): number {
   const args = parseArgv(argv, {
     variadic: ['changed'],
     boolean: ['json', 'strict', 'allow-override', 'markdown', 'no-color'],
   });
+  const jsonOut = args.str('json-out');
 
   const root = resolve(args.str('root', REPO_ROOT));
   const outcome = validateRepo({
@@ -269,22 +271,34 @@ function main(argv: string[]): number {
     strict: args.bool('strict'),
   });
 
+  const report = () =>
+    `${JSON.stringify(
+      {
+        ok: outcome.ok,
+        counts: outcome.counts,
+        errors: outcome.issues.filter((i) => i.level === 'error'),
+        warnings: outcome.issues.filter((i) => i.level === 'warn'),
+        codes: outcome.codes,
+        code_counts: codeCounts(outcome.issues),
+        markdown: renderMarkdown(outcome.issues, { counts: outcome.counts }),
+      },
+      null,
+      2,
+    )}\n`;
+
+  // --json-out exists because --json does not survive a wrapper. Run through
+  // `pnpm exec ... --json > report.json` and a FAILING validation makes pnpm append its own
+  // ELIFECYCLE block to the same stdout, so the file becomes JSON followed by trailing text
+  // and whoever reads it back gets a parse error instead of the findings. That is not
+  // hypothetical: it is why the first external contribution got a SyntaxError from CI
+  // instead of the one sentence telling them which field was wrong. Writing the report here
+  // is immune to anything else sharing the stream.
+  if (jsonOut) {
+    writeFileSync(resolve(jsonOut), report(), 'utf8');
+  }
+
   if (args.bool('json')) {
-    process.stdout.write(
-      `${JSON.stringify(
-        {
-          ok: outcome.ok,
-          counts: outcome.counts,
-          errors: outcome.issues.filter((i) => i.level === 'error'),
-          warnings: outcome.issues.filter((i) => i.level === 'warn'),
-          codes: outcome.codes,
-          code_counts: codeCounts(outcome.issues),
-          markdown: renderMarkdown(outcome.issues, { counts: outcome.counts }),
-        },
-        null,
-        2,
-      )}\n`,
-    );
+    process.stdout.write(report());
   } else if (args.bool('markdown')) {
     process.stdout.write(`${renderMarkdown(outcome.issues, { counts: outcome.counts })}\n`);
   } else {

--- a/tools/test/validate.test.ts
+++ b/tools/test/validate.test.ts
@@ -6,9 +6,11 @@
  * to know the check is looking at what it claims to be looking at — a test that asserts
  * "some error happened" passes when the file fails to parse for an unrelated reason.
  */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { ResultRecord } from '@atlas/core';
-import { validateRepo } from '../src/validate.js';
+import { main, validateRepo } from '../src/validate.js';
 import {
   CASE_SENSITIVE_FS,
   SOURCE_ROOT,
@@ -351,5 +353,55 @@ describe('reporting', () => {
     repo.writeResult(result);
     expect(validateRepo({ root: repo.root }).ok).toBe(true);
     expect(validateRepo({ root: repo.root, strict: true }).ok).toBe(false);
+  });
+});
+
+describe('--json-out', () => {
+  /**
+   * The report has to reach the file even when the run fails, because a failing run is the
+   * only time anybody reads it. Piping `--json` into a file does not survive that: pnpm
+   * appends its own failure block to the same stdout, the file becomes JSON followed by
+   * trailing text, and CI threw a SyntaxError instead of posting the findings — on the first
+   * external contribution, which is exactly the case the comment step exists for.
+   */
+  it('writes a parseable report on a FAILING validation, independently of stdout', () => {
+    repo.writeResult(makeResult(repo, { login: 'alice' }));
+    repo.initGit();
+    repo.git('checkout', '-q', '-b', 'contribution');
+    repo.writeResult(makeResult(repo, { login: 'carol', startedAt: '2026-08-03T09:00:00Z' }));
+    repo.commit('results: a run attributed to carol');
+
+    const out = join(repo.root, 'report.json');
+    const written: string[] = [];
+    const realWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string) => {
+      written.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+
+    let status: number;
+    try {
+      status = main([
+        '--root',
+        repo.root,
+        '--pr-author',
+        'bob',
+        '--base',
+        'main',
+        '--json-out',
+        out,
+      ]);
+    } finally {
+      process.stdout.write = realWrite;
+    }
+
+    expect(status).toBe(1);
+    // Nothing the process printed can reach the file, which is the whole point.
+    const report = JSON.parse(readFileSync(out, 'utf8')) as {
+      ok: boolean;
+      errors: Array<{ code: string }>;
+    };
+    expect(report.ok).toBe(false);
+    expect(report.errors.map((e) => e.code)).toContain('ownership-added');
   });
 });


### PR DESCRIPTION
Two bugs found while reviewing the repository's first external contribution (#53). Between them, that contributor got a stack trace instead of feedback, and would have had two inflated numbers published under their name.

## CI could not report a failing validation

The validate step ran:

```
pnpm --filter @atlas/tools exec tsx src/validate.ts … --json > validate.json
```

On a **failing** validation, pnpm appends its own `ELIFECYCLE` block to the same stdout. `validate.json` became JSON followed by trailing text, and the next step — which reads it back to build the PR comment — died:

```
SyntaxError: validate.json: Unexpected non-whitespace character after JSON at position 2562
```

So the findings were never posted **on exactly the pull requests that needed them**. The workflow's own comment says it posts results back *"because a contributor whose first contribution fails a check they cannot see will not send a second one"* — which is precisely what happened to the first one.

`validate.ts` gains `--json-out`, which writes the report itself and is immune to anything else sharing the stream. Verified against the real PR through the same pnpm wrapper: exit 1, and the file now parses and carries

```
ownership-added — provenance.github_login is "0xBakeer" but the pull request
author is "bumasoft"; you may only submit your own results
```

which is the one sentence that should have appeared all along. The ownership check itself was working fine; only the reporting was broken.

## Multi-device derived metrics were 2× too high

`derived_metrics()` never received `hardware.count`, so a tensor-parallel run was divided by **one** device's memory bandwidth. `bandwidth_efficiency` and `tok_s_per_gb_bandwidth` came out exactly 2× too high for a two-node result — and both are rendered in the site UI.

`packages/core/src/plausibility.ts` already scales by `hwCount` in `bandwidthCeiling`, the VRAM limit and the TDP check. This is the Python side catching up, so the two implementations agree.

- **Registered** figures (bandwidth, memory) scale with the count.
- **Measured** figures (power, VRAM) never do — they are what the meter said.

**No result in the repository has `hardware.count > 1` yet, so nothing already merged changes.**

## Checks

`pnpm test` 348 passed / 1 skipped · `typecheck` clean · `eslint` clean · `pytest` 453 passed / 3 skipped · `ruff check` and `ruff format --check` clean on both touched Python files.

Each fix ships a test. `main` is now exported from `validate.ts` so the CLI path is tested in-process, rather than by spawning a binary whose resolution differs between the package runner and the workspace runner.