### PR TITLE
results: lmstudio 0.4.21 ibm-granite/granite-4.2-3b/mlx-4bit on apple-m2-max-32gb — eval-format-v1

### DIFF
--- a/results/lmstudio/ibm-granite/granite-4.2-3b/apple-m2-max-32gb/251c7884bb174170--eval-format-v1--0fd3a6.json
+++ b/results/lmstudio/ibm-granite/granite-4.2-3b/apple-m2-max-32gb/251c7884bb174170--eval-format-v1--0fd3a6.json
@@ -1,0 +1,519 @@
+{
+  "schema_version": 1,
+  "run_id": "251c7884bb174170--eval-format-v1--0fd3a6",
+  "config_id": "251c7884bb174170",
+  "cell_id": "492c433c3bf8",
+  "workload_id": "eval-format-v1",
+  "kind": "eval",
+  "engine": {
+    "id": "lmstudio",
+    "version": "0.4.21",
+    "commit": null,
+    "container": null,
+    "install_method": "app"
+  },
+  "model": {
+    "id": "ibm-granite/granite-4.2-3b",
+    "quant_id": "mlx-4bit",
+    "hf_id": "lmstudio-community/granite-4.2-3b-MLX-4bit",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "apple-m2-max-32gb",
+    "count": 1,
+    "driver": null,
+    "cuda": null,
+    "host": {
+      "cpu": "Apple M2 Max",
+      "cpu_cores": 12,
+      "ram_gb": 32.0,
+      "os": "macOS 26.5.2",
+      "kernel": "25.5.0",
+      "arch": "arm64"
+    },
+    "fingerprint": "sha256:f2cba40fa2bfa4473afbdc846b7ba69abe53fcb27fb4363b64aac1de5d17e03f",
+    "captured": {
+      "system_profiler": {
+        "_name": "hardware_overview",
+        "activation_lock_status": "activation_lock_enabled",
+        "boot_rom_version": "18000.121.3",
+        "chip_type": "Apple M2 Max",
+        "machine_model": "Mac14,13",
+        "machine_name": "Mac Studio",
+        "model_number": "MQH73D/A",
+        "number_processors": "proc 12:8:4:0",
+        "os_loader_version": "18000.121.3",
+        "physical_memory": "32 GB"
+      }
+    }
+  },
+  "args": {
+    "parallel": 32,
+    "context-length": 131072
+  },
+  "args_canonical": "@dtype=auto;@quant=mlx-4bit;context-length=131072;parallel=32",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-format-v1",
+    "resolved_params": {
+      "dataset_id": "eval-format-v1",
+      "suite": "format",
+      "scorer": "exact",
+      "items": 30,
+      "concurrency": 4,
+      "max_output_tokens": 256,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 30,
+    "requests_ok": 30,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 25.058,
+    "input_tokens_total": 963,
+    "output_tokens_total": 3395,
+    "e2e_ms": {
+      "mean": 3160.856,
+      "p50": 2580.253,
+      "p90": 5244.373,
+      "p95": 6226.426,
+      "p99": 6928.028,
+      "min": 1232.057,
+      "max": 7084.509
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 16.598,
+    "power_avg_w": null,
+    "power_peak_w": null,
+    "energy_wh": null,
+    "gpu_util_avg_pct": null,
+    "temp_max_c": null,
+    "thermal_throttle_detected": null
+  },
+  "scores": {
+    "suite": "format",
+    "total": 30,
+    "correct": 26,
+    "accuracy": 0.866667,
+    "success_rate": 1.0,
+    "by_category": {
+      "boolean": {
+        "total": 4,
+        "correct": 4
+      },
+      "number_only": {
+        "total": 8,
+        "correct": 6
+      },
+      "one_word": {
+        "total": 8,
+        "correct": 8
+      },
+      "pattern": {
+        "total": 3,
+        "correct": 2
+      },
+      "token": {
+        "total": 7,
+        "correct": 6
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 12,
+        "correct": 12
+      },
+      "hard": {
+        "total": 3,
+        "correct": 3
+      },
+      "medium": {
+        "total": 15,
+        "correct": 11
+      }
+    },
+    "avg_output_tokens": 113.17,
+    "avg_latency_ms": 3160.86,
+    "failures": 0,
+    "items": [
+      {
+        "id": "fmt-0001",
+        "correct": true,
+        "predicted": "42",
+        "expected": "42",
+        "latency_ms": 1232.057,
+        "output_tokens": 60,
+        "category": "number_only",
+        "difficulty": "easy"
+      },
+      {
+        "id": "fmt-0002",
+        "correct": true,
+        "predicted": "25",
+        "expected": "25",
+        "latency_ms": 2390.872,
+        "output_tokens": 64,
+        "category": "number_only",
+        "difficulty": "easy"
+      },
+      {
+        "id": "fmt-0003",
+        "correct": true,
+        "predicted": "8",
+        "expected": "8",
+        "latency_ms": 2605.459,
+        "output_tokens": 73,
+        "category": "number_only",
+        "difficulty": "easy"
+      },
+      {
+        "id": "fmt-0004",
+        "correct": true,
+        "predicted": "42",
+        "expected": "42",
+        "latency_ms": 3347.232,
+        "output_tokens": 99,
+        "category": "number_only",
+        "difficulty": "easy"
+      },
+      {
+        "id": "fmt-0005",
+        "correct": false,
+        "predicted": "10",
+        "expected": "9",
+        "latency_ms": 4269.979,
+        "output_tokens": 151,
+        "category": "number_only",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0006",
+        "correct": true,
+        "predicted": "30",
+        "expected": "30",
+        "latency_ms": 2263.38,
+        "output_tokens": 70,
+        "category": "number_only",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0007",
+        "correct": false,
+        "predicted": "",
+        "expected": "13",
+        "latency_ms": 6544.919,
+        "output_tokens": 255,
+        "category": "number_only",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0008",
+        "correct": true,
+        "predicted": "150",
+        "expected": "150",
+        "latency_ms": 4815.065,
+        "output_tokens": 171,
+        "category": "number_only",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0009",
+        "correct": true,
+        "predicted": "OK",
+        "expected": "OK",
+        "latency_ms": 1581.653,
+        "output_tokens": 49,
+        "category": "one_word",
+        "difficulty": "easy"
+      },
+      {
+        "id": "fmt-0010",
+        "correct": true,
+        "predicted": "Tokyo",
+        "expected": "Tokyo",
+        "latency_ms": 1697.852,
+        "output_tokens": 42,
+        "category": "one_word",
+        "difficulty": "easy"
+      },
+      {
+        "id": "fmt-0011",
+        "correct": true,
+        "predicted": "green",
+        "expected": "green",
+        "latency_ms": 3320.393,
+        "output_tokens": 111,
+        "category": "one_word",
+        "difficulty": "easy"
+      },
+      {
+        "id": "fmt-0012",
+        "correct": true,
+        "predicted": "cold",
+        "expected": "cold",
+        "latency_ms": 1997.486,
+        "output_tokens": 60,
+        "category": "one_word",
+        "difficulty": "easy"
+      },
+      {
+        "id": "fmt-0013",
+        "correct": true,
+        "predicted": "mice",
+        "expected": "mice",
+        "latency_ms": 2136.707,
+        "output_tokens": 51,
+        "category": "one_word",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0014",
+        "correct": true,
+        "predicted": "salta",
+        "expected": "salta",
+        "latency_ms": 3037.468,
+        "output_tokens": 105,
+        "category": "one_word",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0015",
+        "correct": true,
+        "predicted": "jumps",
+        "expected": "jumps",
+        "latency_ms": 5178.508,
+        "output_tokens": 200,
+        "category": "one_word",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0016",
+        "correct": true,
+        "predicted": "inf",
+        "expected": "inf",
+        "latency_ms": 2224.376,
+        "output_tokens": 71,
+        "category": "one_word",
+        "difficulty": "hard"
+      },
+      {
+        "id": "fmt-0017",
+        "correct": true,
+        "predicted": "Fe",
+        "expected": "Fe",
+        "latency_ms": 1655.062,
+        "output_tokens": 59,
+        "category": "token",
+        "difficulty": "easy"
+      },
+      {
+        "id": "fmt-0018",
+        "correct": true,
+        "predicted": "DE",
+        "expected": "DE",
+        "latency_ms": 2364.516,
+        "output_tokens": 87,
+        "category": "token",
+        "difficulty": "easy"
+      },
+      {
+        "id": "fmt-0019",
+        "correct": true,
+        "predicted": "ja",
+        "expected": "ja",
+        "latency_ms": 2555.046,
+        "output_tokens": 85,
+        "category": "token",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0020",
+        "correct": true,
+        "predicted": "s",
+        "expected": "s",
+        "latency_ms": 1963.26,
+        "output_tokens": 56,
+        "category": "token",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0021",
+        "correct": false,
+        "predicted": "",
+        "expected": "ff",
+        "latency_ms": 7084.509,
+        "output_tokens": 255,
+        "category": "token",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0022",
+        "correct": true,
+        "predicted": "IX",
+        "expected": "IX",
+        "latency_ms": 3297.278,
+        "output_tokens": 105,
+        "category": "token",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0023",
+        "correct": true,
+        "predicted": "l",
+        "expected": "l",
+        "latency_ms": 3080.589,
+        "output_tokens": 103,
+        "category": "token",
+        "difficulty": "hard"
+      },
+      {
+        "id": "fmt-0024",
+        "correct": true,
+        "predicted": "yes",
+        "expected": "yes",
+        "latency_ms": 5837.157,
+        "output_tokens": 211,
+        "category": "boolean",
+        "difficulty": "easy"
+      },
+      {
+        "id": "fmt-0025",
+        "correct": true,
+        "predicted": "true",
+        "expected": "true",
+        "latency_ms": 1765.051,
+        "output_tokens": 55,
+        "category": "boolean",
+        "difficulty": "easy"
+      },
+      {
+        "id": "fmt-0026",
+        "correct": true,
+        "predicted": "yes",
+        "expected": "yes",
+        "latency_ms": 2079.234,
+        "output_tokens": 62,
+        "category": "boolean",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0027",
+        "correct": true,
+        "predicted": "false",
+        "expected": "false",
+        "latency_ms": 2924.24,
+        "output_tokens": 109,
+        "category": "boolean",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0028",
+        "correct": true,
+        "predicted": "2026-03-01",
+        "expected": "2026-03-01",
+        "latency_ms": 5151.324,
+        "output_tokens": 255,
+        "category": "pattern",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0029",
+        "correct": false,
+        "predicted": "",
+        "expected": "00:15",
+        "latency_ms": 4710.478,
+        "output_tokens": 255,
+        "category": "pattern",
+        "difficulty": "medium"
+      },
+      {
+        "id": "fmt-0030",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1714.521,
+        "output_tokens": 66,
+        "category": "pattern",
+        "difficulty": "hard"
+      }
+    ]
+  },
+  "failures": [],
+  "gotchas": [
+    {
+      "severity": "info",
+      "text": "LM Studio's 'lms load <key> --yes' is NOT idempotent: with the model already resident it loads a SECOND instance under the identifier '<key>:2' at the app defaults (8192 context, parallel 4) instead of reusing the running one. The atlas-bench lmstudio adapter calls exactly that on start, so driving it in serve mode silently measures a differently-configured second copy. Run it in attach mode (--base-url) and load the model yourself with the flags you intend to record."
+    },
+    {
+      "severity": "info",
+      "text": "The LM Studio model key is not the Hugging Face repo id and not the atlas model id: lmstudio-community/granite-4.2-3b-MLX-4bit is served as 'granite-4.2-3b-mlx'. That string is what belongs in model.served_model_id and in the OpenAI 'model' field, while model.id stays ibm-granite/granite-4.2-3b."
+    },
+    {
+      "severity": "info",
+      "text": "Granite 4.2's chat template sets enable_thinking to True when the caller does not pass it, so the LM Studio default is thinking ON. Any comparison against a no-think baseline has to pass chat_template_kwargs explicitly; these numbers are the thinking-enabled default."
+    },
+    {
+      "severity": "info",
+      "text": "Sustained sweeps on an M2 Max in a Mac Studio chassis thermally throttle, and long workloads late in a sweep are measured on a warmer machine than short ones early in it. The existing google/gemma-4-E2B-it cells on this same box carry the same thermal-throttle warning, which is a point in favour of comparing the two, not against it."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "30dc2e40aabd6ce3385b537363b179a471d5babe620cdb5250d62bfc8e2d2d1f",
+    "payload_path": null,
+    "payload": {
+      "scorer": "exact",
+      "scorers_used": [
+        "exact"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:1234/v1",
+        "served_model_id": "granite-4.2-3b-mlx",
+        "advertised_models": [
+          "granite-4.2-3b-mlx",
+          "text-embedding-qwen.qwen3-embedding-0.6b",
+          "text-embedding-qwen.qwen3-embedding-4b",
+          "qwen.qwen3-reranker-0.6b",
+          "google/gemma-4-e2b",
+          "text-embedding-nomic-embed-text-v1.5"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-28T15:33:10Z",
+    "finished_at": "2026-08-28T15:33:35Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Box was NOT dedicated: also running Khaled's desktop session (an idle Chrome with no window, up since 2026-08-24) and the Claude Code session driving the harness. No other GPU work, no compiles, and no dev server. Mac Studio (Mac14,13) M2 Max 32 GB, macOS 26.5.2, ambient ~22 C. LM Studio 0.4.21 build +2 (CLI commit 71bd99c), MLX backend, attach mode: the model was loaded by hand with 'lms load granite-4.2-3b-mlx --yes --context-length 131072 --parallel 32' and the harness attached to the running server rather than loading it. Isolation check: the resident-model set was sampled immediately before and immediately after this workload and contained only granite-4.2-3b-mlx. LM Studio on this host listens on *:1234 and Khaled's Open WebUI points both its RAG embeddings and its task generation at that same endpoint, so a second model can JIT-load mid-run; any workload whose before/after sets did not match exactly was discarded and re-run, and this file is from a clean pair. Thinking left at the Granite 4.2 chat-template default, which is enabled. The idle Chrome was also present during the existing google/gemma-4-E2B-it mlx-4bit runs on this same box, which is a point in favour of comparing the two rather than against it."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/lmstudio/ibm-granite/granite-4.2-3b/apple-m2-max-32gb/251c7884bb174170--eval-format-v1--0fd3a6.json
+++ b/results/lmstudio/ibm-granite/granite-4.2-3b/apple-m2-max-32gb/251c7884bb174170--eval-format-v1--0fd3a6.json
@@ -28,7 +28,7 @@
     "host": {
       "cpu": "Apple M2 Max",
       "cpu_cores": 12,
-      "ram_gb": 32.0,
+      "ram_gb": 32,
       "os": "macOS 26.5.2",
       "kernel": "25.5.0",
       "arch": "arm64"
@@ -64,7 +64,7 @@
       "items": 30,
       "concurrency": 4,
       "max_output_tokens": 256,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -77,7 +77,7 @@
     "requests_total": 30,
     "requests_ok": 30,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 25.058,
     "input_tokens_total": 963,
     "output_tokens_total": 3395,
@@ -104,7 +104,7 @@
     "total": 30,
     "correct": 26,
     "accuracy": 0.866667,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "boolean": {
         "total": 4,
@@ -501,7 +501,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-28T15:33:10Z",
     "finished_at": "2026-08-28T15:33:35Z",
     "submitted_at": null,


### PR DESCRIPTION
### Cells filled

- **lmstudio 0.4.21** · `ibm-granite/granite-4.2-3b` / `mlx-4bit` · `apple-m2-max-32gb` · `eval-format-v1` — accuracy **0.8667** (26/30 correct)

Measured numbers in this run:

| metric | value |
| --- | --- |
| `success_rate` | 1.00 |
| `requests_total` | 30 |
| `requests_ok` | 30 |
| `requests_failed` | 0 |
| `duration_s` | 25.06 |
| `input_tokens_total` | 963 |
| `output_tokens_total` | 3,395 |
| `ram_peak_gb` | 16.60 |
| `scores.suite` | format |
| `scores.total` | 30 |
| `scores.correct` | 26 |
| `scores.accuracy` | 0.87 |
| `scores.success_rate` | 1.00 |

### Against the gemma-4-E2B-it cell on the same box

Same engine, same quantization family, same physical machine, so the two are directly comparable. `google/gemma-4-E2B-it` / `mlx-4bit` was measured here earlier.

| metric | granite-4.2-3b | gemma-4-E2B-it | delta |
| --- | --- | --- | --- |
| `accuracy` | 0.8667 | 0.8667 | +0.0% |

### What failed

Nothing failed. 30 of 30 requests succeeded, success rate 1.0.

### Gotchas

- {'severity': 'info', 'text': "LM Studio's 'lms load <key> --yes' is NOT idempotent: with the model already resident it loads a SECOND instance under the identifier '<key>:2' at the app defaults (8192 context, parallel 4) instead of reusing the running one. The atlas-bench lmstudio adapter calls exactly that on start, so driving it in serve mode silently measures a differently-configured second copy. Run it in attach mode (--base-url) and load the model yourself with the flags you intend to record."}
- {'severity': 'info', 'text': "The LM Studio model key is not the Hugging Face repo id and not the atlas model id: lmstudio-community/granite-4.2-3b-MLX-4bit is served as 'granite-4.2-3b-mlx'. That string is what belongs in model.served_model_id and in the OpenAI 'model' field, while model.id stays ibm-granite/granite-4.2-3b."}
- {'severity': 'info', 'text': "Granite 4.2's chat template sets enable_thinking to True when the caller does not pass it, so the LM Studio default is thinking ON. Any comparison against a no-think baseline has to pass chat_template_kwargs explicitly; these numbers are the thinking-enabled default."}
- {'severity': 'info', 'text': 'Sustained sweeps on an M2 Max in a Mac Studio chassis thermally throttle, and long workloads late in a sweep are measured on a warmer machine than short ones early in it. The existing google/gemma-4-E2B-it cells on this same box carry the same thermal-throttle warning, which is a point in favour of comparing the two, not against it.'}

### Conditions

Box was NOT dedicated: also running Khaled's desktop session (an idle Chrome with no window, up since 2026-08-24) and the Claude Code session driving the harness. No other GPU work, no compiles, and no dev server. Mac Studio (Mac14,13) M2 Max 32 GB, macOS 26.5.2, ambient ~22 C. LM Studio 0.4.21 build +2 (CLI commit 71bd99c), MLX backend, attach mode: the model was loaded by hand with 'lms load granite-4.2-3b-mlx --yes --context-length 131072 --parallel 32' and the harness attached to the running server rather than loading it. Isolation check: the resident-model set was sampled immediately before and immediately after this workload and contained only granite-4.2-3b-mlx. LM Studio on this host listens on *:1234 and Khaled's Open WebUI points both its RAG embeddings and its task generation at that same endpoint, so a second model can JIT-load mid-run; any workload whose before/after sets did not match exactly was discarded and re-run, and this file is from a clean pair. Thinking left at the Granite 4.2 chat-template default, which is enabled. The idle Chrome was also present during the existing google/gemma-4-E2B-it mlx-4bit runs on this same box, which is a point in favour of comparing the two rather than against it.

`pnpm validate --changed` and `pnpm format:check` both clean. Result file: `251c7884bb174170--eval-format-v1--0fd3a6.json`.
