### PR TITLE
results: lmstudio 0.4.21 ibm-granite/granite-4.2-3b/mlx-4bit on apple-m2-max-32gb — eval-code-v1

### DIFF
--- a/results/lmstudio/ibm-granite/granite-4.2-3b/apple-m2-max-32gb/251c7884bb174170--eval-code-v1--243e50.json
+++ b/results/lmstudio/ibm-granite/granite-4.2-3b/apple-m2-max-32gb/251c7884bb174170--eval-code-v1--243e50.json
@@ -1,0 +1,1100 @@
+{
+  "schema_version": 1,
+  "run_id": "251c7884bb174170--eval-code-v1--243e50",
+  "config_id": "251c7884bb174170",
+  "cell_id": "492c433c3bf8",
+  "workload_id": "eval-code-v1",
+  "kind": "eval",
+  "engine": {
+    "id": "lmstudio",
+    "version": "0.4.21",
+    "commit": null,
+    "container": null,
+    "install_method": "app"
+  },
+  "model": {
+    "id": "ibm-granite/granite-4.2-3b",
+    "quant_id": "mlx-4bit",
+    "hf_id": "lmstudio-community/granite-4.2-3b-MLX-4bit",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "apple-m2-max-32gb",
+    "count": 1,
+    "driver": null,
+    "cuda": null,
+    "host": {
+      "cpu": "Apple M2 Max",
+      "cpu_cores": 12,
+      "ram_gb": 32.0,
+      "os": "macOS 26.5.2",
+      "kernel": "25.5.0",
+      "arch": "arm64"
+    },
+    "fingerprint": "sha256:f2cba40fa2bfa4473afbdc846b7ba69abe53fcb27fb4363b64aac1de5d17e03f",
+    "captured": {
+      "system_profiler": {
+        "_name": "hardware_overview",
+        "activation_lock_status": "activation_lock_enabled",
+        "boot_rom_version": "18000.121.3",
+        "chip_type": "Apple M2 Max",
+        "machine_model": "Mac14,13",
+        "machine_name": "Mac Studio",
+        "model_number": "MQH73D/A",
+        "number_processors": "proc 12:8:4:0",
+        "os_loader_version": "18000.121.3",
+        "physical_memory": "32 GB"
+      }
+    }
+  },
+  "args": {
+    "parallel": 32,
+    "context-length": 131072
+  },
+  "args_canonical": "@dtype=auto;@quant=mlx-4bit;context-length=131072;parallel=32",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-code-v1",
+    "resolved_params": {
+      "dataset_id": "eval-code-v1",
+      "suite": "code",
+      "scorer": "code_exec",
+      "items": 140,
+      "concurrency": 4,
+      "max_output_tokens": 4096,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 140,
+    "requests_ok": 85,
+    "requests_failed": 55,
+    "success_rate": 0.607143,
+    "duration_s": 615.896,
+    "input_tokens_total": 10095,
+    "output_tokens_total": 69596,
+    "e2e_ms": {
+      "mean": 26757.99,
+      "p50": 19252.194,
+      "p90": 56591.322,
+      "p95": 84607.201,
+      "p99": 120067.016,
+      "min": 4118.116,
+      "max": 131998.312
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 29.284,
+    "power_avg_w": null,
+    "power_peak_w": null,
+    "energy_wh": null,
+    "gpu_util_avg_pct": null,
+    "temp_max_c": null,
+    "thermal_throttle_detected": null
+  },
+  "scores": {
+    "suite": "code",
+    "total": 85,
+    "correct": 77,
+    "accuracy": 0.905882,
+    "success_rate": 0.607143,
+    "by_category": {
+      "algorithms": {
+        "total": 4,
+        "correct": 4
+      },
+      "bugfix": {
+        "total": 17,
+        "correct": 14
+      },
+      "dicts": {
+        "total": 13,
+        "correct": 12
+      },
+      "edge_cases": {
+        "total": 13,
+        "correct": 12
+      },
+      "lists": {
+        "total": 17,
+        "correct": 17
+      },
+      "math": {
+        "total": 3,
+        "correct": 3
+      },
+      "recursion": {
+        "total": 1,
+        "correct": 1
+      },
+      "strings": {
+        "total": 17,
+        "correct": 14
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 36,
+        "correct": 34
+      },
+      "hard": {
+        "total": 14,
+        "correct": 12
+      },
+      "medium": {
+        "total": 35,
+        "correct": 31
+      }
+    },
+    "avg_output_tokens": 818.78,
+    "avg_latency_ms": 17525.51,
+    "failures": 55,
+    "items": [
+      {
+        "id": "code-0001",
+        "correct": true,
+        "predicted": "def reverse_words(text: str) -> str:\n    \"\"\"Return *text* with the order of its whitespace-separated words reversed. Runs of\n    whitespace collapse to a single space and leading/trailing whitespace is dropped.\"\"\"\n    words = text.split()\n    return ' '.join(reversed(words))",
+        "expected": "<tests pass>",
+        "latency_ms": 10870.741,
+        "output_tokens": 412,
+        "category": "strings",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0002",
+        "correct": true,
+        "predicted": "def is_palindrome(text: str) -> bool:\n    \"\"\"Return True when *text* reads the same forwards and backwards, ignoring case\n    and every character that is not a letter or a digit.\n    \"\"\"\n    cleaned = ''.join(ch for ch in text if ch.isalnum()).lower()\n    return cleaned == cleaned[::-1]",
+        "expected": "<tests pass>",
+        "latency_ms": 13648.892,
+        "output_tokens": 487,
+        "category": "strings",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0003",
+        "correct": true,
+        "predicted": "def count_vowels(text: str) -> int:\n    \"\"\"Return how many of the letters a, e, i, o and u occur in *text*, ignoring case.\n    \"\"\"\n    vowels = set('aeiou')\n    return sum(1 for ch in text.lower() if ch in vowels)",
+        "expected": "<tests pass>",
+        "latency_ms": 9227.987,
+        "output_tokens": 319,
+        "category": "strings",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0004",
+        "correct": true,
+        "predicted": "import re\n\ndef capitalize_words(text: str) -> str:\n    return re.sub(r'\\S+', lambda m: m.group().capitalize(), text)",
+        "expected": "<tests pass>",
+        "latency_ms": 46648.44,
+        "output_tokens": 1655,
+        "category": "strings",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0005",
+        "correct": true,
+        "predicted": "def truncate(text: str, limit: int) -> str:\n    \"\"\"Return *text* unchanged when it is at most *limit* characters long. Otherwise cut\n    it so the result including the trailing '...' is exactly *limit* characters. When\n    *limit* is 3 or less, return the first *limit* characters of '...'.\n    \"\"\"\n    if len(text) <= limit:\n        return text\n    # Truncate with '...'\n    if limit <= 3:\n        return '.' * limit   # first limit chars of '...' are dots.\n    else:\n        prefix_len = limit - 3\n",
+        "expected": "<tests pass>",
+        "latency_ms": 31305.225,
+        "output_tokens": 1121,
+        "category": "strings",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0006",
+        "correct": true,
+        "predicted": "def longest_word(text: str) -> str:\n    \"\"\"Return the longest whitespace-separated word in *text*. On a tie return the one\n    that occurs first. Return '' for text with no words.\"\"\"\n    words = text.split()\n    if not words:\n        return ''\n    longest = words[0]\n    max_len = len(longest)\n    for w in words[1:]:\n        if len(w) > max_len:\n            longest = w\n            max_len = len(w)\n    return longest",
+        "expected": "<tests pass>",
+        "latency_ms": 16783.897,
+        "output_tokens": 617,
+        "category": "strings",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0007",
+        "correct": true,
+        "predicted": "def dedupe_chars(text: str) -> str:\n    \"\"\"Return *text* with later occurrences of a character removed, keeping the first\n    occurrence in place. The comparison is case sensitive.\"\"\"\n    seen = set()\n    result_parts = []\n    for ch in text:\n        if ch not in seen:\n            result_parts.append(ch)\n            seen.add(ch)\n    return ''.join(result_parts)",
+        "expected": "<tests pass>",
+        "latency_ms": 23061.724,
+        "output_tokens": 838,
+        "category": "strings",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0008",
+        "correct": true,
+        "predicted": "def char_frequency(text: str) -> dict:\n    \"\"\"Return a dict mapping each non-whitespace character of *text* to how often it\n    occurs. Case is significant.\"\"\"\n    freq = {}\n    for ch in text:\n        if not ch.isspace():\n            freq[ch] = freq.get(ch, 0) + 1\n    return freq",
+        "expected": "<tests pass>",
+        "latency_ms": 17955.943,
+        "output_tokens": 612,
+        "category": "strings",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0009",
+        "correct": false,
+        "predicted": "def snake_to_camel(name: str) -> str:\n    \"\"\"Convert a snake_case identifier to camelCase. Leading underscores are preserved,\n    repeated underscores are treated as one separator, and a trailing underscore is\n    dropped.\n    \"\"\"\n    if name.startswith('_'):\n        prefix = '_'\n        rest = name[1:]\n    else:\n        prefix = ''\n        rest = name\n\n    words = [w for w in rest.split('_') if w]\n\n    if not words:\n        return prefix\n\n    camel = words[0] + ''.join(word.capitalize() for wor",
+        "expected": "<tests pass>",
+        "latency_ms": 88484.912,
+        "output_tokens": 2834,
+        "category": "strings",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0010",
+        "correct": false,
+        "predicted": "",
+        "expected": "<code>",
+        "latency_ms": 131998.312,
+        "output_tokens": 4095,
+        "category": "strings",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0011",
+        "correct": true,
+        "predicted": "def is_anagram(a: str, b: str) -> bool:\n    \"\"\"Return True when *a* and *b* contain the same letters with the same counts,\n    ignoring case and every non-letter character.\n    \"\"\"\n    a_clean = sorted(ch.lower() for ch in a if ch.isalpha())\n    b_clean = sorted(ch.lower() for ch in b if ch.isalpha())\n    return a_clean == b_clean",
+        "expected": "<tests pass>",
+        "latency_ms": 20390.167,
+        "output_tokens": 697,
+        "category": "strings",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0012",
+        "correct": false,
+        "predicted": "def compress(text: str) -> str:\n    \"\"\"Run-length encode *text*: every run of the same character becomes the character\n    followed by the run length, but runs of length 1 keep no number. Return '' for ''.\n    \"\"\"\n    if not text:\n        return \"\"\n    result = []\n    count = 1\n    prev_char = text[0]\n    for ch in text[1:]:\n        if ch == prev_char:\n            count += 1\n        else:\n            result.append(prev_char)\n            if count > 1:\n                result.append(str(count))\n   ",
+        "expected": "<tests pass>",
+        "latency_ms": 51145.824,
+        "output_tokens": 1688,
+        "category": "strings",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0013",
+        "correct": true,
+        "predicted": "def caesar(text: str, shift: int) -> str:\n    \"\"\"Shift every ASCII letter of *text* by *shift* places through the alphabet,\n    wrapping around and preserving case. Non-letters are returned unchanged. A negative shift\n    shifts backwards.\"\"\"\n    result_chars = []\n    for ch in text:\n        if 'a' <= ch <= 'z':\n            new_ord = (ord(ch) - ord('a') + shift) % 26 + ord('a')\n            result_chars.append(chr(new_ord))\n        elif 'A' <= ch <= 'Z':\n            new_ord = (ord(ch) - ord('A') ",
+        "expected": "<tests pass>",
+        "latency_ms": 24489.585,
+        "output_tokens": 780,
+        "category": "strings",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0014",
+        "correct": true,
+        "predicted": "def normalise_whitespace(text: str) -> str:\n    \"\"\"Collapse every run of whitespace in *text* to a single space and strip the ends.\"\"\"\n    return \" \".join(text.split())",
+        "expected": "<tests pass>",
+        "latency_ms": 14446.592,
+        "output_tokens": 431,
+        "category": "strings",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0015",
+        "correct": true,
+        "predicted": "def chunk(items: list, size: int) -> list:\n    \"\"\"Split *items* into consecutive lists of at most *size* elements. Raise ValueError\n    when *size* is not at least 1.\"\"\"\n    if size < 1:\n        raise ValueError(\"size must be at least 1\")\n    result = []\n    current = []\n    for item in items:\n        if len(current) == size:\n            result.append(current)\n            current = []\n        current.append(item)\n    if current:\n        result.append(current)\n    return result",
+        "expected": "<tests pass>",
+        "latency_ms": 15721.276,
+        "output_tokens": 469,
+        "category": "lists",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0016",
+        "correct": true,
+        "predicted": "def flatten_once(items: list) -> list:\n    \"\"\"Flatten one level: elements that are lists are spliced in, everything else is kept\n    as it is. Strings are never flattened.\n    \"\"\"\n    result = []\n    for item in items:\n        if isinstance(item, list):\n            result.extend(item)\n        else:\n            result.append(item)\n    return result",
+        "expected": "<tests pass>",
+        "latency_ms": 15624.139,
+        "output_tokens": 454,
+        "category": "lists",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0017",
+        "correct": true,
+        "predicted": "def rotate(items: list, n: int) -> list:\n    \"\"\"Return a new list with *items* rotated *n* places to the left. A negative *n*\n    rotates right. Rotating an empty list returns an empty list.\"\"\"\n    if not items:\n        return []\n    m = len(items)\n    shift = n % m\n    return items[shift:] + items[:shift]",
+        "expected": "<tests pass>",
+        "latency_ms": 23109.653,
+        "output_tokens": 684,
+        "category": "lists",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0018",
+        "correct": true,
+        "predicted": "def second_largest(numbers: list) -> float | None:\n    \"\"\"Return the second largest distinct value in *numbers*, or None when there are\n    fewer than two distinct values.\n    \"\"\"\n    distinct = sorted(set(numbers), reverse=True)\n    if len(distinct) < 2:\n        return None\n    return float(distinct[1])",
+        "expected": "<tests pass>",
+        "latency_ms": 21546.015,
+        "output_tokens": 618,
+        "category": "lists",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0019",
+        "correct": true,
+        "predicted": "def running_sum(numbers: list) -> list:\n    \"\"\"Return the list of running totals: element i is the sum of the first i+1 numbers.\n    \"\"\"\n    result = []\n    total = 0\n    for num in numbers:\n        total += num\n        result.append(total)\n    return result",
+        "expected": "<tests pass>",
+        "latency_ms": 12008.434,
+        "output_tokens": 349,
+        "category": "lists",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0020",
+        "correct": true,
+        "predicted": "def drop_consecutive_duplicates(items: list) -> list:\n    \"\"\"Remove elements that are equal to the element directly before them.\"\"\"\n    result = []\n    for item in items:\n        if not result or result[-1] != item:\n            result.append(item)\n    return result",
+        "expected": "<tests pass>",
+        "latency_ms": 25012.475,
+        "output_tokens": 710,
+        "category": "lists",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0021",
+        "correct": true,
+        "predicted": "def differences(numbers: list) -> list:\n    \"\"\"Return the differences between consecutive elements: element i is numbers[i+1] -\n    numbers[i]. A list of fewer than two numbers gives an empty list.\n    \"\"\"\n    if len(numbers) < 2:\n        return []\n    return [numbers[i+1] - numbers[i] for i in range(len(numbers)-1)]",
+        "expected": "<tests pass>",
+        "latency_ms": 10086.872,
+        "output_tokens": 281,
+        "category": "lists",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0022",
+        "correct": true,
+        "predicted": "def interleave(a: list, b: list) -> list:\n    \"\"\"Alternate elements of *a* and *b*, starting with *a*. When one list is longer, its\n    remaining elements are appended in order.\n    \"\"\"\n    result = []\n    i, j = 0, 0\n    while i < len(a) and j < len(b):\n        result.append(a[i])\n        result.append(b[j])\n        i += 1\n        j += 1\n    result.extend(a[i:])\n    result.extend(b[j:])\n    return result",
+        "expected": "<tests pass>",
+        "latency_ms": 17914.037,
+        "output_tokens": 506,
+        "category": "lists",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0023",
+        "correct": true,
+        "predicted": "def partition_evens(numbers: list) -> tuple:\n    \"\"\"Return a tuple (evens, odds), each preserving the original order.\n    \"\"\"\n    evens = [x for x in numbers if x % 2 == 0]\n    odds = [x for x in numbers if x % 2 != 0]\n    return (evens, odds)",
+        "expected": "<tests pass>",
+        "latency_ms": 10159.156,
+        "output_tokens": 298,
+        "category": "lists",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0024",
+        "correct": true,
+        "predicted": "from collections import Counter\n\ndef top_k_frequent(items: list, k: int) -> list:\n    \"\"\"Return the *k* most frequent elements, most frequent first. Ties are broken by\n    first appearance in *items*. When *k* exceeds the number of distinct elements,\n    return all of them.\n    \"\"\"\n    freq = Counter(items)\n    first_idx = {}\n    for i, val in enumerate(items):\n        if val not in first_idx:\n            first_idx[val] = i\n\n    sorted_elements = sorted(freq.keys(), key=lambda x: (-freq[x], firs",
+        "expected": "<tests pass>",
+        "latency_ms": 45184.559,
+        "output_tokens": 1289,
+        "category": "lists",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0025",
+        "correct": true,
+        "predicted": "def longest_increasing_run(numbers: list) -> list:\n    \"\"\"Return the longest run of strictly increasing consecutive elements. On a tie return\n    the earliest such run. An empty input gives an empty list.\"\"\"\n    n = len(numbers)\n    if n == 0:\n        return []\n    best_len = 1          # at least one element forms a run\n    best_start = 0\n    cur_len = 1\n    i = 0\n    while i < n - 1:\n        if numbers[i + 1] > numbers[i]:\n            cur_len += 1\n        else:\n            if cur_len > best_le",
+        "expected": "<tests pass>",
+        "latency_ms": 69096.36,
+        "output_tokens": 1946,
+        "category": "lists",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0026",
+        "correct": true,
+        "predicted": "def move_zeros(numbers: list) -> list:\n    \"\"\"Return a new list with every 0 moved to the end, other elements keeping their\n    relative order.\"\"\"\n    non_zero = [x for x in numbers if x != 0]\n    return non_zero + [0] * (len(numbers) - len(non_zero))",
+        "expected": "<tests pass>",
+        "latency_ms": 23411.379,
+        "output_tokens": 665,
+        "category": "lists",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0027",
+        "correct": true,
+        "predicted": "def index_of_min(numbers: list) -> int:\n    \"\"\"Return the index of the smallest element, the earliest one on a tie. Return -1 for\n    an empty list.\"\"\"\n    if not numbers:\n        return -1\n    min_val = numbers[0]\n    min_idx = 0\n    for i, val in enumerate(numbers[1:], start=1):\n        if val < min_val:\n            min_val = val\n            min_idx = i\n    return min_idx",
+        "expected": "<tests pass>",
+        "latency_ms": 16942.616,
+        "output_tokens": 482,
+        "category": "lists",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0028",
+        "correct": true,
+        "predicted": "def split_at_threshold(numbers: list, threshold: float) -> tuple:\n    \"\"\"Return (below, at_or_above): numbers strictly below *threshold* and the rest,\n    each keeping the original order.\"\"\"\n    below = []\n    at_or_above = []\n    for num in numbers:\n        if num < threshold:\n            below.append(num)\n        else:\n            at_or_above.append(num)\n    return (below, at_or_above)",
+        "expected": "<tests pass>",
+        "latency_ms": 23171.968,
+        "output_tokens": 658,
+        "category": "lists",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0029",
+        "correct": false,
+        "predicted": "def invert(mapping: dict) -> dict:\n    \"\"\"Return a dict with keys and values swapped. When two keys share a value, the key\n    that comes later in iteration order wins.\"\"\"\n    result = {}\n    for k, v in mapping:\n        result[v] = k\n    return result",
+        "expected": "<tests pass>",
+        "latency_ms": 21715.867,
+        "output_tokens": 610,
+        "category": "dicts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0030",
+        "correct": true,
+        "predicted": "def merge_sum(a: dict, b: dict) -> dict:\n    \"\"\"Merge two dicts of numbers by adding the values of shared keys.\n    \"\"\"\n    result = {}\n    for key, val in a.items():\n        result[key] = val\n    for key, val in b.items():\n        if key in result:\n            result[key] += val\n        else:\n            result[key] = val\n    return result",
+        "expected": "<tests pass>",
+        "latency_ms": 14766.27,
+        "output_tokens": 391,
+        "category": "dicts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0031",
+        "correct": true,
+        "predicted": "def group_by_length(words: list) -> dict:\n    \"\"\"Group *words* into a dict from word length to the list of words of that length, in\n    input order.\n    \"\"\"\n    result = {}\n    for w in words:\n        l = len(w)\n        if l not in result:\n            result[l] = []\n        result[l].append(w)\n    return result",
+        "expected": "<tests pass>",
+        "latency_ms": 15649.201,
+        "output_tokens": 404,
+        "category": "dicts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0032",
+        "correct": true,
+        "predicted": "def word_count(text: str) -> dict:\n    \"\"\"Count the whitespace-separated words of *text* case-insensitively, ignoring leading\n    and trailing punctuation of each word (. , ! ? ; :).\n    \"\"\"\n    count = {}\n    for token in text.split():\n        cleaned = token.strip('.,!?:')\n        if cleaned:\n            w = cleaned.lower()\n            count[w] = count.get(w, 0) + 1\n    return count",
+        "expected": "<tests pass>",
+        "latency_ms": 58217.47,
+        "output_tokens": 1557,
+        "category": "dicts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0033",
+        "correct": true,
+        "predicted": "def top_n_by_value(mapping: dict, n: int) -> list:\n    \"\"\"Return the *n* keys with the largest values, largest first. Ties are broken by the\n    key in ascending order.\"\"\"\n    sorted_items = sorted(mapping.items(), key=lambda kv: (-kv[1], kv[0]))\n    return [k for k, _ in sorted_items[:n]]",
+        "expected": "<tests pass>",
+        "latency_ms": 33228.867,
+        "output_tokens": 888,
+        "category": "dicts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0034",
+        "correct": true,
+        "predicted": "def filter_values(mapping: dict, minimum: float) -> dict:\n    \"\"\"Return a new dict with only the entries whose value is at least *minimum*.\n    \"\"\"\n    return {k: v for k, v in mapping.items() if v >= minimum}",
+        "expected": "<tests pass>",
+        "latency_ms": 10024.95,
+        "output_tokens": 262,
+        "category": "dicts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0035",
+        "correct": true,
+        "predicted": "def pairs_to_dict(pairs: list) -> dict:\n    \"\"\"Build a dict from a list of (key, value) tuples. A later pair overwrites an earlier\n    one with the same key.\"\"\"\n    result = {}\n    for key, value in pairs:\n        result[key] = value\n    return result",
+        "expected": "<tests pass>",
+        "latency_ms": 13848.932,
+        "output_tokens": 373,
+        "category": "dicts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0036",
+        "correct": true,
+        "predicted": "def nested_get(data: dict, path: str, default=None):\n    \"\"\"Look up a dotted *path* such as 'a.b.c' in nested dicts. Return *default* when any\n    step is missing or when a step runs into something that is not a dict. An empty\n    path returns *data*.\"\"\"\n    if not path:\n        return data\n    parts = path.split('.')\n    cur = data\n    for p in parts:\n        if not isinstance(cur, dict) or p not in cur:\n            return default\n        cur = cur[p]\n    return cur",
+        "expected": "<tests pass>",
+        "latency_ms": 26096.674,
+        "output_tokens": 695,
+        "category": "dicts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0037",
+        "correct": true,
+        "predicted": "def sum_by_prefix(mapping: dict, prefix: str) -> float:\n    \"\"\"Add up the values of every entry whose key starts with *prefix*.\"\"\"\n    total = 0.0\n    for key, value in mapping.items():\n        if isinstance(key, str) and key.startswith(prefix):\n            total += float(value)\n    return total",
+        "expected": "<tests pass>",
+        "latency_ms": 15354.486,
+        "output_tokens": 398,
+        "category": "dicts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0038",
+        "correct": true,
+        "predicted": "def most_common_key(counts: dict) -> str | None:\n    \"\"\"Return the key with the largest value, breaking ties by the smaller key. Return\n    None for an empty dict.\"\"\"\n    if not counts:\n        return None\n    max_val = max(counts.values())\n    candidates = [k for k, v in counts.items() if v == max_val]\n    return min(candidates)",
+        "expected": "<tests pass>",
+        "latency_ms": 35889.793,
+        "output_tokens": 928,
+        "category": "dicts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0041",
+        "correct": true,
+        "predicted": "def gcd_of(a: int, b: int) -> int:\n    \"\"\"Return the greatest common divisor of two non-negative integers, without using math.gcd. gcd_of(0, 0) is 0.\"\"\"\n    while b:\n        a, b = b, a % b\n    return a",
+        "expected": "<tests pass>",
+        "latency_ms": 9676.099,
+        "output_tokens": 244,
+        "category": "math",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0082",
+        "correct": true,
+        "predicted": "def longest_common_prefix(words: list) -> str:\n    \"\"\"Return the longest string that starts every word in *words*. An empty list gives ''.\n    \"\"\"\n    if not words:\n        return ''\n    min_len = len(words[0])\n    for w in words:\n        if len(w) < min_len:\n            min_len = len(w)\n    for i in range(min_len):\n        ch = words[0][i]\n        if all(words[j][i] == ch for j in range(len(words))):\n            continue\n        else:\n            return words[0][:i]\n    return words[0][:min_len",
+        "expected": "<tests pass>",
+        "latency_ms": 21638.764,
+        "output_tokens": 577,
+        "category": "algorithms",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0086",
+        "correct": true,
+        "predicted": "def find_duplicates(items: list) -> list:\n    \"\"\"Return the values that occur more than once, each once, in order of first repeat.\n    \"\"\"\n    seen = set()\n    duplicates = []\n    for item in items:\n        if item in seen and item not in duplicates:\n            duplicates.append(item)\n        seen.add(item)\n    return duplicates",
+        "expected": "<tests pass>",
+        "latency_ms": 61113.742,
+        "output_tokens": 1986,
+        "category": "algorithms",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0087",
+        "correct": true,
+        "predicted": "def group_anagrams(words: list) -> list:\n    \"\"\"Group words that are anagrams of each other, ignoring case. Return a list of groups\n    sorted by the first word of each group; inside a group keep the input order.\"\"\"\n    groups = {}\n    for w in words:\n        key = ''.join(sorted(w.lower()))\n        groups.setdefault(key, []).append(w)\n\n    return sorted(groups.values(), key=lambda lst: lst[0].lower())",
+        "expected": "<tests pass>",
+        "latency_ms": 28392.943,
+        "output_tokens": 831,
+        "category": "algorithms",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0088",
+        "correct": true,
+        "predicted": "def min_coins(amount: int, coins: list) -> int:\n    \"\"\"Return the fewest coins that add up to *amount*, or -1 when it cannot be made.\n    Coins may be used any number of times. min_coins(0, ...) is 0.\n    \"\"\"\n    if amount == 0:\n        return 0\n    dp = [float('inf')] * (amount + 1)\n    dp[0] = 0\n    for i in range(1, amount + 1):\n        for c in coins:\n            if i >= c and dp[i - c] + 1 < dp[i]:\n                dp[i] = dp[i - c] + 1\n    return dp[amount] if dp[amount] != float('inf') els",
+        "expected": "<tests pass>",
+        "latency_ms": 26249.788,
+        "output_tokens": 758,
+        "category": "algorithms",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0089",
+        "correct": true,
+        "predicted": "def safe_divide(a: float, b: float, default: float = 0.0) -> float:\n    \"\"\"Divide *a* by *b* and return *default* when *b* is 0.\n    \"\"\"\n    if b == 0:\n        return default\n    return a / b",
+        "expected": "<tests pass>",
+        "latency_ms": 11737.885,
+        "output_tokens": 409,
+        "category": "edge_cases",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0090",
+        "correct": true,
+        "predicted": "def first_or(items: list, default=None):\n    \"\"\"Return the first element of *items*, or *default* when the list is empty.\n    \"\"\"\n    if items:\n        return items[0]\n    return default",
+        "expected": "<tests pass>",
+        "latency_ms": 11376.895,
+        "output_tokens": 408,
+        "category": "edge_cases",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0091",
+        "correct": true,
+        "predicted": "def at_index(items: list, index: int, default=None):\n    \"\"\"Return items[index], supporting negative indices, and *default* when the index is out of range.\"\"\"\n    if 0 <= index < len(items) or -len(items) <= index < 0:\n        return items[index]\n    return default",
+        "expected": "<tests pass>",
+        "latency_ms": 20483.496,
+        "output_tokens": 702,
+        "category": "edge_cases",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0092",
+        "correct": true,
+        "predicted": "def mean_or_zero(numbers: list) -> float:\n    \"\"\"Return the arithmetic mean of *numbers*, or 0.0 for an empty list.\n    \"\"\"\n    if not numbers:\n        return 0.0\n    return sum(numbers) / len(numbers)",
+        "expected": "<tests pass>",
+        "latency_ms": 9704.843,
+        "output_tokens": 329,
+        "category": "edge_cases",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0093",
+        "correct": true,
+        "predicted": "def to_int(value, default: int = 0) -> int:\n    \"\"\"Convert *value* to an int, returning *default* when it cannot be converted. Strings\n    with surrounding whitespace are accepted; floats are truncated toward zero;\n    booleans convert to 1 and 0.\n    \"\"\"\n    if isinstance(value, (int, float)):\n        return int(value)\n    if isinstance(value, str):\n        s = value.strip()\n        try:\n            return int(s)\n        except ValueError:\n            return default\n    return default",
+        "expected": "<tests pass>",
+        "latency_ms": 54152.1,
+        "output_tokens": 1838,
+        "category": "edge_cases",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0094",
+        "correct": true,
+        "predicted": "def take(items: list, n: int) -> list:\n    \"\"\"Return the first *n* elements. A negative *n* gives an empty list, and an *n* larger\n    than the list gives the whole list.\"\"\"\n    if n < 0:\n        return []\n    return items[:n]",
+        "expected": "<tests pass>",
+        "latency_ms": 24058.878,
+        "output_tokens": 813,
+        "category": "edge_cases",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0095",
+        "correct": true,
+        "predicted": "def last_n(items: list, n: int) -> list:\n    \"\"\"Return the last *n* elements in their original order. A negative or zero *n* gives\n    an empty list.\"\"\"\n    if n <= 0:\n        return []\n    return items[-n:]",
+        "expected": "<tests pass>",
+        "latency_ms": 8970.051,
+        "output_tokens": 298,
+        "category": "edge_cases",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0096",
+        "correct": true,
+        "predicted": "def is_blank(text) -> bool:\n    \"\"\"Return True when *text* is None, empty, or only whitespace.\n    \"\"\"\n    if text is None:\n        return True\n    if isinstance(text, str):\n        return text.strip() == \"\"\n    return False",
+        "expected": "<tests pass>",
+        "latency_ms": 24496.552,
+        "output_tokens": 808,
+        "category": "edge_cases",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0097",
+        "correct": true,
+        "predicted": "def drop_none(items: list) -> list:\n    \"\"\"Remove every None from the list, keeping the order. Falsy values that are not None,\n    such as 0 and '', are kept.\"\"\"\n    return [x for x in items if x is not None]",
+        "expected": "<tests pass>",
+        "latency_ms": 10581.048,
+        "output_tokens": 340,
+        "category": "edge_cases",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0098",
+        "correct": true,
+        "predicted": "def split_or_empty(text: str, sep: str = ',') -> list:\n    \"\"\"Split *text* on *sep* and strip each part, dropping parts that are empty after\n    stripping. An empty or whitespace-only input gives an empty list.\"\"\"\n    if not text.strip():\n        return []\n    parts = text.split(sep)\n    return [p.strip() for p in parts if p.strip()]",
+        "expected": "<tests pass>",
+        "latency_ms": 18338.567,
+        "output_tokens": 609,
+        "category": "edge_cases",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0099",
+        "correct": true,
+        "predicted": "def ensure_list(value) -> list:\n    \"\"\"Wrap *value* in a list unless it already is one. None becomes an empty list, and a\n    string is treated as a single value, not a sequence.\"\"\"\n    if value is None:\n        return []\n    if isinstance(value, list):\n        return value\n    return [value]",
+        "expected": "<tests pass>",
+        "latency_ms": 18975.127,
+        "output_tokens": 625,
+        "category": "edge_cases",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0100",
+        "correct": false,
+        "predicted": "def clamp_slice(items: list, start: int, end: int) -> list:\n    \"\"\"Return items[start:end] with the bounds clamped into range and start never\n    greater than end. Negative bounds are clamped to 0, not counted from the end.\"\"\"\n    s = max(start, 0)\n    e = min(max(end, 0), len(items))\n    if s > e:\n        # after clamping we still have start > end; adjust to a valid slice\n        s, e = 0, len(items)\n    return items[s:e]",
+        "expected": "<tests pass>",
+        "latency_ms": 89326.471,
+        "output_tokens": 2789,
+        "category": "edge_cases",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0101",
+        "correct": true,
+        "predicted": "def mask_email(email: str) -> str:\n    \"\"\"Mask an email address: keep the first character of the local part, replace the\n    rest of it with one '*' per character, and leave the domain untouched. A string\n    with no '@', or with an empty local part, is returned unchanged.\"\"\"\n    at_pos = email.find('@')\n    if at_pos == -1 or at_pos == 0:   # no '@' or empty local part\n        return email\n    local = email[:at_pos]             # non‑empty by condition above\n    masked_local = local[0] + ('*' *",
+        "expected": "<tests pass>",
+        "latency_ms": 35592.59,
+        "output_tokens": 1148,
+        "category": "strings",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0102",
+        "correct": true,
+        "predicted": "def starts_with_any(text: str, prefixes: list) -> bool:\n    \"\"\"Return True when *text* starts with any of the given prefixes. An empty list of\n    prefixes gives False; an empty prefix string counts as a match.\"\"\"\n    for p in prefixes:\n        if p == \"\" or text.startswith(p):\n            return True\n    return False",
+        "expected": "<tests pass>",
+        "latency_ms": 22509.52,
+        "output_tokens": 729,
+        "category": "strings",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0103",
+        "correct": true,
+        "predicted": "def wrap_text(text: str, width: int) -> list:\n    \"\"\"Wrap *text* into lines of at most *width* characters, breaking only at spaces and\n    never splitting a word. A word longer than *width* gets a line of its own. Runs of\n    whitespace collapse; empty input gives an empty list. Raise ValueError when width\n    is below 1.\"\"\"\n    if width < 1:\n        raise ValueError(\"width must be >= 1\")\n    words = text.split()\n    lines: list[str] = []\n    current_line_words: list[str] = []\n\n    i = 0\n    whi",
+        "expected": "<tests pass>",
+        "latency_ms": 109394.459,
+        "output_tokens": 3317,
+        "category": "strings",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0104",
+        "correct": true,
+        "predicted": "def zip_fill(a: list, b: list, fill=None) -> list:\n    \"\"\"Pair up elements of *a* and *b*, padding the shorter list with *fill* so the result\n    is as long as the longer input.\n    \"\"\"\n    max_len = max(len(a), len(b))\n    result = []\n    for i in range(max_len):\n        a_val = a[i] if i < len(a) else fill\n        b_val = b[i] if i < len(b) else fill\n        result.append((a_val, b_val))\n    return result",
+        "expected": "<tests pass>",
+        "latency_ms": 29217.632,
+        "output_tokens": 906,
+        "category": "lists",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0105",
+        "correct": true,
+        "predicted": "def count_occurrences(items: list, value) -> int:\n    \"\"\"Count how many elements of *items* are equal to *value*.\n    \"\"\"\n    count = 0\n    for item in items:\n        if item == value:\n            count += 1\n    return count",
+        "expected": "<tests pass>",
+        "latency_ms": 8859.367,
+        "output_tokens": 273,
+        "category": "lists",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0106",
+        "correct": true,
+        "predicted": "def rank(numbers: list) -> list:\n    \"\"\"Return the competition rank of each number: the largest gets rank 1, equal values\n    share a rank, and the next distinct value skips the ranks that were used up\n    (10, 8, 8, 5 gives 1, 2, 2, 4).\"\"\"\n    n = len(numbers)\n    if n == 0:\n        return []\n    # Pair each number with its original index for stable ordering.\n    sorted_with_idx = sorted(enumerate(numbers), key=lambda x: x[1], reverse=True)\n    ranks = [0] * n\n    current_rank = 1\n    i = 0\n   ",
+        "expected": "<tests pass>",
+        "latency_ms": 63993.145,
+        "output_tokens": 1881,
+        "category": "lists",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0107",
+        "correct": true,
+        "predicted": "def deep_merge(a: dict, b: dict) -> dict:\n    \"\"\"Merge two nested dicts recursively and return a new dict. Where both sides hold a\n    dict the merge continues one level deeper; otherwise the value from *b* wins.\n    Neither input is modified.\"\"\"\n    result = {}\n    for key in set(a.keys()) | set(b.keys()):\n        if key not in a:\n            result[key] = b[key]\n        elif key not in b:\n            result[key] = a[key]\n        else:\n            val_a, val_b = a[key], b[key]\n            if is",
+        "expected": "<tests pass>",
+        "latency_ms": 117794.388,
+        "output_tokens": 3293,
+        "category": "dicts",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0108",
+        "correct": true,
+        "predicted": "def keys_with_value(mapping: dict, value) -> list:\n    \"\"\"Return the keys whose value equals *value*, sorted ascending.\n    \"\"\"\n    return sorted(k for k, v in mapping.items() if v == value)",
+        "expected": "<tests pass>",
+        "latency_ms": 14235.332,
+        "output_tokens": 406,
+        "category": "dicts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0109",
+        "correct": true,
+        "predicted": "def invert_multi(mapping: dict) -> dict:\n    \"\"\"Invert a dict, collecting the keys that share a value into a sorted list.\"\"\"\n    groups = {}\n    for key, val in mapping.items():\n        if val not in groups:\n            groups[val] = []\n        groups[val].append(key)\n    return {val: sorted(keys) for val, keys in groups.items()}",
+        "expected": "<tests pass>",
+        "latency_ms": 24159.166,
+        "output_tokens": 660,
+        "category": "dicts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0110",
+        "correct": true,
+        "predicted": "def average_of_top(numbers: list, k: int) -> float:\n    \"\"\"Return the mean of the *k* largest values. When *k* exceeds the length, average\n    everything. Raise ValueError when *k* is below 1 or the list is empty.\n    \"\"\"\n    if not numbers:\n        raise ValueError(\"list is empty\")\n    if k < 1:\n        raise ValueError(\"k must be at least 1\")\n    sorted_numbers = sorted(numbers, reverse=True)\n    top_k = sorted_numbers[:k]\n    return sum(top_k) / len(top_k)",
+        "expected": "<tests pass>",
+        "latency_ms": 22375.639,
+        "output_tokens": 607,
+        "category": "math",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0111",
+        "correct": true,
+        "predicted": "def prime_factors(n: int) -> list:\n    \"\"\"Return the prime factors of *n* in ascending order, repeating a factor as often as\n    it divides. prime_factors(1) is []. Raise ValueError for n below 1.\"\"\"\n    if n < 1:\n        raise ValueError(\"n must be at least 1\")\n    factors = []\n    i = 2\n    while i * i <= n:\n        while n % i == 0:\n            factors.append(i)\n            n //= i\n        i += 1\n    if n > 1:\n        factors.append(n)\n    return factors",
+        "expected": "<tests pass>",
+        "latency_ms": 21864.876,
+        "output_tokens": 584,
+        "category": "math",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0114",
+        "correct": true,
+        "predicted": "def deep_get_path(data, keys: list, default=None):\n    \"\"\"Walk a nested structure recursively following *keys*, returning *default* when a\n    step is missing or the current value is not a dict. An empty key list returns the\n    data itself.\n    \"\"\"\n    if not keys:\n        return data\n    if not isinstance(data, dict):\n        return default\n    first_key = keys[0]\n    if first_key not in data:\n        return default\n    return deep_get_path(data[first_key], keys[1:], default)",
+        "expected": "<tests pass>",
+        "latency_ms": 30541.082,
+        "output_tokens": 837,
+        "category": "recursion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0120",
+        "correct": true,
+        "predicted": "def first_matching(items: list, prefix: str):\n    \"\"\"Return the first string in *items* that starts with *prefix*, or None when there is\n    none. Non-string elements are skipped.\"\"\"\n    for item in items:\n        if isinstance(item, str) and item.startswith(prefix):\n            return item\n    return None",
+        "expected": "<tests pass>",
+        "latency_ms": 14699.893,
+        "output_tokens": 302,
+        "category": "edge_cases",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0124",
+        "correct": true,
+        "predicted": "def remove_evens(numbers):\n    \"\"\"Return *numbers* with every even value removed, keeping order.\"\"\"\n    filtered = [x for x in numbers if x % 2 != 0]\n    numbers[:] = filtered\n    return numbers",
+        "expected": "<tests pass>",
+        "latency_ms": 24634.882,
+        "output_tokens": 671,
+        "category": "bugfix",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0125",
+        "correct": false,
+        "predicted": "def starts_with_vowel(word):\n    \"\"\"Return True when *word* starts with a, e, i, o or u, ignoring case.\"\"\"\n    return word[0].lower() in 'aeiou'",
+        "expected": "<tests pass>",
+        "latency_ms": 11606.809,
+        "output_tokens": 182,
+        "category": "bugfix",
+        "difficulty": "easy"
+      },
+      {
+        "id": "code-0126",
+        "correct": true,
+        "predicted": "def percentage(part, whole):\n    \"\"\"Return part as a percentage of whole, or 0.0 when whole is 0.\"\"\"\n    if whole == 0:\n        return 0.0\n    return (part / whole) * 100",
+        "expected": "<tests pass>",
+        "latency_ms": 19252.194,
+        "output_tokens": 467,
+        "category": "bugfix",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0127",
+        "correct": true,
+        "predicted": "def last_element(items):\n    \"\"\"Return the last element, or None when the list is empty.\"\"\"\n    if not items:\n        return None\n    return items[len(items) - 1]",
+        "expected": "<tests pass>",
+        "latency_ms": 6899.361,
+        "output_tokens": 252,
+        "category": "bugfix",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0128",
+        "correct": true,
+        "predicted": "def merge_configs(defaults, overrides):\n    merged = defaults.copy()\n    merged.update(overrides)\n    return merged",
+        "expected": "<tests pass>",
+        "latency_ms": 9164.891,
+        "output_tokens": 319,
+        "category": "bugfix",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0129",
+        "correct": false,
+        "predicted": "def find_index(items, target):\n    \"\"\"Return the index of the first occurrence of *target*, or -1.\"\"\"\n    found = -1\n    for i, item in enumerate(items):\n        if item == target:\n            found = i\n    return found",
+        "expected": "<tests pass>",
+        "latency_ms": 4118.116,
+        "output_tokens": 143,
+        "category": "bugfix",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0130",
+        "correct": false,
+        "predicted": "import re\n\ndef title_case(text):\n    words = re.split(r'[-\\s]+', text)\n    return ' '.join(w.capitalize() for w in words if w)",
+        "expected": "<tests pass>",
+        "latency_ms": 45816.37,
+        "output_tokens": 1735,
+        "category": "bugfix",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0131",
+        "correct": true,
+        "predicted": "def running_max(numbers):\n    \"\"\"Return the running maximum: element i is max(numbers[0..i]).\"\"\"\n    if not numbers:\n        return []\n    out = [numbers[0]]\n    best = numbers[0]\n    for x in numbers[1:]:\n        best = max(best, x)\n        out.append(best)\n    return out",
+        "expected": "<tests pass>",
+        "latency_ms": 20193.879,
+        "output_tokens": 718,
+        "category": "bugfix",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0132",
+        "correct": true,
+        "predicted": "def dedupe(items):\n    \"\"\"Remove duplicates, keeping the first occurrence of each value in order.\"\"\"\n    seen = set()\n    result = []\n    for item in items:\n        if item not in seen:\n            seen.add(item)\n            result.append(item)\n    return result",
+        "expected": "<tests pass>",
+        "latency_ms": 9366.377,
+        "output_tokens": 327,
+        "category": "bugfix",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0133",
+        "correct": true,
+        "predicted": "def clamp_value(value, low, high):\n    \"\"\"Return *value* limited to [low, high].\"\"\"\n    return max(low, min(value, high))",
+        "expected": "<tests pass>",
+        "latency_ms": 8649.297,
+        "output_tokens": 314,
+        "category": "bugfix",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0134",
+        "correct": true,
+        "predicted": "def count_matches(items, predicate_value):\n    \"\"\"Count how many elements equal *predicate_value*.\"\"\"\n    total = 0\n    for item in items:\n        if item == predicate_value:\n            total += 1\n    return total",
+        "expected": "<tests pass>",
+        "latency_ms": 7119.331,
+        "output_tokens": 229,
+        "category": "bugfix",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0135",
+        "correct": true,
+        "predicted": "def chunk_list(items, size):\n    \"\"\"Split *items* into lists of at most *size* elements.\"\"\"\n    return [items[i:i + size] for i in range(0, len(items), size)]",
+        "expected": "<tests pass>",
+        "latency_ms": 9003.971,
+        "output_tokens": 297,
+        "category": "bugfix",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0136",
+        "correct": true,
+        "predicted": "def strip_prefix(text, prefix):\n    \"\"\"Remove *prefix* from the start of *text* if it is there, otherwise return *text*.\"\"\"\n    if text.startswith(prefix):\n        return text[len(prefix):]\n    return text",
+        "expected": "<tests pass>",
+        "latency_ms": 9026.497,
+        "output_tokens": 283,
+        "category": "bugfix",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0137",
+        "correct": true,
+        "predicted": "def sum_positive(numbers):\n    \"\"\"Add up every number greater than 0, skipping the rest.\"\"\"\n    total = 0\n    for x in numbers:\n        if x <= 0:\n            continue\n        total += x\n    return total",
+        "expected": "<tests pass>",
+        "latency_ms": 7470.973,
+        "output_tokens": 251,
+        "category": "bugfix",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0138",
+        "correct": true,
+        "predicted": "def get_setting(config, key, default=None):\n    \"\"\"Return config[key], or *default* only when the key is missing.\"\"\"\n    if key in config:\n        return config[key]\n    return default",
+        "expected": "<tests pass>",
+        "latency_ms": 15388.107,
+        "output_tokens": 530,
+        "category": "bugfix",
+        "difficulty": "medium"
+      },
+      {
+        "id": "code-0139",
+        "correct": true,
+        "predicted": "def is_sorted(numbers):\n    \"\"\"Return True when *numbers* is non-decreasing.\"\"\"\n    for i in range(len(numbers) - 1):\n        if numbers[i] > numbers[i + 1]:\n            return False\n    return True",
+        "expected": "<tests pass>",
+        "latency_ms": 13108.412,
+        "output_tokens": 476,
+        "category": "bugfix",
+        "difficulty": "hard"
+      },
+      {
+        "id": "code-0140",
+        "correct": true,
+        "predicted": "def word_lengths(text):\n    \"\"\"Return the length of every word, ignoring leading and trailing . , ! and ?\"\"\"\n    return [len(w.strip('.,?!')) for w in text.split()]",
+        "expected": "<tests pass>",
+        "latency_ms": 14859.615,
+        "output_tokens": 594,
+        "category": "bugfix",
+        "difficulty": "medium"
+      }
+    ]
+  },
+  "failures": [
+    {
+      "at": "request",
+      "count": 49,
+      "category": "http-4xx",
+      "message": "{\"error\":\"Error in iterating prediction stream: Exception: Encountered fatal exception in the backend scheduler: Traceback (most recent call last):\\n  File \\\"/Users/khaledbakeer/.lmstudio/extensions/backends/vendor/_amphibian/app-mlx-generate-mac14-arm64@34/lib/python3.11/site-packages/mlx_engine/model_kit/batched_model_kit.py\\\", line 265, in _generate_with_exception_handling\\n    self._generate()\\n  File \\\"/Users/khaledbakeer/.lmstudio/extensions/backends/vendor/_amphibian/app-mlx-generate-mac1",
+      "sample_request_id": "eval-00038"
+    },
+    {
+      "at": "request",
+      "count": 6,
+      "category": "http-5xx",
+      "message": "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Error</title>\n</head>\n<body>\n<pre>Internal Server Error</pre>\n</body>\n</html>",
+      "sample_request_id": "eval-00082"
+    }
+  ],
+  "gotchas": [
+    {
+      "severity": "warn",
+      "text": "55 of 140 eval items could not be scored and are excluded from both accuracy and scores.items."
+    },
+    {
+      "severity": "info",
+      "text": "LM Studio's 'lms load <key> --yes' is NOT idempotent: with the model already resident it loads a SECOND instance under the identifier '<key>:2' at the app defaults (8192 context, parallel 4) instead of reusing the running one. The atlas-bench lmstudio adapter calls exactly that on start, so driving it in serve mode silently measures a differently-configured second copy. Run it in attach mode (--base-url) and load the model yourself with the flags you intend to record."
+    },
+    {
+      "severity": "info",
+      "text": "The LM Studio model key is not the Hugging Face repo id and not the atlas model id: lmstudio-community/granite-4.2-3b-MLX-4bit is served as 'granite-4.2-3b-mlx'. That string is what belongs in model.served_model_id and in the OpenAI 'model' field, while model.id stays ibm-granite/granite-4.2-3b."
+    },
+    {
+      "severity": "info",
+      "text": "Granite 4.2's chat template sets enable_thinking to True when the caller does not pass it, so the LM Studio default is thinking ON. Any comparison against a no-think baseline has to pass chat_template_kwargs explicitly; these numbers are the thinking-enabled default."
+    },
+    {
+      "severity": "info",
+      "text": "Sustained sweeps on an M2 Max in a Mac Studio chassis thermally throttle, and long workloads late in a sweep are measured on a warmer machine than short ones early in it. The existing google/gemma-4-E2B-it cells on this same box carry the same thermal-throttle warning, which is a point in favour of comparing the two, not against it."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "5f41758c7993d77b9f8b337055e22f36c62bbcca65d4e792cfb1cbb04dbeb72a",
+    "payload_path": null,
+    "payload": {
+      "scorer": "code_exec",
+      "scorers_used": [
+        "code_exec"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:1234/v1",
+        "served_model_id": "granite-4.2-3b-mlx",
+        "advertised_models": [
+          "granite-4.2-3b-mlx",
+          "text-embedding-qwen.qwen3-embedding-0.6b",
+          "text-embedding-qwen.qwen3-embedding-4b",
+          "qwen.qwen3-reranker-0.6b",
+          "google/gemma-4-e2b",
+          "text-embedding-nomic-embed-text-v1.5"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-28T15:21:17Z",
+    "finished_at": "2026-08-28T15:31:33Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Mac Studio (Mac14,13) M2 Max 32 GB, macOS 26.5.2, ambient ~22 C. LM Studio 0.4.21 build +2 (CLI commit 71bd99c), MLX backend, attach mode: the model was loaded by hand with 'lms load granite-4.2-3b-mlx --yes --context-length 131072 --parallel 32' and the harness attached to the running server rather than loading it. The resident-model set was sampled immediately before and immediately after this workload and contained only granite-4.2-3b-mlx; LM Studio on this host listens on *:1234 and Khaled's Open WebUI points both its RAG embeddings and its task generation at that same endpoint, so a second model can JIT-load mid-run. Any workload where the before/after sets did not match exactly was discarded and re-run, and this file is from a clean pair. Otherwise resident: nothing. Desktop conditions: an idle Chrome with no window, up since 2026-08-24 and therefore also present during the existing google/gemma-4-E2B-it mlx-4bit runs on this same box, plus the Claude Code session driving the harness. No other GPU work, no compiles, no dev server. Thinking left at the Granite 4.2 chat-template default, which is enabled."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/lmstudio/ibm-granite/granite-4.2-3b/apple-m2-max-32gb/251c7884bb174170--eval-code-v1--243e50.json
+++ b/results/lmstudio/ibm-granite/granite-4.2-3b/apple-m2-max-32gb/251c7884bb174170--eval-code-v1--243e50.json
@@ -28,7 +28,7 @@
     "host": {
       "cpu": "Apple M2 Max",
       "cpu_cores": 12,
-      "ram_gb": 32.0,
+      "ram_gb": 32,
       "os": "macOS 26.5.2",
       "kernel": "25.5.0",
       "arch": "arm64"
@@ -64,7 +64,7 @@
       "items": 140,
       "concurrency": 4,
       "max_output_tokens": 4096,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -1082,7 +1082,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-28T15:21:17Z",
     "finished_at": "2026-08-28T15:31:33Z",
     "submitted_at": null,


### PR DESCRIPTION
### Cells filled

- **lmstudio 0.4.21** · `ibm-granite/granite-4.2-3b` / `mlx-4bit` · `apple-m2-max-32gb` · `eval-code-v1` — accuracy **0.9059** (77/85 correct)

Measured numbers in this run:

| metric | value |
| --- | --- |
| `success_rate` | 0.61 |
| `requests_total` | 140 |
| `requests_ok` | 85 |
| `requests_failed` | 55 |
| `duration_s` | 615.90 |
| `input_tokens_total` | 10,095 |
| `output_tokens_total` | 69,596 |
| `ram_peak_gb` | 29.28 |
| `scores.suite` | code |
| `scores.total` | 85 |
| `scores.correct` | 77 |
| `scores.accuracy` | 0.91 |
| `scores.success_rate` | 0.61 |

### Against the gemma-4-E2B-it cell on the same box

Same engine, same quantization family, same physical machine, so the two are directly comparable. `google/gemma-4-E2B-it` / `mlx-4bit` was measured here earlier.

| metric | granite-4.2-3b | gemma-4-E2B-it | delta |
| --- | --- | --- | --- |
| `accuracy` | 0.9059 | 0.9143 | -0.9% |

### What failed

- `failure` — {"error":"Error in iterating prediction stream: Exception: Encountered fatal exception in the backend scheduler: Traceback (most recent call last):\n  File \"/Users/khaledbakeer/.lmstudio/extensions/backends/vendor/_amphibian/app-mlx-generate-mac14-arm64@34/lib/python3.11/site-packages/mlx_engine/model_kit/batched_model_kit.py\", line 265, in _generate_with_exception_handling\n    self._generate()\n  File \"/Users/khaledbakeer/.lmstudio/extensions/backends/vendor/_amphibian/app-mlx-generate-mac1
- `failure` — <!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Internal Server Error</pre>
</body>
</html>

### Gotchas

- {'severity': 'warn', 'text': '55 of 140 eval items could not be scored and are excluded from both accuracy and scores.items.'}
- {'severity': 'info', 'text': "LM Studio's 'lms load <key> --yes' is NOT idempotent: with the model already resident it loads a SECOND instance under the identifier '<key>:2' at the app defaults (8192 context, parallel 4) instead of reusing the running one. The atlas-bench lmstudio adapter calls exactly that on start, so driving it in serve mode silently measures a differently-configured second copy. Run it in attach mode (--base-url) and load the model yourself with the flags you intend to record."}
- {'severity': 'info', 'text': "The LM Studio model key is not the Hugging Face repo id and not the atlas model id: lmstudio-community/granite-4.2-3b-MLX-4bit is served as 'granite-4.2-3b-mlx'. That string is what belongs in model.served_model_id and in the OpenAI 'model' field, while model.id stays ibm-granite/granite-4.2-3b."}
- {'severity': 'info', 'text': "Granite 4.2's chat template sets enable_thinking to True when the caller does not pass it, so the LM Studio default is thinking ON. Any comparison against a no-think baseline has to pass chat_template_kwargs explicitly; these numbers are the thinking-enabled default."}
- {'severity': 'info', 'text': 'Sustained sweeps on an M2 Max in a Mac Studio chassis thermally throttle, and long workloads late in a sweep are measured on a warmer machine than short ones early in it. The existing google/gemma-4-E2B-it cells on this same box carry the same thermal-throttle warning, which is a point in favour of comparing the two, not against it.'}

### Conditions

Mac Studio (Mac14,13) M2 Max 32 GB, macOS 26.5.2, ambient ~22 C. LM Studio 0.4.21 build +2 (CLI commit 71bd99c), MLX backend, attach mode: the model was loaded by hand with 'lms load granite-4.2-3b-mlx --yes --context-length 131072 --parallel 32' and the harness attached to the running server rather than loading it. The resident-model set was sampled immediately before and immediately after this workload and contained only granite-4.2-3b-mlx; LM Studio on this host listens on *:1234 and Khaled's Open WebUI points both its RAG embeddings and its task generation at that same endpoint, so a second model can JIT-load mid-run. Any workload where the before/after sets did not match exactly was discarded and re-run, and this file is from a clean pair. Otherwise resident: nothing. Desktop conditions: an idle Chrome with no window, up since 2026-08-24 and therefore also present during the existing google/gemma-4-E2B-it mlx-4bit runs on this same box, plus the Claude Code session driving the harness. No other GPU work, no compiles, no dev server. Thinking left at the Granite 4.2 chat-template default, which is enabled.

`pnpm validate --changed` and `pnpm format:check` both clean. Result file: `251c7884bb174170--eval-code-v1--243e50.json`.
