### PR TITLE
fix: vendor colours failed the chroma floor, and dark AMD collided with danger

### DIFF
--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -91,12 +91,18 @@
   --seq-4: #6366f1;
   --seq-5: #4338ca;
 
-  /* vendor hues for hardware series */
-  --vendor-nvidia: #6aa300;
-  --vendor-amd: #e2463c;
-  --vendor-apple: #5b6f99;
+  /* vendor hues for hardware series — OKLCH-retuned (2026-08-28) so every hue clears the
+   * dataviz chroma floor (C >= 0.10) and the light lightness band, and so the fixed
+   * categorical order in util/colors.ts passes adjacent-pair CVD ΔE >= 8 (deutan/protan,
+   * Machado 2009) with a normal-vision floor >= 15. Hue families are preserved for vendor
+   * recognisability: nvidia chartreuse, amd vermilion, apple violet-slate, intel cobalt,
+   * cpu dark gold. --vendor-other is deliberately near-gray ("unknown", never a series
+   * colour — it is not in SERIES_VARS). Asserted by util/colors.test.ts. */
+  --vendor-nvidia: #649a00;
+  --vendor-amd: #e14b36;
+  --vendor-apple: #5969b8;
   --vendor-intel: #1f6feb;
-  --vendor-cpu: #b07d3c;
+  --vendor-cpu: #a7841d;
   --vendor-other: #7a8494;
 
   /* chart series — cobalt carries throughput/primary curves, signal orange carries latency.
@@ -154,11 +160,14 @@
   --seq-4: #7f8be8;
   --seq-5: #b0b8ff;
 
-  --vendor-nvidia: #8fd400;
-  --vendor-amd: #ff6b5f;
-  --vendor-apple: #9db0dc;
-  --vendor-intel: #58a6ff;
-  --vendor-cpu: #d6a266;
+  /* own dark steps of the same vendor hue families, inside the dark lightness band
+   * (OKLCH L 0.48–0.67) and >= 3:1 on both dark surfaces; --vendor-amd sits away from
+   * --danger (#ff6b6b) — the old #ff6b5f was a near-collision (ΔE 1.4). */
+  --vendor-nvidia: #6ea800;
+  --vendor-amd: #e25a42;
+  --vendor-apple: #7888d3;
+  --vendor-intel: #4091ea;
+  --vendor-cpu: #8f6e00;
   --vendor-other: #9aa4b5;
 
   /* darker steps of the same hues, re-validated against the dark surface */

--- a/app/src/util/colors.test.ts
+++ b/app/src/util/colors.test.ts
@@ -1,0 +1,225 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { SERIES_VARS, vendorClass, withAlpha } from './colors.js';
+
+/* Palette accessibility gates for the categorical series (SERIES_VARS) in both themes.
+ *
+ * The checks mirror the dataviz palette validator (same OKLab math, same Machado 2009
+ * CVD simulation at severity 1.0, same thresholds), so a token edit that pushes a hue
+ * below the chroma floor, out of the lightness band, or an adjacent pair into the
+ * CVD warn band fails here instead of shipping. Values are parsed from tokens.css —
+ * the real stylesheet, not a copy.
+ */
+
+// -- tokens.css parsing ---------------------------------------------------------
+
+/* happy-dom rewrites import.meta.url to an http: URL, so resolve from the working
+ * directory instead (vitest may run from the repo root or from app/). */
+const tokensPath = ['src/styles/tokens.css', 'app/src/styles/tokens.css']
+  .map((p) => resolve(process.cwd(), p))
+  .find((p) => existsSync(p));
+if (!tokensPath) throw new Error('tokens.css not found from ' + process.cwd());
+const css = readFileSync(tokensPath, 'utf8');
+
+function parseBlock(block: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const m of block.matchAll(/--([\w-]+):\s*([^;]+);/g)) out.set(`--${m[1]!}`, m[2]!.trim());
+  return out;
+}
+
+const darkStart = css.indexOf("[data-theme='dark']");
+const lightVars = parseBlock(css.slice(0, darkStart));
+const darkOnly = parseBlock(css.slice(darkStart));
+/** Dark inherits from :root; only overridden vars change. */
+const darkVars = new Map([...lightVars, ...darkOnly]);
+
+function hexVar(vars: Map<string, string>, name: string): string {
+  const v = vars.get(name);
+  if (!v || !/^#[0-9a-f]{6}$/i.test(v)) throw new Error(`${name} is not a 6-digit hex: ${v}`);
+  return v;
+}
+
+// -- color math (identical formulation to the dataviz validator) -----------------
+
+type Vec3 = [number, number, number];
+const s2lin = (c: number): number => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+const hexLin = (h: string): Vec3 =>
+  [1, 3, 5].map((i) => s2lin(parseInt(h.slice(i, i + 2), 16) / 255)) as Vec3;
+
+function oklabFromLin([r, g, b]: Vec3): Vec3 {
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+  return [
+    0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+    1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+    0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+  ];
+}
+const oklch = (h: string): { L: number; C: number } => {
+  const [L, a, b] = oklabFromLin(hexLin(h));
+  return { L, C: Math.hypot(a, b) };
+};
+
+/** Machado, Oliveira & Fernandes (2009), severity 1.0 — part of the standard. */
+const MACHADO: Record<'protan' | 'deutan', number[][]> = {
+  protan: [
+    [0.152286, 1.052583, -0.204868],
+    [0.114503, 0.786281, 0.099216],
+    [-0.003882, -0.048116, 1.051998],
+  ],
+  deutan: [
+    [0.367322, 0.860646, -0.227968],
+    [0.280085, 0.672501, 0.047413],
+    [-0.01182, 0.04294, 0.968881],
+  ],
+};
+function simulate(h: string, kind: 'protan' | 'deutan'): Vec3 {
+  const [r, g, b] = hexLin(h);
+  const M = MACHADO[kind];
+  const clamp = (c: number): number => Math.max(0, Math.min(1, c));
+  return [0, 1, 2].map((i) => clamp(M[i]![0]! * r + M[i]![1]! * g + M[i]![2]! * b)) as Vec3;
+}
+/** Euclidean distance in OKLab ×100; no kind = unsimulated (normal) vision. */
+function deltaE(h1: string, h2: string, kind?: 'protan' | 'deutan'): number {
+  const a = oklabFromLin(kind ? simulate(h1, kind) : hexLin(h1));
+  const b = oklabFromLin(kind ? simulate(h2, kind) : hexLin(h2));
+  return 100 * Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+const cvdDeltaE = (a: string, b: string): number =>
+  Math.min(deltaE(a, b, 'protan'), deltaE(a, b, 'deutan'));
+
+const relLum = (h: string): number => {
+  const [r, g, b] = hexLin(h);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+function contrast(a: string, b: string): number {
+  const [hi, lo] = [relLum(a), relLum(b)].sort((x, y) => y - x) as [number, number];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// -- thresholds (validator constants) --------------------------------------------
+
+const CHROMA_FLOOR = 0.1; // below this a hue reads as gray and stops doing identity work
+const BAND: Record<Mode, [number, number]> = { light: [0.43, 0.77], dark: [0.48, 0.67] };
+const CVD_TARGET = 8.0; // adjacent pairs must CLEAR the target, not sit in the 6–8 warn band
+const NORMAL_FLOOR = 15.0; // worst adjacent pair, unsimulated vision — hard gate
+const CONTRAST_MIN = 3.0; // marks vs surface
+
+type Mode = 'light' | 'dark';
+const MODES: { mode: Mode; vars: Map<string, string>; surfaces: string[] }[] = [
+  { mode: 'light', vars: lightVars, surfaces: ['--surface', '--bg'] },
+  { mode: 'dark', vars: darkVars, surfaces: ['--surface', '--bg'] },
+];
+
+describe.each(MODES)('categorical palette ($mode)', ({ mode, vars, surfaces }) => {
+  const palette = SERIES_VARS.map((name) => ({ name, hex: hexVar(vars, name) }));
+
+  it('defines every series token as a plain hex in this theme', () => {
+    expect(palette).toHaveLength(8);
+  });
+
+  it(`keeps every hue inside the ${mode} lightness band`, () => {
+    const [lo, hi] = BAND[mode];
+    for (const { name, hex } of palette) {
+      const { L } = oklch(hex);
+      expect
+        .soft(L, `${name} ${hex} L=${L.toFixed(3)} outside [${lo}, ${hi}]`)
+        .toBeGreaterThanOrEqual(lo);
+      expect
+        .soft(L, `${name} ${hex} L=${L.toFixed(3)} outside [${lo}, ${hi}]`)
+        .toBeLessThanOrEqual(hi);
+    }
+  });
+
+  it('keeps every hue above the chroma floor (no gray-outs)', () => {
+    for (const { name, hex } of palette) {
+      const { C } = oklch(hex);
+      expect
+        .soft(C, `${name} ${hex} C=${C.toFixed(3)} reads as gray`)
+        .toBeGreaterThanOrEqual(CHROMA_FLOOR);
+    }
+  });
+
+  it('clears CVD ΔE >= 8 for every ADJACENT series pair (not just the 6–8 warn band)', () => {
+    for (let i = 0; i < palette.length - 1; i++) {
+      const a = palette[i]!,
+        b = palette[i + 1]!;
+      const d = cvdDeltaE(a.hex, b.hex);
+      expect
+        .soft(
+          d,
+          `${a.name} ↔ ${b.name} (${a.hex} ↔ ${b.hex}) CVD ΔE ${d.toFixed(1)} < ${CVD_TARGET}`,
+        )
+        .toBeGreaterThanOrEqual(CVD_TARGET);
+    }
+  });
+
+  it('clears the normal-vision floor for every adjacent pair', () => {
+    for (let i = 0; i < palette.length - 1; i++) {
+      const a = palette[i]!,
+        b = palette[i + 1]!;
+      const d = deltaE(a.hex, b.hex);
+      expect
+        .soft(d, `${a.name} ↔ ${b.name} normal ΔE ${d.toFixed(1)} < ${NORMAL_FLOOR}`)
+        .toBeGreaterThanOrEqual(NORMAL_FLOOR);
+    }
+  });
+
+  it('keeps every series colour >= 3:1 against the card surface and the page background', () => {
+    for (const surfaceVar of surfaces) {
+      const surface = hexVar(vars, surfaceVar);
+      for (const { name, hex } of palette) {
+        const c = contrast(hex, surface);
+        expect
+          .soft(c, `${name} ${hex} is ${c.toFixed(2)}:1 on ${surfaceVar} ${surface}`)
+          .toBeGreaterThanOrEqual(CONTRAST_MIN);
+      }
+    }
+  });
+
+  it('keeps status colours apart from vendor and chart series (colour means one thing)', () => {
+    // Regression gate: dark --vendor-amd used to sit at ΔE 1.4 from dark --danger.
+    // 5.5 is set from the measured minimum of the shipped palette (5.9, light warn↔cpu);
+    // anything under it means a status colour is drifting into a series identity.
+    const STATUS_MIN = 5.5;
+    for (const statusVar of ['--ok', '--warn', '--danger']) {
+      const status = hexVar(vars, statusVar);
+      for (const { name, hex } of palette) {
+        const d = deltaE(status, hex);
+        expect
+          .soft(
+            d,
+            `${statusVar} ${status} ↔ ${name} ${hex} normal ΔE ${d.toFixed(1)} < ${STATUS_MIN}`,
+          )
+          .toBeGreaterThanOrEqual(STATUS_MIN);
+      }
+    }
+  });
+});
+
+describe('series assignment', () => {
+  it('leads with the validated chart accents and never uses status tokens', () => {
+    expect(SERIES_VARS.slice(0, 2)).toEqual(['--chart-1', '--chart-2']);
+    for (const name of SERIES_VARS) expect(name).not.toMatch(/^--(ok|warn|danger)/);
+  });
+});
+
+describe('vendorClass', () => {
+  it('maps known vendors, folds generic architectures into cpu, and falls back to other', () => {
+    expect(vendorClass('NVIDIA')).toBe('vendor-nvidia');
+    expect(vendorClass('apple')).toBe('vendor-apple');
+    expect(vendorClass('x86')).toBe('vendor-cpu');
+    expect(vendorClass('arm')).toBe('vendor-cpu');
+    expect(vendorClass('acme')).toBe('vendor-other');
+    expect(vendorClass(null)).toBe('vendor-other');
+  });
+});
+
+describe('withAlpha', () => {
+  it('converts #rrggbb and passes through non-hex values', () => {
+    expect(withAlpha('#1b4fd6', 0.5)).toBe('rgba(27, 79, 214, 0.5)');
+    expect(withAlpha('var(--x)', 0.5)).toBe('var(--x)');
+  });
+});

--- a/app/src/util/colors.ts
+++ b/app/src/util/colors.ts
@@ -20,8 +20,11 @@ export function vendorColor(vendor: string | null | undefined): string {
 }
 
 /** Fixed categorical order for chart series: assigned by entity, never cycled. Leads with the
- * two validated chart accents; status colours (--warn etc.) are never series colours. */
-const SERIES_VARS = [
+ * two validated chart accents; status colours (--warn etc.) are never series colours.
+ * This order is the CVD-safety mechanism: every ADJACENT pair clears deutan/protan
+ * ΔE >= 8 in both themes (see colors.test.ts, which re-validates it from tokens.css).
+ * Exported for the palette test — do not reorder without re-running the validation. */
+export const SERIES_VARS = [
   '--chart-1',
   '--chart-2',
   '--vendor-apple',


### PR DESCRIPTION
The reported problem: `--vendor-apple` and `--vendor-cpu` sat below the chroma floor and read as grey rather than as categorical colours, and the worst adjacent pair for colour-vision deficiency sat in the WARN band rather than passing.

**Retuning for that turned up a worse one.** In dark theme `--vendor-amd #ff6b5f` was **1.4 OKLab units** from `--danger #ff6b6b` — an AMD dot and a danger indicator were the same colour to anyone reading the page. Now **7.7**.

### Measured, both themes, against both `--surface` and `--bg`

| | before | after |
|---|---|---|
| light | chroma floor **FAIL** (`#5b6f99` C 0.07); worst adjacent CVD ΔE 7.5 | **all pass**; worst adjacent **8.7** |
| dark | lightness band **FAIL ×5**; chroma **FAIL ×2**; worst adjacent 9.3 | **all pass**; worst adjacent **8.9** |
| dark amd ↔ danger | **1.4** | **7.7** |
| dark cpu ↔ warn | 5.7 | **16.9** |

Target for adjacent CVD ΔE is 8.0, so both themes now clear it rather than sitting in the 6–8 WARN band.

### What moved, and what didn't

Every hue keeps its vendor's family; only lightness and chroma move, with two deliberate exceptions:

- **Apple** 264° → 273°, to buy distance from the two other blues while staying cool steel — and it finally reads as a colour rather than washed grey.
- **CPU** 70° → 88°, bronze to dark gold: the added yellow-axis distance is what survives deuteranopia against the accent, and it simultaneously moves CPU off `--warn`, which it had been sitting **5.5°** from.

`--vendor-other` is deliberately unchanged and near-grey: it means *unknown vendor*, it is not in the categorical series, and the chroma floor does not apply to it. `--chart-1`/`--chart-2`, the status colours, the evidence colours, the sequential ramp and the series order are all untouched.

### The test is the point

`colors.test.ts` re-implements the validator's own maths — OKLab, Machado 2009 at severity 1.0, the same thresholds — against the **real** `tokens.css`, per theme. It asserts the lightness band, the chroma floor, adjacent CVD ΔE ≥ 8.0 (so the WARN band fails), adjacent normal ΔE ≥ 15, ≥3:1 contrast against both surfaces, and ≥5.5 between every status token and every series colour. A future edit that drifts back toward a status collision fails CI instead of being noticed by eye, which is how this one survived.

### Checks

`pnpm test` 367 passed / 1 skipped · `typecheck` · `lint` · `format:check` · `validate` 0 errors. Verified visually in both themes on the hardware registry, the heatmap and the Pareto scatter.

### Judgement call not taken

Light `cpu` ↔ `warn` at normal ΔE 5.9 is the tightest status/series pair left. Widening it means either lightening `--warn` (a status token, out of scope here) or pushing CPU past 90° into olive, which erodes the generic-silicon identity. 5.9 is the measured optimum inside those constraints.