### PR TITLE
fix: stop warning about fields CI itself writes

### DIFF
--- a/tools/src/lib/check-result.ts
+++ b/tools/src/lib/check-result.ts
@@ -25,6 +25,20 @@ const MAX_RAW_PAYLOAD_BYTES = 100 * 1024;
 
 export interface CheckResultOptions {
   /**
+   * Whether the caller is actually working on this file, i.e. it was named by `--changed`.
+   *
+   * The CI-owned-field checks below are gated on this, because CI *writes* those fields: the
+   * stamp-user-ids job resolves provenance.github_user_id and commits it. Warning whenever
+   * the field is set therefore fires on every result that has ever been merged - 151 of them
+   * at the time this was added, growing by one per contribution - and buries the findings a
+   * contributor actually needs under a wall of noise about files they never touched.
+   *
+   * A full-repository sweep names no files and so says nothing about them. CI always passes
+   * --changed, and so does the local pre-flight in CONTRIBUTING, which is exactly where a
+   * hand-typed value should still be caught.
+   */
+  underReview?: boolean;
+  /**
    * When the workload registry is empty the repository is mid-landing (wave 2 order:
    * results seeded before `workloads/`), and every result would fail on an id that is
    * simply not there yet. An empty registry downgrades the check to a warning; a
@@ -169,7 +183,7 @@ export function checkResult(
 
   /* ------------------------------------------------------------ CI-owned fields */
 
-  if (result.provenance.github_user_id != null) {
+  if (options.underReview && result.provenance.github_user_id != null) {
     reporter.warn(
       file,
       'ci-owned-field',
@@ -177,7 +191,7 @@ export function checkResult(
       { path: 'provenance.github_user_id' },
     );
   }
-  if (result.provenance.commit != null || result.provenance.pr != null) {
+  if (options.underReview && (result.provenance.commit != null || result.provenance.pr != null)) {
     reporter.warn(
       file,
       'ci-owned-field',

--- a/tools/src/validate.ts
+++ b/tools/src/validate.ts
@@ -74,6 +74,10 @@ function median(values: number[]): number {
 export function validateRepo(options: ValidateOptions): ValidateOutcome {
   const root = options.root;
   const reporter = new Reporter();
+  // The files this invocation is actually about. CI and the local pre-flight both name them
+  // with --changed; a full-repository sweep names none, and checks that only make sense for
+  // a contribution in progress stay quiet accordingly.
+  const underReview = new Set((options.changed ?? []).map(normalize));
   const repo = loadRepo(root, reporter);
 
   /* ------------------------------------------------------------------- site */
@@ -136,7 +140,10 @@ export function validateRepo(options: ValidateOptions): ValidateOutcome {
     } else {
       seenRunIds.set(data.run_id, path);
     }
-    checkResult(repo, path, data, reporter, { allowMissingWorkloads: true });
+    checkResult(repo, path, data, reporter, {
+      allowMissingWorkloads: true,
+      underReview: underReview.has(normalize(path)),
+    });
   }
 
   crossCheck(repo, reporter);

--- a/tools/test/validate.test.ts
+++ b/tools/test/validate.test.ts
@@ -350,9 +350,11 @@ describe('reporting', () => {
   it('fails on warnings under --strict', () => {
     const result = makeResult(repo);
     result.provenance.github_user_id = 12345;
-    repo.writeResult(result);
-    expect(validateRepo({ root: repo.root }).ok).toBe(true);
-    expect(validateRepo({ root: repo.root, strict: true }).ok).toBe(false);
+    // Named with --changed, because the CI-owned-field warning belongs to the file under
+    // review: a repository-wide sweep says nothing about results CI has already stamped.
+    const path = repo.writeResult(result);
+    expect(validateRepo({ root: repo.root, changed: [path] }).ok).toBe(true);
+    expect(validateRepo({ root: repo.root, changed: [path], strict: true }).ok).toBe(false);
   });
 });
 
@@ -403,5 +405,36 @@ describe('--json-out', () => {
     };
     expect(report.ok).toBe(false);
     expect(report.errors.map((e) => e.code)).toContain('ownership-added');
+  });
+});
+
+describe('CI-owned fields', () => {
+  /**
+   * CI *writes* these: the stamp-user-ids job resolves provenance.github_user_id and commits
+   * it. Warning whenever the field is set therefore fired on every result ever merged — 151
+   * of them when this was written — and buried the findings a contributor needed under noise
+   * about files they had never touched. The check belongs to the file under review.
+   */
+  it('warns about a hand-set github_user_id only on a file the caller named', () => {
+    const result = makeResult(repo);
+    result.provenance.github_user_id = 12345;
+    const path = repo.writeResult(result);
+
+    const sweep = validateRepo({ root: repo.root });
+    expect(codes(sweep, 'warn')).not.toContain('ci-owned-field');
+
+    const reviewed = validateRepo({ root: repo.root, changed: [path] });
+    expect(codes(reviewed, 'warn')).toContain('ci-owned-field');
+  });
+
+  it('does the same for commit and pr', () => {
+    const result = makeResult(repo);
+    result.provenance.commit = 'a'.repeat(40);
+    const path = repo.writeResult(result);
+
+    expect(codes(validateRepo({ root: repo.root }), 'warn')).not.toContain('ci-owned-field');
+    expect(codes(validateRepo({ root: repo.root, changed: [path] }), 'warn')).toContain(
+      'ci-owned-field',
+    );
   });
 });


### PR DESCRIPTION
The `stamp-user-ids` job resolves `provenance.github_user_id` and **commits it into the result file**. `check-result` then warned whenever that field was set.

So every result that has ever been merged carries the warning — **151 of them**, growing by one per contribution — and the validation comment on a pull request is mostly noise about files the contributor never touched. The first external contribution got a report where the one finding that mattered sat under a wall of them.

The check now applies only to a file the caller **named with `--changed`**, which is what CI passes and what the local pre-flight in CONTRIBUTING passes. A hand-typed value in a contribution is still caught; a repository-wide sweep says nothing about results CI has already stamped. Same treatment for `provenance.commit` and `provenance.pr`.

`pnpm validate` on this repository: **254 warnings → 106**.

One existing test moved to `--changed` with it — "fails on warnings under `--strict`" had been relying on this very warning firing on a sweep, which is the behaviour being removed. Two new tests assert both halves: silent on a sweep, still caught on a named file.

`pnpm test` 350 passed / 1 skipped · typecheck · eslint · prettier · validate 0 errors.