### PR TITLE
registry: granite-4.2-3b mlx-4bit, the LM Studio community MLX quantization

### DIFF
--- a/models/ibm-granite/granite-4.2-3b/quants/mlx-4bit.json
+++ b/models/ibm-granite/granite-4.2-3b/quants/mlx-4bit.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "mlx-4bit",
+  "model_id": "ibm-granite/granite-4.2-3b",
+  "format": "mlx",
+  "bits": 4.5,
+  "hf_id": "lmstudio-community/granite-4.2-3b-MLX-4bit",
+  "revision": null,
+  "size_gb": 2.06,
+  "engines": [
+    "lmstudio",
+    "mlx-lm"
+  ],
+  "source": "community",
+  "notes": "config.json records a uniform affine quantization at bits 4, group_size 64, with no per-layer overrides. bits is therefore 4.5, not 4: each group of 64 weights carries an fp16 scale and an fp16 bias, which is 32 extra bits per group, so 4 + 32/64 = 4.5 bits per weight. That arithmetic is confirmed by the payload — 2,059,005,430 bytes over the 3,659,737,600 parameters of the source checkpoint is 4.501 bits per weight. size_gb is the safetensors payload of the repository (2,059,005,430 bytes); LM Studio reports 2.07 GB because it counts the tokenizer as well. Unlike the gemma-4-E2B-it MLX ladder, nothing here is left wider — the flat 4.5 is pure group-scale overhead rather than a mix of widths.",
+  "links": {
+    "hf": "https://huggingface.co/lmstudio-community/granite-4.2-3b-MLX-4bit"
+  }
+}


### PR DESCRIPTION
Adds the one registry file that was missing before `ibm-granite/granite-4.2-3b` can be
measured on a Mac: the MLX 4-bit quantization. The model entry and its `bf16` entry already
exist (#29), and `engines/lmstudio`, `engines/mlx-lm` and `hardware/apple-m2-max-32gb` all
exist too — so this is a single new file and nothing else.

### Why `bits` is 4.5 and not 4

`config.json` in the quantized repository records a uniform affine quantization at `bits: 4`,
`group_size: 64`, with **no per-layer overrides**. Each group of 64 weights therefore carries
an fp16 scale and an fp16 bias — 32 extra bits per group — so the true cost is
`4 + 32/64 = 4.5` bits per weight.

The payload confirms the arithmetic rather than relying on it: 2,059,005,430 bytes of
safetensors over the 3,659,737,600 parameters of the source checkpoint is **4.501 bits per
weight**.

This is worth stating because it looks like the `gemma-4-E2B-it` MLX ladder, which is also
recorded at 4.5 bits, but for a different reason: there the flatness comes from embeddings
and towers being left wider, whereas here the quantization is genuinely uniform and the
overhead is pure group-scale cost.

### Fields

- `size_gb` is the safetensors payload of the repository, 2,059,005,430 bytes → 2.06 GB. LM
  Studio reports 2.07 GB because it counts the tokenizer as well.
- `source` is `community`: `lmstudio-community` is not IBM. IBM does publish
  `ibm-granite/granite-4.2-3b-GGUF` officially, but no official MLX build.
- `engines` is `lmstudio` and `mlx-lm`, matching both engines' declared `quant_formats`.
- `revision` is left `null`; the repository is at sha `4fe06f1`.

### What this is for

The next PRs will be `lmstudio` measurements of this quantization on `apple-m2-max-32gb`,
deliberately the same engine, quantization family, and physical machine as the existing
`google/gemma-4-E2B-it` `mlx-4bit` results, so the two models are directly comparable.

`pnpm validate --changed` and `pnpm format:check` both clean.
