### PR TITLE
ci: gate on types, lint and formatting

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,6 +45,16 @@ jobs:
       - name: Unit tests
         run: pnpm test
 
+      - name: Types
+        run: pnpm typecheck
+
+      # Only possible since the data directories were taken out of prettier's scope: it used
+      # to fail on 348 machine-written JSON files, so nobody could run it as a gate.
+      - name: Lint and format
+        run: |
+          pnpm lint
+          pnpm format:check
+
       - name: Collect the changed files
         id: changed
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,8 @@ repository — official or community — actually holds those weights.
 pnpm install
 pnpm test          # vitest across the workspace
 pnpm typecheck
+pnpm lint          # eslint
+pnpm format:check  # prettier; `pnpm format` writes
 pnpm validate      # every JSON file against its schema, ids recomputed, physics checked
 pnpm dev           # compile the data, then the app on localhost
 ```

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "test": "vitest run --passWithNoTests",
     "packet": "pnpm --filter @atlas/tools run packet",
     "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "typecheck": "pnpm -r --if-present run typecheck",
     "check:registries": "node packages/core/scripts/check-registries.mjs"
   },


### PR DESCRIPTION
The validate workflow ran the unit tests and the data validation, but never `typecheck`, `eslint` or `prettier`.

Formatting in particular *could not* be a gate: `prettier --check` failed on 348 files, almost all machine-written JSON, so wiring it in would have blocked every pull request. #56 took the data directories out of prettier's scope; this is the part that was waiting on that.

`package.json` gains `format` and `format:check` alongside the existing `lint`, so CI runs the same commands a contributor runs rather than a bespoke invocation, and CONTRIBUTING lists them with the other local checks.

`pnpm test` · `typecheck` · `lint` · `format:check` · `validate` all clean on this branch.