### PR TITLE
feat: let a result say what else was on the box, and say when it does not know

### DIFF
--- a/app/src/components/ui.ts
+++ b/app/src/components/ui.ts
@@ -2,7 +2,13 @@
 import { html, nothing, render, svg, type TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import type { CoverageLevel, Distribution, VerificationLevel, WorkloadKind } from '@atlas/core';
+import type {
+  CoverageLevel,
+  Distribution,
+  ResolvedConditions,
+  VerificationLevel,
+  WorkloadKind,
+} from '@atlas/core';
 import { href, modelHref } from '../router.js';
 import { store } from '../store.js';
 import { copyText } from '../util/clipboard.js';
@@ -53,6 +59,52 @@ export function evBadge(level: CoverageLevel, label?: string): TemplateResult {
 
 export function verifBadge(level: VerificationLevel | string): TemplateResult {
   return html`<span class="verif ${level}">${level}</span>`;
+}
+
+/**
+ * Run-conditions tag. Deliberately neutral: in this app colour means evidence, and a shared
+ * box is a fact about a run, not a defect. The asserted detail rides in the title; what was
+ * MEASURED (vs asserted) is rendered separately by `condMeasured`.
+ */
+export function condTag(c: ResolvedConditions): TemplateResult {
+  if (c.dedicated === null)
+    return html`<span
+      class="tag"
+      title="This run did not record conditions in a machine-readable form. The run's notes are the only record."
+      >conditions not recorded</span
+    >`;
+  return c.dedicated
+    ? html`<span
+        class="tag"
+        title=${c.detail ? `Box was dedicated: ${c.detail}` : 'Box was dedicated'}
+        >${icon('box')} dedicated box</span
+      >`
+    : html`<span
+        class="tag"
+        title=${c.detail ? `Box was not dedicated: ${c.detail}` : 'Box was not dedicated'}
+        >${icon('users')} shared box</span
+      >`;
+}
+
+/** Whether isolation was measured or only asserted — the distinction the vocabulary draws. */
+export function condMeasured(c: ResolvedConditions): TemplateResult | typeof nothing {
+  if (c.isolationCheck)
+    return html`<div
+      class="xs muted"
+      style="margin-top:2px"
+      title=${`Isolation check: ${c.isolationCheck}`}
+    >
+      isolation measured
+    </div>`;
+  if (c.dedicated !== null)
+    return html`<div
+      class="xs muted"
+      style="margin-top:2px"
+      title="The contributor stated the conditions; no isolation check was recorded as measured."
+    >
+      asserted, not measured
+    </div>`;
+  return nothing;
 }
 
 export function kindTag(kind: WorkloadKind | string): TemplateResult {

--- a/app/src/views/compare-view.ts
+++ b/app/src/views/compare-view.ts
@@ -1,6 +1,6 @@
 import { html, nothing, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import type { ResultRecord } from '@atlas/core';
+import { conditionsComparability, resolveConditions, type ResultRecord } from '@atlas/core';
 import '../components/chart.js';
 import '../components/run-picker.js';
 import { icon } from '../components/icons.js';
@@ -11,6 +11,8 @@ import {
   type SweepMetric,
 } from '../components/sweep-chart.js';
 import {
+  condMeasured,
+  condTag,
   deltaTag,
   emptyState,
   hbar,
@@ -125,11 +127,45 @@ export class AtlasCompareView extends ViewElement {
           : loading
             ? skeletonLines(6)
             : html`${missing.length ? html`<div class="callout warn mb-3">${missing.length} run id${missing.length === 1 ? '' : 's'} could not be loaded: ${missing.join(', ')}</div>` : nothing}
+              ${recs.length > 1 ? this.conditionsNote(recs) : nothing}
               ${recs.length ? this.table(recs) : nothing}
               ${recs.length ? this.metrics(recs) : nothing}
               ${recs.some((r) => r.sweep?.length) ? this.sweeps(recs) : nothing}
               ${recs.some((r) => r.scores) ? this.evals(recs) : nothing}`
       }
+    </div>`;
+  }
+
+  /**
+   * Two cells can both be honestly recorded and still not be comparable. This note is the
+   * atlas saying so — it states what is known about each run's conditions and stops there.
+   * It never ranks the runs and never declares one invalid.
+   */
+  private conditionsNote(recs: ResultRecord[]): TemplateResult | typeof nothing {
+    const resolved = recs.map((r) => resolveConditions(r));
+    const verdict = conditionsComparability(resolved);
+    if (verdict === 'uniform') return nothing;
+    const known = resolved.filter((c) => c.dedicated !== null).length;
+    if (verdict === 'mixed') {
+      const ded = resolved.filter((c) => c.dedicated === true).length;
+      const shared = resolved.filter((c) => c.dedicated === false).length;
+      return html`<div class="callout mb-3">
+        <strong>These runs were measured under different conditions.</strong> ${ded} ran on a
+        dedicated box, ${shared} on a box that was not. A gap between their numbers can reflect
+        conditions as much as configuration — the conditions row below shows what each run recorded,
+        and whether its isolation was measured or only asserted.
+      </div>`;
+    }
+    if (verdict === 'partial') {
+      return html`<div class="callout mb-3">
+        <strong>Run conditions are recorded for ${known} of ${recs.length} runs.</strong> For the
+        others, the run's notes are the only record of what else was on the box — read them before
+        reading the deltas.
+      </div>`;
+    }
+    return html`<div class="callout mb-3">
+      <strong>None of these runs recorded machine-readable conditions.</strong> Whether each box was
+      dedicated lives only in the runs' notes — open a run to read them before reading the deltas.
     </div>`;
   }
 
@@ -199,6 +235,13 @@ export class AtlasCompareView extends ViewElement {
             <tr>
               <td class="muted xs">verification</td>
               ${recs.map((r) => html`<td>${verifBadge(r.verification.level)}</td>`)}
+            </tr>
+            <tr>
+              <td class="muted xs">conditions</td>
+              ${recs.map((r) => {
+                const c = resolveConditions(r);
+                return html`<td>${condTag(c)}${condMeasured(c)}</td>`;
+              })}
             </tr>
             <tr>
               <td class="muted xs">config_id</td>

--- a/app/src/views/conditions-surface.test.ts
+++ b/app/src/views/conditions-surface.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Two cells can both be honestly recorded and still not be comparable — the compare view
+ * must say so. These tests pin the three surfaces: the conditions row, the comparability
+ * note, and the canonical-prose fallback for results that predate the structured field.
+ * They also pin what the view must NOT do: rank, hide, or warn-shame either run.
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { ResultRecord } from '@atlas/core';
+import { fixtureRegistry } from '../data/fixture.js';
+import { parseHash, route } from '../router.js';
+import { store } from '../store.js';
+
+import './compare-view.js';
+
+function makeRun(
+  runId: string,
+  extra: Partial<ResultRecord> & { notes?: string | null } = {},
+): ResultRecord {
+  const { notes = null, ...rest } = extra;
+  return {
+    schema_version: 1,
+    run_id: runId,
+    config_id: runId.slice(0, 16),
+    cell_id: runId.slice(0, 12),
+    workload_id: 'serve-test-c2-v1',
+    kind: 'serving',
+    engine: { id: 'vllm', version: '0.27.1' },
+    model: { id: 'acme/test-model-1b', quant_id: 'fp8' },
+    hardware: { id: 'test-gpu-24gb', count: 1 },
+    args: { 'max-model-len': 32768 },
+    args_canonical: '@dtype=auto;max-model-len=32768',
+    metrics: null,
+    provenance: {
+      github_login: 'tester',
+      started_at: '2026-08-27T10:00:00Z',
+      method: 'atlas-bench',
+      notes,
+    },
+    verification: { level: 'self-reported' },
+    ...rest,
+  } as ResultRecord;
+}
+
+const runs = new Map<string, ResultRecord>();
+
+beforeAll(() => {
+  store.registry.value = fixtureRegistry();
+  store.index.value = [];
+  store.run = (row: { run_id: string }) => Promise.resolve(runs.get(row.run_id) ?? null);
+});
+
+async function mountCompare(ids: string[]): Promise<HTMLElement> {
+  route.value = parseHash(`#/compare?runs=${ids.join(',')}`);
+  const el = document.createElement('atlas-compare-view') as HTMLElement & {
+    updateComplete: Promise<unknown>;
+  };
+  document.body.appendChild(el);
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 0));
+  await el.updateComplete;
+  return el;
+}
+
+function textOf(el: HTMLElement): string {
+  const text = el.textContent ?? '';
+  el.remove();
+  return text;
+}
+
+describe('compare view — run conditions', () => {
+  it('says so when two honestly-recorded runs were measured under different conditions', async () => {
+    runs.set(
+      'aaaaaaaaaaaaaaaa--serve-test-c2-v1--000001',
+      makeRun('aaaaaaaaaaaaaaaa--serve-test-c2-v1--000001', {
+        conditions: {
+          dedicated: true,
+          detail: 'SSH tunnel stopped for the duration',
+          isolation_check: 'GPU compute-app list sampled before each workload',
+        },
+      }),
+    );
+    runs.set(
+      'bbbbbbbbbbbbbbbb--serve-test-c2-v1--000002',
+      makeRun('bbbbbbbbbbbbbbbb--serve-test-c2-v1--000002', {
+        conditions: {
+          dedicated: false,
+          detail: 'shared LM Studio endpoint reachable by other services',
+          isolation_check: null,
+        },
+      }),
+    );
+    const text = textOf(
+      await mountCompare([
+        'aaaaaaaaaaaaaaaa--serve-test-c2-v1--000001',
+        'bbbbbbbbbbbbbbbb--serve-test-c2-v1--000002',
+      ]),
+    );
+    expect(text).toContain('measured under different conditions');
+    expect(text).toContain('dedicated box');
+    expect(text).toContain('shared box');
+    // asserted vs measured stays distinct
+    expect(text).toContain('isolation measured');
+    expect(text).toContain('asserted, not measured');
+    // never a verdict on which run to trust: the note explains, it does not disqualify
+    expect(text.toLowerCase()).not.toContain('invalid');
+    expect(text.toLowerCase()).not.toContain('do not compare');
+  });
+
+  it('reads the canonical prose vocabulary for runs that predate the structured field', async () => {
+    runs.set(
+      'cccccccccccccccc--serve-test-c2-v1--000003',
+      makeRun('cccccccccccccccc--serve-test-c2-v1--000003', {
+        notes:
+          'Box was NOT dedicated: idle Chrome and an agent session. Isolation check: resident-model set sampled before and after every workload.',
+      }),
+    );
+    runs.set(
+      'dddddddddddddddd--serve-test-c2-v1--000004',
+      makeRun('dddddddddddddddd--serve-test-c2-v1--000004', {
+        notes: 'Box WAS dedicated: nothing else on the machine.',
+      }),
+    );
+    const text = textOf(
+      await mountCompare([
+        'cccccccccccccccc--serve-test-c2-v1--000003',
+        'dddddddddddddddd--serve-test-c2-v1--000004',
+      ]),
+    );
+    expect(text).toContain('measured under different conditions');
+    expect(text).toContain('shared box');
+    expect(text).toContain('dedicated box');
+  });
+
+  it('is honest about legacy results: unrecorded, not guessed', async () => {
+    runs.set(
+      'eeeeeeeeeeeeeeee--serve-test-c2-v1--000005',
+      makeRun('eeeeeeeeeeeeeeee--serve-test-c2-v1--000005', {
+        notes: 'Mac Studio M2 Max 32GB, desktop session active (not a clean idle box).',
+      }),
+    );
+    runs.set(
+      'ffffffffffffffff--serve-test-c2-v1--000006',
+      makeRun('ffffffffffffffff--serve-test-c2-v1--000006', {
+        notes: 'The machine was fully isolated for the run.',
+      }),
+    );
+    const text = textOf(
+      await mountCompare([
+        'eeeeeeeeeeeeeeee--serve-test-c2-v1--000005',
+        'ffffffffffffffff--serve-test-c2-v1--000006',
+      ]),
+    );
+    expect(text).toContain('conditions not recorded');
+    expect(text).toContain('None of these runs recorded machine-readable conditions');
+    // free prose is never classified
+    expect(text).not.toContain('shared box');
+    expect(text).not.toContain('dedicated box');
+  });
+
+  it('stays quiet when conditions are known and agree', async () => {
+    for (const id of [
+      '1111111111111111--serve-test-c2-v1--000007',
+      '2222222222222222--serve-test-c2-v1--000008',
+    ]) {
+      runs.set(
+        id,
+        makeRun(id, { conditions: { dedicated: true, detail: null, isolation_check: null } }),
+      );
+    }
+    const text = textOf(
+      await mountCompare([
+        '1111111111111111--serve-test-c2-v1--000007',
+        '2222222222222222--serve-test-c2-v1--000008',
+      ]),
+    );
+    expect(text).toContain('dedicated box');
+    expect(text).not.toContain('measured under different conditions');
+    expect(text).not.toContain('machine-readable');
+  });
+});

--- a/app/src/views/run-view.ts
+++ b/app/src/views/run-view.ts
@@ -1,6 +1,6 @@
 import { html, nothing, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { renderServeCommand } from '@atlas/core';
+import { renderServeCommand, resolveConditions } from '@atlas/core';
 import type { EngineVersion, ResultRecord, SweepAxis, SweepPoint } from '@atlas/core';
 import { addButton } from '../components/add-modal.js';
 import '../components/chart.js';
@@ -19,6 +19,8 @@ import {
 } from '../components/sweep-chart.js';
 import {
   codeBlock,
+  condMeasured,
+  condTag,
   copyBtn,
   deltaTag,
   emptyState,
@@ -274,6 +276,13 @@ export class AtlasRunView extends ViewElement {
                     'user id',
                     prov.github_user_id ?? html`<span class="faint">resolved by CI</span>`,
                   ],
+                  (() => {
+                    const c = resolveConditions(rec);
+                    return ['conditions', html`${condTag(c)}${condMeasured(c)}`] as [
+                      string,
+                      unknown,
+                    ];
+                  })(),
                 ])}
               </div>
             </div>

--- a/bench/atlas_bench/cli.py
+++ b/bench/atlas_bench/cli.py
@@ -32,7 +32,7 @@ from .registry import Registry
 from .repo import find_repo_root, write_json
 from .result import ResultInputs, build_result, output_path, resolve_login
 from .runner import run_spec_sync
-from .spec import load_spec
+from .spec import RunConditions, load_spec
 from .submit import submit as do_submit
 from .validate import check_model_registry, validate_file
 from .workloads import resolve_workload
@@ -50,6 +50,23 @@ error_console = Console(stderr=True)
 def _registry(repo: Path | None) -> Registry:
     """Registry rooted at ``--repo``/``--registry-dir`` or the discovered checkout."""
     return Registry(repo)
+
+
+def _conditions_option(
+    dedicated: bool | None, detail: str | None, isolation_check: str | None
+) -> RunConditions | None:
+    """Build the ``conditions`` record from CLI flags.
+
+    ``--dedicated``/``--not-dedicated`` is the anchor: detail and the isolation check only
+    mean something relative to it, so passing them alone is an error rather than a guess.
+    """
+    if dedicated is None:
+        if detail or isolation_check:
+            raise typer.BadParameter(
+                "--conditions-detail/--isolation-check need --dedicated or --not-dedicated"
+            )
+        return None
+    return RunConditions(dedicated=dedicated, detail=detail, isolation_check=isolation_check)
 
 
 def _parse_kv(pairs: list[str]) -> dict[str, Any]:
@@ -201,6 +218,18 @@ def run(
     registry_dir: Path | None = typer.Option(None, "--registry-dir", "--repo"),
     login: str | None = typer.Option(None, "--login", help="GitHub login for provenance."),
     notes: str | None = typer.Option(None, "--notes", help="provenance.notes for this run."),
+    dedicated: bool | None = typer.Option(
+        None,
+        "--dedicated/--not-dedicated",
+        help="Run conditions: was the box dedicated to this run? Falls back to the packet's "
+        "`conditions`; omitted entirely when neither is given.",
+    ),
+    conditions_detail: str | None = typer.Option(
+        None, "--conditions-detail", help="What else was resident or reachable (asserted)."
+    ),
+    isolation_check: str | None = typer.Option(
+        None, "--isolation-check", help="What was MEASURED about isolation, not just asserted."
+    ),
     gotcha: list[str] = typer.Option([], "--gotcha", help="Add a gotcha (repeatable)."),
     telemetry: bool = typer.Option(True, "--telemetry/--no-telemetry"),
     tokenizer: str | None = typer.Option(
@@ -211,6 +240,7 @@ def run(
     spec = load_spec(spec_path)
     if tokenizer:
         spec.tokenizer = tokenizer
+    conditions = _conditions_option(dedicated, conditions_detail, isolation_check)
     registry = _registry(registry_dir)
     resolved_login = resolve_login(login or spec.github_login)
     if not resolved_login and not dry_run:
@@ -230,6 +260,7 @@ def run(
         telemetry=telemetry,
         gotchas=list(gotcha),
         notes=notes,
+        conditions=conditions,
     )
 
     if dry_run:
@@ -453,6 +484,9 @@ def wrap(
     registry_dir: Path | None = typer.Option(None, "--registry-dir", "--repo"),
     login: str | None = typer.Option(None, "--login"),
     notes: str | None = typer.Option(None, "--notes"),
+    dedicated: bool | None = typer.Option(None, "--dedicated/--not-dedicated"),
+    conditions_detail: str | None = typer.Option(None, "--conditions-detail"),
+    isolation_check: str | None = typer.Option(None, "--isolation-check"),
 ) -> None:
     """Wrap ``vllm bench serve`` / SGLang ``bench_serving`` output into a result file."""
     spec = load_spec(spec_path)
@@ -508,6 +542,7 @@ def wrap(
             finished_at=utc_now(),
             serve_command=adapter.serve_command(),
             notes=notes,
+            conditions=_conditions_option(dedicated, conditions_detail, isolation_check),
         )
     )
     path = output_path(record, out)

--- a/bench/atlas_bench/result.py
+++ b/bench/atlas_bench/result.py
@@ -23,7 +23,7 @@ from .hwinfo import HostInfo, fingerprint
 from .ids import cell_id, config_id_from_canonical, result_path, run_id
 from .plausibility import active_weight_gb
 from .registry import Registry
-from .spec import TaskSpec
+from .spec import RunConditions, TaskSpec
 from .workloads.base import WorkloadOutcome
 
 __all__ = [
@@ -64,6 +64,8 @@ class ResultInputs:
     attached: bool = False
     extra_gotchas: list[str] = field(default_factory=list)
     notes: str | None = None
+    #: Run conditions: dedicated-or-not is asserted, ``isolation_check`` is measured.
+    conditions: RunConditions | None = None
     warnings: list[str] = field(default_factory=list)
 
 
@@ -357,6 +359,8 @@ def build_result(inputs: ResultInputs) -> dict[str, Any]:
     if outcome.scores is not None:
         record["scores"] = outcome.scores
     record["failures"] = outcome.failures
+    conditions = inputs.conditions or spec.conditions
+    record["conditions"] = conditions.record_dict() if conditions else None
     record["gotchas"] = auto_gotchas(inputs, metrics)
     record["derived"] = derived_metrics(
         metrics, hardware_record, model_record, quant, spec.hardware.count

--- a/bench/atlas_bench/runner.py
+++ b/bench/atlas_bench/runner.py
@@ -21,7 +21,7 @@ from .engines.base import AttachAdapter, EngineAdapter, get_adapter
 from .registry import Registry
 from .repo import write_json
 from .result import ResultInputs, build_result, output_path
-from .spec import TaskSpec
+from .spec import RunConditions, TaskSpec
 from .telemetry import TelemetrySampler
 from .workloads import RunContext, get_runner, resolve_workload
 
@@ -140,6 +140,7 @@ async def run_spec(
     telemetry: bool = True,
     gotchas: list[str] | None = None,
     notes: str | None = None,
+    conditions: RunConditions | None = None,
     transport: httpx.AsyncBaseTransport | None = None,
     adapter: EngineAdapter | None = None,
     host: hwinfo.HostInfo | None = None,
@@ -208,6 +209,7 @@ async def run_spec(
                     attached=attached,
                     extra_gotchas=list(gotchas or []),
                     notes=notes,
+                    conditions=conditions,
                     warnings=list(output.warnings),
                 )
             )

--- a/bench/atlas_bench/spec.py
+++ b/bench/atlas_bench/spec.py
@@ -21,6 +21,7 @@ __all__ = [
     "InstallSpec",
     "ModelRef",
     "RequestOptions",
+    "RunConditions",
     "TaskSpec",
     "WorkloadRef",
     "load_spec",
@@ -131,6 +132,23 @@ class RequestOptions(_Base):
     api_key: str | None = None
 
 
+class RunConditions(_Base):
+    """Run conditions (result schema ``conditions``): what else could have contended for the
+    box. ``dedicated`` + ``detail`` are asserted; ``isolation_check`` is what was MEASURED."""
+
+    dedicated: bool
+    detail: str | None = None
+    isolation_check: str | None = None
+
+    def record_dict(self) -> dict[str, bool | str | None]:
+        """Exactly the three schema fields — never any extra packet keys."""
+        return {
+            "dedicated": self.dedicated,
+            "detail": self.detail,
+            "isolation_check": self.isolation_check,
+        }
+
+
 class TaskSpec(_Base):
     """A full task packet."""
 
@@ -149,6 +167,7 @@ class TaskSpec(_Base):
     pr_title: str | None = None
     agent_rules: list[str] = Field(default_factory=list)
     notes: str | None = None
+    conditions: RunConditions | None = None
     github_login: str | None = None
     tokenizer: str | None = None
 
@@ -187,6 +206,7 @@ class TaskSpec(_Base):
             "pr_title",
             "agent_rules",
             "notes",
+            "conditions",
         ]
         ordered = {k: data[k] for k in order if k in data}
         ordered.update({k: v for k, v in data.items() if k not in ordered})

--- a/bench/tests/test_result.py
+++ b/bench/tests/test_result.py
@@ -1,4 +1,4 @@
-"""Result assembly: payload bounding, derived metrics, gotchas, provenance and paths."""
+"""Result assembly: payload bounding, derived metrics, gotchas, conditions, provenance, paths."""
 
 from __future__ import annotations
 
@@ -18,6 +18,7 @@ from atlas_bench.result import (
     output_path,
     resolve_login,
 )
+from atlas_bench.spec import RunConditions
 from atlas_bench.workloads.base import WorkloadOutcome
 from tests.test_run_e2e import host, make_spec
 
@@ -207,3 +208,38 @@ def test_derived_metrics_scales_registered_figures_by_hardware_count() -> None:
         derived_metrics(metrics, hardware, model, quant)["bandwidth_efficiency"]
         == (one["bandwidth_efficiency"])
     )
+
+
+def test_conditions_from_inputs(atlas_repo: Path) -> None:
+    """Structured run conditions land in the record, asserted and measured kept distinct."""
+    record = build_result(
+        inputs(
+            atlas_repo,
+            WorkloadOutcome(kind="serving"),
+            conditions=RunConditions(
+                dedicated=False,
+                detail="shared LM Studio endpoint reachable by other services",
+                isolation_check="resident-model set sampled before and after every workload",
+            ),
+        )
+    )
+    assert record["conditions"] == {
+        "dedicated": False,
+        "detail": "shared LM Studio endpoint reachable by other services",
+        "isolation_check": "resident-model set sampled before and after every workload",
+    }
+
+
+def test_conditions_fall_back_to_the_packet(atlas_repo: Path) -> None:
+    """A packet can carry conditions, like it carries notes."""
+    made = inputs(atlas_repo, WorkloadOutcome(kind="serving"))
+    made.spec = make_spec(conditions={"dedicated": True, "extra_key": "kept in the packet"})
+    record = build_result(made)
+    # Exactly the three schema fields: packet extras never leak into the CC-BY record.
+    assert record["conditions"] == {"dedicated": True, "detail": None, "isolation_check": None}
+
+
+def test_conditions_absent_stays_null(atlas_repo: Path) -> None:
+    """No conditions given: the field is null, never invented."""
+    record = build_result(inputs(atlas_repo, WorkloadOutcome(kind="serving")))
+    assert record["conditions"] is None

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -360,6 +360,11 @@ Eval rows: `{ "id", "category", "difficulty", "prompt"|"messages", "answer", "sc
   },
   "failures": [ { "at": "request", "count": 3, "category": "timeout|oom|context-overflow|http-5xx|http-4xx|malformed-output|refusal|other",
                   "message": "…", "sample_request_id": "…" } ],
+  "conditions": {                                             // optional; null/absent on results recorded before it existed
+    "dedicated": false,                                        // ASSERTED: nothing else was using the box's compute
+    "detail": "shared LM Studio endpoint reachable by other services; idle Chrome; agent session driving the harness",
+    "isolation_check": "resident-model set sampled before and after every workload; contaminated runs discarded"  // what was MEASURED, as opposed to asserted; null = nothing measured
+  },
   "gotchas": [ { "severity": "info|warn|blocker", "text": "Prefix caching defaults OFF for hybrid models; pass --enable-prefix-caching explicitly." } ],
   "derived": { "cost_per_1m_output_tokens_usd": null, "tokens_per_watt": 25.8, "tok_s_per_gb_bandwidth": 0.32 },
   "raw": { "harness": "atlas-bench", "harness_version": "0.1.0", "sha256": "…", "payload_path": null, "payload": { /* bounded <=100KB */ } },
@@ -377,6 +382,14 @@ Eval rows: `{ "id", "category", "difficulty", "prompt"|"messages", "answer", "sc
 
 Bounded: any `raw.payload` above 100 KB must be truncated with `raw.truncated: true` (keep the
 aggregates). Per-item eval results keep at most `predicted` truncated to 500 chars.
+
+`conditions` records run conditions — a property of the run, like ambient temperature, never
+an identifier for the machine. Two honestly-recorded results can differ in nothing but their
+conditions, and the compare view uses this field to say so; it never ranks runs by it.
+Results from before the field existed carry `null`; for those, the canonical prose in
+`provenance.notes` (`Box WAS dedicated: ...` / `Box was NOT dedicated: ...` /
+`Isolation check: ...`) is parsed as a fallback, and anything older resolves to
+"not recorded" rather than a guess.
 
 ## 5. Ownership & provenance enforcement (validate.yml + `tools/validate`)
 

--- a/packages/core/src/conditions.test.ts
+++ b/packages/core/src/conditions.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { conditionsComparability, resolveConditions } from './conditions.js';
+import type { ResolvedConditions } from './conditions.js';
+import type { RunConditions } from './types.js';
+
+const rec = (notes: string | null, conditions?: RunConditions | null) => ({
+  conditions,
+  provenance: { notes },
+});
+
+describe('resolveConditions — structured field', () => {
+  it('is authoritative when present, even over canonical prose', () => {
+    const r = resolveConditions(
+      rec('Box was NOT dedicated: prose says shared.', {
+        dedicated: true,
+        detail: 'SSH tunnel stopped for the duration',
+        isolation_check: 'GPU compute-app list sampled before each workload',
+      }),
+    );
+    expect(r).toEqual({
+      dedicated: true,
+      detail: 'SSH tunnel stopped for the duration',
+      isolationCheck: 'GPU compute-app list sampled before each workload',
+      source: 'structured',
+    });
+  });
+
+  it('keeps asserted and measured distinct: a check may be absent', () => {
+    const r = resolveConditions(rec(null, { dedicated: false }));
+    expect(r.dedicated).toBe(false);
+    expect(r.detail).toBeNull();
+    expect(r.isolationCheck).toBeNull();
+    expect(r.source).toBe('structured');
+  });
+});
+
+describe('resolveConditions — canonical prose vocabulary', () => {
+  it('parses a dedicated opener', () => {
+    const r = resolveConditions(
+      rec(
+        'Box WAS dedicated: nothing else on the machine, reverse-proxy tunnel stopped. Ambient ~22C.',
+      ),
+    );
+    expect(r.dedicated).toBe(true);
+    expect(r.detail).toBe('nothing else on the machine, reverse-proxy tunnel stopped');
+    expect(r.isolationCheck).toBeNull();
+    expect(r.source).toBe('notes');
+  });
+
+  it('parses a not-dedicated opener with an isolation check sentence', () => {
+    const r = resolveConditions(
+      rec(
+        'Box was NOT dedicated: idle Chrome, a Claude Code session, and a shared LM Studio endpoint reachable by other services. Isolation check: resident-model set sampled before and after every workload; contaminated runs discarded. Ambient ~22C.',
+      ),
+    );
+    expect(r.dedicated).toBe(false);
+    expect(r.detail).toBe(
+      'idle Chrome, a Claude Code session, and a shared LM Studio endpoint reachable by other services',
+    );
+    expect(r.isolationCheck).toBe(
+      'resident-model set sampled before and after every workload; contaminated runs discarded',
+    );
+    expect(r.source).toBe('notes');
+  });
+
+  it('parses an isolation check that follows immediately, before any other sentence', () => {
+    const r = resolveConditions(
+      rec(
+        'Box WAS dedicated: nothing else ran. Isolation check: nvidia-smi compute-apps empty before each workload.',
+      ),
+    );
+    expect(r.detail).toBe('nothing else ran');
+    expect(r.isolationCheck).toBe('nvidia-smi compute-apps empty before each workload');
+  });
+
+  it('requires the opener at the start of the notes', () => {
+    const r = resolveConditions(
+      rec('Ambient ~22C. Box WAS dedicated: this is not the opening sentence.'),
+    );
+    expect(r.dedicated).toBeNull();
+    expect(r.source).toBe('none');
+  });
+
+  it('an isolation check without an opener still surfaces the measurement', () => {
+    const r = resolveConditions(
+      rec('Isolation check: resident-model set compared before/after; clean pair.'),
+    );
+    expect(r.dedicated).toBeNull();
+    expect(r.isolationCheck).toBe('resident-model set compared before/after; clean pair');
+    expect(r.source).toBe('notes');
+  });
+});
+
+describe('resolveConditions — everything older is honestly unknown', () => {
+  it('never guesses from free prose', () => {
+    const r = resolveConditions(
+      rec(
+        'Mac Studio M2 Max 32GB, desktop session active (browser + dev tools running, not a clean idle box). The machine was fully isolated for the run.',
+      ),
+    );
+    expect(r).toEqual({ dedicated: null, detail: null, isolationCheck: null, source: 'none' });
+  });
+
+  it('handles null and empty notes', () => {
+    expect(resolveConditions(rec(null)).source).toBe('none');
+    expect(resolveConditions(rec('')).source).toBe('none');
+  });
+});
+
+describe('conditionsComparability', () => {
+  const c = (dedicated: boolean | null): ResolvedConditions => ({
+    dedicated,
+    detail: null,
+    isolationCheck: null,
+    source: dedicated === null ? 'none' : 'structured',
+  });
+
+  it('classifies a known difference as mixed', () => {
+    expect(conditionsComparability([c(true), c(false)])).toBe('mixed');
+  });
+  it('classifies agreement as uniform', () => {
+    expect(conditionsComparability([c(true), c(true)])).toBe('uniform');
+    expect(conditionsComparability([c(false), c(false)])).toBe('uniform');
+  });
+  it('classifies known-vs-unknown as partial', () => {
+    expect(conditionsComparability([c(true), c(null)])).toBe('partial');
+  });
+  it('classifies all-unknown as unrecorded', () => {
+    expect(conditionsComparability([c(null), c(null)])).toBe('unrecorded');
+    expect(conditionsComparability([])).toBe('unrecorded');
+  });
+});

--- a/packages/core/src/conditions.ts
+++ b/packages/core/src/conditions.ts
@@ -1,0 +1,120 @@
+/**
+ * Run conditions — were two honestly-recorded results measured under comparable conditions?
+ *
+ * A result can carry conditions in two places:
+ *
+ * 1. `conditions` (structured, authoritative when present): `dedicated` + `detail` are what
+ *    the contributor ASSERTS about the box, `isolation_check` is what was MEASURED about
+ *    isolation. The two are deliberately distinct and stay distinct here.
+ * 2. The canonical prose vocabulary in `provenance.notes`: notes that open with
+ *    `Box WAS dedicated: ...` or `Box was NOT dedicated: ...` and carry a labelled
+ *    `Isolation check: ...` sentence. Results written before the structured field existed
+ *    use only this form.
+ *
+ * Everything older than the canonical vocabulary resolves to `dedicated: null` — "not
+ * recorded" is a true statement about those files, and the full prose stays one click away
+ * on the run page. This module never guesses from free prose: a wrong derived flag would be
+ * worse than an honest unknown.
+ */
+import type { Provenance, RunConditions } from './types.js';
+
+export type ConditionsSource = 'structured' | 'notes' | 'none';
+
+export interface ResolvedConditions {
+  /** `null` means the run did not record conditions in any machine-readable form. */
+  dedicated: boolean | null;
+  /** The asserted conditions beyond the flag itself (what else was resident/reachable). */
+  detail: string | null;
+  /** What was MEASURED about isolation, as opposed to asserted. `null` = nothing measured. */
+  isolationCheck: string | null;
+  source: ConditionsSource;
+}
+
+/**
+ * How comparable a set of runs is on the conditions axis.
+ *
+ * - `uniform`: every run recorded conditions and they agree.
+ * - `mixed`: at least one dedicated box and one shared box — a known difference.
+ * - `partial`: some runs recorded conditions, some did not.
+ * - `unrecorded`: no run recorded conditions.
+ */
+export type Comparability = 'uniform' | 'mixed' | 'partial' | 'unrecorded';
+
+const OPENER = /^box\s+was\s+(not\s+)?dedicated:\s*/i;
+const ISOLATION_LABEL = /isolation\s+check:\s*/i;
+
+/**
+ * End of the sentence starting at `from`: the first `.` followed by whitespace and an
+ * upper-case/paren/digit start, or the end of the text. Good enough for the canonical
+ * vocabulary; a mid-sentence abbreviation may truncate the captured detail, never extend it.
+ */
+function sentenceEnd(text: string, from: number): number {
+  const rest = text.slice(from);
+  const m = /\.(?=\s+[A-Z0-9("'])/.exec(rest);
+  return m ? from + m.index + 1 : text.length;
+}
+
+function parseNotes(notes: string): Omit<ResolvedConditions, 'source'> | null {
+  const trimmed = notes.trim();
+  const opener = OPENER.exec(trimmed);
+  const iso = ISOLATION_LABEL.exec(trimmed);
+  if (!opener && !iso) return null;
+
+  let dedicated: boolean | null = null;
+  let detail: string | null = null;
+  if (opener) {
+    dedicated = !opener[1];
+    const start = opener[0].length;
+    let end = sentenceEnd(trimmed, start);
+    if (iso && iso.index > start && iso.index < end) end = iso.index;
+    const text = trimmed.slice(start, end).trim().replace(/\.$/, '');
+    detail = text || null;
+  }
+
+  let isolationCheck: string | null = null;
+  if (iso) {
+    const start = iso.index + iso[0].length;
+    const end = sentenceEnd(trimmed, start);
+    const text = trimmed.slice(start, end).trim().replace(/\.$/, '');
+    isolationCheck = text || null;
+  }
+
+  return { dedicated, detail, isolationCheck };
+}
+
+/**
+ * Resolve a run's conditions: the structured `conditions` field when present, else the
+ * canonical prose vocabulary in `provenance.notes`, else unknown.
+ */
+export function resolveConditions(rec: {
+  conditions?: RunConditions | null;
+  provenance: Pick<Provenance, 'notes'>;
+}): ResolvedConditions {
+  if (rec.conditions) {
+    return {
+      dedicated: rec.conditions.dedicated,
+      detail: rec.conditions.detail ?? null,
+      isolationCheck: rec.conditions.isolation_check ?? null,
+      source: 'structured',
+    };
+  }
+  const notes = rec.provenance.notes;
+  if (typeof notes === 'string' && notes) {
+    const parsed = parseNotes(notes);
+    if (parsed) return { ...parsed, source: 'notes' };
+  }
+  return { dedicated: null, detail: null, isolationCheck: null, source: 'none' };
+}
+
+/**
+ * Classify a set of resolved conditions for a side-by-side comparison. Says how much the
+ * conditions axis is known — never which run is better.
+ */
+export function conditionsComparability(list: ResolvedConditions[]): Comparability {
+  const known = list.filter((c) => c.dedicated !== null);
+  if (known.length === 0) return 'unrecorded';
+  if (known.length < list.length) return 'partial';
+  const dedicated = known.some((c) => c.dedicated === true);
+  const shared = known.some((c) => c.dedicated === false);
+  return dedicated && shared ? 'mixed' : 'uniform';
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,8 @@ export {
   tokensPerForwardPass,
 } from './plausibility.js';
 export type { PlausibilityIssue, PlausibilityInput } from './plausibility.js';
+export { resolveConditions, conditionsComparability } from './conditions.js';
+export type { ResolvedConditions, ConditionsSource, Comparability } from './conditions.js';
 export { computeScores } from './scoring.js';
 export type { ScoringInput, ScoringOutput, ScoredRun, RegistryCredits } from './scoring.js';
 export { computeCoverage, emptyCell, minorsBehind } from './coverage.js';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -407,6 +407,17 @@ export interface Gotcha {
   link?: string | null;
 }
 
+/**
+ * Run conditions: what else could have contended for the box while this was measured.
+ * `dedicated` + `detail` record what the contributor ASSERTS about the box; `isolation_check`
+ * records what was MEASURED about isolation. The two are deliberately separate.
+ */
+export interface RunConditions {
+  dedicated: boolean;
+  detail?: string | null;
+  isolation_check?: string | null;
+}
+
 export interface Provenance {
   github_login: string;
   github_user_id?: number | null;
@@ -472,6 +483,7 @@ export interface ResultRecord {
   sweep?: SweepPoint[] | null;
   scores?: Scores | null;
   failures?: Failure[];
+  conditions?: RunConditions | null;
   gotchas?: Gotcha[];
   derived?: {
     cost_per_1m_output_tokens_usd?: number | null;

--- a/schemas/result.schema.json
+++ b/schemas/result.schema.json
@@ -259,6 +259,31 @@
         }
       }
     },
+    "conditions": {
+      "description": "Run conditions: what else could have contended for the box while this was measured. A property of the run, like ambient temperature — never an identifier for the machine. Absent (or null) on results recorded before this field existed; for those, the canonical prose in provenance.notes (\"Box WAS dedicated: ...\" / \"Box was NOT dedicated: ...\" / \"Isolation check: ...\") is the only record.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["dedicated"],
+          "properties": {
+            "dedicated": {
+              "type": "boolean",
+              "description": "Asserted by the contributor: nothing else was using the box's compute for the duration of this run."
+            },
+            "detail": {
+              "$ref": "#/$defs/nstr",
+              "description": "The rest of the assertion: what else was resident, reachable, or shut off — the prose after \"Box WAS/was NOT dedicated:\"."
+            },
+            "isolation_check": {
+              "$ref": "#/$defs/nstr",
+              "description": "What was MEASURED about isolation, as opposed to asserted: the check that ran and what it compared (e.g. GPU compute-app list sampled before each workload; resident-model set compared before/after). Null when nothing was measured."
+            }
+          }
+        },
+        { "type": "null" }
+      ]
+    },
     "gotchas": {
       "type": "array",
       "description": "The knowledge that usually evaporates: what you had to know to make this work.",


### PR DESCRIPTION
> Two cells can both be honestly recorded and still not be comparable, and the atlas has no way to say so.

That framing came from a contributor benchmarking on a different machine, and it is a stronger claim than "the compare view doesn't show provenance" — which is why it needed more than a display fix.

### The case that produced it

Happening in this repository right now, two sets of results landing within the hour:

- one measured on a **dedicated DGX Spark** — nothing else on the box, the external tunnel stopped for the duration, the GPU compute-app list sampled before each workload;
- one measured on an **Apple M2 Max that is also somebody's desktop** — an idle browser, the harness's own session, and a shared LM Studio instance other services can send inbound requests to at any moment.

Both honestly recorded. Both appear as rows. A reader comparing them saw two numbers and nothing about the difference that most plausibly explains a gap.

### Where conditions belong

Run conditions are a property of **the run**, so they go in the result record: an optional `conditions` object of `dedicated`, `detail`, `isolation_check`.

That shape is deliberate. `dedicated` and `detail` are what the contributor **asserts**; `isolation_check` is what was **measured**. Flattening those into one badge would lose the distinction that makes the claim worth anything — "nothing else was running" and "I checked that nothing else was running" are not the same statement, and this repository learned that the hard way today.

No enum of check methods. Sampling `nvidia-smi` compute-apps, diffing a resident-model set, and stopping a tunnel are not the same kind of check, and an enum now would be premature.

**This is a different kind of field from the machine-local model key rejected earlier today.** That described *somebody's machine* in a *shared registry file*. This describes *the run*, in the *contributor's own result file*, alongside host info and ambient temperature. The precedent supports the placement rather than arguing against it, and the schema description says so.

### What happens to the ~164 results that predate the field

They resolve through the canonical prose already in `provenance.notes` — the exact openers `Box WAS dedicated:` / `Box was NOT dedicated:` / `Isolation check:`, start-of-notes only, nothing fuzzier. Everything older resolves to **"not recorded"**, and the compare view says that out loud rather than leaving a blank.

**Nothing is backfilled and nothing is inferred.** Deriving conditions from `verification.flags`, gotcha severities or metric presence was considered and rejected: it is empirically empty today — nothing structurally distinguishes the two machines above — and a heuristic over free prose would eventually assert something a contributor never said. In a dataset whose whole premise is trust, a wrong derived flag is worse than an honest unknown.

### It stays a coverage map

Colour in this app means evidence, so `dedicated box` and `shared box` are **neutral tags** rather than green and orange; the comparability note is the **info** callout, not the warning one; and the copy says a gap can reflect conditions as much as configuration without ranking the runs, disqualifying data, or naming a contributor. A test pins that the view never says "invalid".

### Also

`--dedicated` / `--not-dedicated`, `--conditions-detail` and `--isolation-check` on `atlas-bench run` and `wrap`; passing a detail or a check without the anchor flag is an error rather than a silent half-record. `docs/SPEC.md` gains the field and its semantics.

### Checks

`pnpm test` 367 passed / 1 skipped (32 files) · `typecheck` · `lint` · `format:check` · `validate` **0 errors, 110 warnings identical to the pre-change baseline** · `pytest` 456 passed / 3 skipped. Verified visually in both themes and at 390 px.

Backward compatibility confirmed: `conditions` is optional and nullable, and all existing results validate unchanged.

### Not done here

No backfill of legacy results — re-recording is each owner's call. No conditions column in the index views; the compare view was the stated problem. No enum of check methods until there are several contributors' checks to generalise from.

One pre-existing quirk noticed but not fixed: a run whose `args` carry a very long value (the vLLM `compilation-config` JSON) stretches the compare table into horizontal scroll and pushes the second run's meta cells off-screen. Predates this change and deserves its own fix — truncate long values with expand-on-click.
