### PR TITLE
results: Qwen/Qwen3.8-Flash-Next on nvidia-gb10-dgx-spark — eval-vision-v1

### DIFF
--- a/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/cb516ca371e97893--eval-vision-v1--b4c733.json
+++ b/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/cb516ca371e97893--eval-vision-v1--b4c733.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -103,7 +103,7 @@
       "items": 60,
       "concurrency": 4,
       "max_output_tokens": 2048,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -116,7 +116,7 @@
     "requests_total": 60,
     "requests_ok": 60,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 232.978,
     "input_tokens_total": 10624,
     "output_tokens_total": 17224,
@@ -135,7 +135,7 @@
     "power_peak_w": 44.99,
     "energy_wh": 2.5091,
     "gpu_util_avg_pct": 91.53,
-    "temp_max_c": 65.0,
+    "temp_max_c": 65,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -143,7 +143,7 @@
     "total": 60,
     "correct": 58,
     "accuracy": 0.966667,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "arrows": {
         "total": 8,
@@ -851,7 +851,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-28T19:53:02Z",
     "finished_at": "2026-08-28T19:56:55Z",
     "submitted_at": null,

--- a/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/cb516ca371e97893--eval-vision-v1--b4c733.json
+++ b/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/cb516ca371e97893--eval-vision-v1--b4c733.json
@@ -1,0 +1,869 @@
+{
+  "schema_version": 1,
+  "run_id": "cb516ca371e97893--eval-vision-v1--b4c733",
+  "config_id": "cb516ca371e97893",
+  "cell_id": "146e5bfec676",
+  "workload_id": "eval-vision-v1",
+  "kind": "eval",
+  "engine": {
+    "id": "vllm",
+    "version": "0.1.dev20073+g8e685d198",
+    "commit": "8e685d198",
+    "container": "qwen38-flash-dgx (built from blazux/qwen3.8-Flash-DGX at 82ed48d)",
+    "install_method": "docker"
+  },
+  "model": {
+    "id": "Qwen/Qwen3.8-Flash-Next",
+    "quant_id": "nvfp4",
+    "hf_id": "Qwen/Qwen3.8-Flash-Next",
+    "revision": "7b719225242aacd3dbd3f9407468c2ee9a9d2594",
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "load-format": "safetensors",
+    "max-model-len": 262144,
+    "max-num-seqs": 64,
+    "gpu-memory-utilization": 0.85,
+    "enable-prefix-caching": false,
+    "enable-chunked-prefill": true,
+    "max-num-batched-tokens": 8192,
+    "compilation-config": {
+      "cudagraph_mode": "PIECEWISE",
+      "splitting_ops": [
+        "vllm::unified_attention_with_output",
+        "vllm::unified_mla_attention_with_output",
+        "vllm::mamba_mixer2",
+        "vllm::mamba_mixer",
+        "vllm::short_conv",
+        "vllm::qwen3_8_flash_next_ple_short_conv",
+        "vllm::qwen3_8_flash_next_qsa_with_output",
+        "vllm::linear_attention",
+        "vllm::qwen_gdn_attention_core",
+        "vllm::qwen_gdn_attention_core_fused_norm_packed",
+        "vllm::sparse_attn_indexer",
+        "vllm::ple_mmap_lookup"
+      ]
+    },
+    "enable-flashinfer-autotune": false,
+    "enable-auto-tool-choice": true,
+    "tool-call-parser": "qwen3_coder",
+    "reasoning-parser": "qwen3",
+    "speculative-config": {
+      "method": "mtp",
+      "num_speculative_tokens": 3
+    },
+    "vllm-ple-mmap": 1,
+    "vllm-ple-mmap-workers": 32,
+    "vllm-ple-mmap-prewarm": 1,
+    "vllm-use-flashinfer-sampler": 1
+  },
+  "args_canonical": "@dtype=auto;@quant=nvfp4;compilation-config={\"cudagraph_mode\":\"PIECEWISE\",\"splitting_ops\":[\"vllm::linear_attention\",\"vllm::mamba_mixer\",\"vllm::mamba_mixer2\",\"vllm::ple_mmap_lookup\",\"vllm::qwen3_8_flash_next_ple_short_conv\",\"vllm::qwen3_8_flash_next_qsa_with_output\",\"vllm::qwen_gdn_attention_core\",\"vllm::qwen_gdn_attention_core_fused_norm_packed\",\"vllm::short_conv\",\"vllm::sparse_attn_indexer\",\"vllm::unified_attention_with_output\",\"vllm::unified_mla_attention_with_output\"]};enable-auto-tool-choice=true;enable-chunked-prefill=true;enable-flashinfer-autotune=false;enable-prefix-caching=false;gpu-memory-utilization=0.85;load-format=safetensors;max-model-len=262144;max-num-batched-tokens=8192;max-num-seqs=64;reasoning-parser=qwen3;speculative-config={\"method\":\"mtp\",\"num_speculative_tokens\":3};tool-call-parser=qwen3_coder;vllm-ple-mmap=1;vllm-ple-mmap-prewarm=1;vllm-ple-mmap-workers=32;vllm-use-flashinfer-sampler=1",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-vision-v1",
+    "resolved_params": {
+      "dataset_id": "eval-vision-v1",
+      "suite": "vision",
+      "scorer": "vision",
+      "items": 60,
+      "concurrency": 4,
+      "max_output_tokens": 2048,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 60,
+    "requests_ok": 60,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 232.978,
+    "input_tokens_total": 10624,
+    "output_tokens_total": 17224,
+    "e2e_ms": {
+      "mean": 15221.121,
+      "p50": 9112.808,
+      "p90": 30933.89,
+      "p95": 60642.208,
+      "p99": 108861.567,
+      "min": 3135.74,
+      "max": 119034.057
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 111.592,
+    "power_avg_w": 38.84,
+    "power_peak_w": 44.99,
+    "energy_wh": 2.5091,
+    "gpu_util_avg_pct": 91.53,
+    "temp_max_c": 65.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "vision",
+    "total": 60,
+    "correct": 58,
+    "accuracy": 0.966667,
+    "success_rate": 1.0,
+    "by_category": {
+      "arrows": {
+        "total": 8,
+        "correct": 8
+      },
+      "chart": {
+        "total": 10,
+        "correct": 10
+      },
+      "clock": {
+        "total": 8,
+        "correct": 7
+      },
+      "dice": {
+        "total": 6,
+        "correct": 6
+      },
+      "grid": {
+        "total": 6,
+        "correct": 6
+      },
+      "ocr": {
+        "total": 10,
+        "correct": 10
+      },
+      "shapes": {
+        "total": 12,
+        "correct": 11
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 38,
+        "correct": 38
+      },
+      "hard": {
+        "total": 8,
+        "correct": 7
+      },
+      "medium": {
+        "total": 14,
+        "correct": 13
+      }
+    },
+    "avg_output_tokens": 287.07,
+    "avg_latency_ms": 15221.12,
+    "failures": 0,
+    "items": [
+      {
+        "id": "vis-0001",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 5771.008,
+        "output_tokens": 103,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0002",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 12024.315,
+        "output_tokens": 214,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0003",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 9595.906,
+        "output_tokens": 184,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0004",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 8222.443,
+        "output_tokens": 143,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0005",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 4419.294,
+        "output_tokens": 81,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0006",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 10563.295,
+        "output_tokens": 211,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0007",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 8414.22,
+        "output_tokens": 165,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0008",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 9347.09,
+        "output_tokens": 171,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0009",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 11949.307,
+        "output_tokens": 222,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0010",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 7413.593,
+        "output_tokens": 149,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0011",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 8169.321,
+        "output_tokens": 142,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0012",
+        "correct": false,
+        "predicted": "",
+        "expected": "bottom-right",
+        "latency_ms": 119034.057,
+        "output_tokens": 2048,
+        "category": "shapes",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0013",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 4238.098,
+        "output_tokens": 61,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0014",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 16314.961,
+        "output_tokens": 282,
+        "category": "chart",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0015",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 7325.436,
+        "output_tokens": 128,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0016",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 12442.748,
+        "output_tokens": 239,
+        "category": "chart",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0017",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 15913.494,
+        "output_tokens": 272,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0018",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 10620.733,
+        "output_tokens": 208,
+        "category": "chart",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0019",
+        "correct": true,
+        "predicted": "No",
+        "expected": "no",
+        "latency_ms": 11228.037,
+        "output_tokens": 221,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0020",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 7879.914,
+        "output_tokens": 138,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0021",
+        "correct": true,
+        "predicted": "yes",
+        "expected": "yes",
+        "latency_ms": 9186.256,
+        "output_tokens": 183,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0022",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 7887.323,
+        "output_tokens": 151,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0023",
+        "correct": true,
+        "predicted": "104170",
+        "expected": "104170",
+        "latency_ms": 3766.752,
+        "output_tokens": 67,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0024",
+        "correct": true,
+        "predicted": "A32-9207",
+        "expected": "A32-9207",
+        "latency_ms": 3721.212,
+        "output_tokens": 54,
+        "category": "ocr",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0025",
+        "correct": true,
+        "predicted": "COMPASS",
+        "expected": "COMPASS",
+        "latency_ms": 4508.054,
+        "output_tokens": 53,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0026",
+        "correct": true,
+        "predicted": "926725",
+        "expected": "926725",
+        "latency_ms": 4429.118,
+        "output_tokens": 67,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0027",
+        "correct": true,
+        "predicted": "P10-9941",
+        "expected": "P10-9941",
+        "latency_ms": 3135.74,
+        "output_tokens": 49,
+        "category": "ocr",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0028",
+        "correct": true,
+        "predicted": "PLATFORM",
+        "expected": "PLATFORM",
+        "latency_ms": 3277.799,
+        "output_tokens": 50,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0029",
+        "correct": true,
+        "predicted": "921021",
+        "expected": "921021",
+        "latency_ms": 3546.573,
+        "output_tokens": 67,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0030",
+        "correct": true,
+        "predicted": "S33-7805",
+        "expected": "S33-7805",
+        "latency_ms": 3302.177,
+        "output_tokens": 56,
+        "category": "ocr",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0031",
+        "correct": true,
+        "predicted": "PLATFORM",
+        "expected": "PLATFORM",
+        "latency_ms": 3583.617,
+        "output_tokens": 58,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0032",
+        "correct": true,
+        "predicted": "498775",
+        "expected": "498775",
+        "latency_ms": 4339.108,
+        "output_tokens": 70,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0033",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 12315.374,
+        "output_tokens": 249,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0034",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 9973.722,
+        "output_tokens": 205,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0035",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 11744.859,
+        "output_tokens": 230,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0036",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 9101.798,
+        "output_tokens": 164,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0037",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 13063.918,
+        "output_tokens": 282,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0038",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 11199.737,
+        "output_tokens": 225,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0039",
+        "correct": true,
+        "predicted": "up",
+        "expected": "up",
+        "latency_ms": 5949.812,
+        "output_tokens": 78,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0040",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 10711.391,
+        "output_tokens": 189,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0041",
+        "correct": true,
+        "predicted": "left",
+        "expected": "left",
+        "latency_ms": 3833.892,
+        "output_tokens": 70,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0042",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 5905.928,
+        "output_tokens": 111,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0043",
+        "correct": true,
+        "predicted": "up",
+        "expected": "up",
+        "latency_ms": 4958.744,
+        "output_tokens": 70,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0044",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 7188.332,
+        "output_tokens": 136,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0045",
+        "correct": true,
+        "predicted": "up",
+        "expected": "up",
+        "latency_ms": 4452.57,
+        "output_tokens": 74,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0046",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 10268.53,
+        "output_tokens": 205,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0047",
+        "correct": true,
+        "predicted": "12:10",
+        "expected": "12:10",
+        "latency_ms": 20826.106,
+        "output_tokens": 371,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0048",
+        "correct": true,
+        "predicted": "6:10",
+        "expected": "6:10",
+        "latency_ms": 34295.494,
+        "output_tokens": 614,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0049",
+        "correct": true,
+        "predicted": "1:25",
+        "expected": "1:25",
+        "latency_ms": 30560.379,
+        "output_tokens": 609,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0050",
+        "correct": false,
+        "predicted": "",
+        "expected": "11:20",
+        "latency_ms": 101792.549,
+        "output_tokens": 2048,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0051",
+        "correct": true,
+        "predicted": "11:00",
+        "expected": "11:00",
+        "latency_ms": 9747.563,
+        "output_tokens": 163,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0052",
+        "correct": true,
+        "predicted": "6:20",
+        "expected": "6:20",
+        "latency_ms": 81281.109,
+        "output_tokens": 1609,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0053",
+        "correct": true,
+        "predicted": "10:35",
+        "expected": "10:35",
+        "latency_ms": 59555.95,
+        "output_tokens": 1235,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0054",
+        "correct": true,
+        "predicted": "9:20",
+        "expected": "9:20",
+        "latency_ms": 46691.281,
+        "output_tokens": 949,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0055",
+        "correct": true,
+        "predicted": "11",
+        "expected": "11",
+        "latency_ms": 13608.192,
+        "output_tokens": 284,
+        "category": "dice",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0056",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 7221.729,
+        "output_tokens": 130,
+        "category": "dice",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0057",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 9519.046,
+        "output_tokens": 187,
+        "category": "dice",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0058",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 6036.291,
+        "output_tokens": 114,
+        "category": "dice",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0059",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 9123.818,
+        "output_tokens": 180,
+        "category": "dice",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0060",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 6768.15,
+        "output_tokens": 136,
+        "category": "dice",
+        "difficulty": "easy"
+      }
+    ]
+  },
+  "failures": [],
+  "gotchas": [
+    {
+      "severity": "info",
+      "text": "--max-num-seqs is 64 here, not the 2 the upstream recipe shipped with, and the change rests on a measured curve rather than on preference. At GPU_MEM=0.85 the server reports a KV pool of 654,635 tokens, while the heaviest workload in this run - c64 at about 1.3k tokens per request - needs roughly 83,000. So 2 was a scheduler cap, not a memory limit, and it left about 87 percent of the KV pool unused while turning every cell above concurrency 2 into a measurement of queue depth rather than of batching. Aggregate decode against N concurrent 256-token requests on this same box and this same server: 24.3 tok/s at N=1, 56.2 at 2, 80.2 at 4, 114.6 at 8, 220.5 at 16, 210.9 at 32, 236.2 at 64, with all 64 requests returning and no preemption in the log. Aggregate throughput therefore plateaus around N=16 at roughly 215-235 tok/s; past that the box trades per-request rate (13.8 tok/s at 16 down to 5.4 at 64) for concurrency rather than gaining throughput. 64 is used here so that no workload in the atlas is capped by the scheduler. Results with config_id fa4e2bc-era max-num-seqs 2 exist separately in this repository and are the other arm of that comparison."
+    },
+    {
+      "severity": "info",
+      "text": "Speculative decoding is ON and it is the model's own trained MTP head (--speculative-config {method: mtp, num_speculative_tokens: 3}), not n-gram drafting. Because the head is trained rather than copying from the prompt, throughput is nearly flat across task shapes - the recipe measures a 1.2x spread over four editing and prose tasks where the llama.cpp/ngram-mod recipe for the same model swings 3.2x. Never compare a decode figure here against a cell run with different speculation."
+    },
+    {
+      "severity": "info",
+      "text": "Prefix caching must stay off (--no-enable-prefix-caching) - it is a GB10 GDN kernel bug, not a tuning choice. One upside: the prefill figures here are honest, because nothing is served from cache. Full torch.compile is also off (an Inductor int64-indexing assert on sm_121); the recipe instead declares the n-gram gather a splitting op and captures PIECEWISE CUDA graphs, and switching to a FULL capture mode breaks the run."
+    },
+    {
+      "severity": "info",
+      "text": "A third of this checkpoint is served from NVMe, so page-cache state is a hidden independent variable and any result from this configuration that does not state it is not reproducible. Residency of the 47.75 GiB n-gram table was measured with mincore(2) immediately before this workload started: 100.0% of it was in the page cache."
+    },
+    {
+      "severity": "info",
+      "text": "VLLM_PLE_CPU_OFFLOAD=1, the official pinned-host-RAM path, hangs on this box: it registers a PleOffloadLayer and then spins a core with no disk I/O, indefinitely. Only VLLM_PLE_MMAP works here. The four VLLM_PLE_* / VLLM_USE_* environment variables are recorded in args for that reason - they are not CLI flags, but VLLM_PLE_MMAP is the difference between the model loading and not loading."
+    },
+    {
+      "severity": "info",
+      "text": "Read gpu_util_avg_pct here with care, and do NOT read a lower average at higher concurrency as evidence of stalling. It is a mean over the ENTIRE workload window - the sampler runs for the whole measured window and summarize() averages every sample it took, with no filtering of warmup, ramp-up or drain - so it is not a steady-state figure. A workload that completes few waves spends proportionally more of its window ramping up and draining with the batch half empty, and that alone drags the mean down: serve-chat-c32 runs 12.5 waves at 76.8 s per wave against serve-short-c16 at 20 waves and 13.5 s, and reports 80.3 percent against 90.7. power_avg_w is averaged the same way and carries the same artefact. An earlier version of this note treated that c16-to-c32 difference as a stall signature on a unified-memory part; that inference was not supported by these numbers and is withdrawn. What IS verified, by sampling utilization.gpu directly during active generation on this box, is that the instantaneous figure does track real work - 88 to 96 percent with four requests generating - so unlike some unified-memory utilisation counters this one is not measuring something unrelated. Two further caveats on the telemetry itself: vram_peak_gb is null in every result here because there is no separate device memory to measure and nvidia-smi reports fb_memory_total as 0, so ram_peak_gb is the real occupancy figure; and the power figures are whatever the driver exposes on this part, which may not account for the whole SoC, so treat them as a relative signal across these runs rather than as absolute wall power."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "91bfd55c27f3fea96cc983a5536ca1f0df90626ba2c45bf7dba9a15a74ec035a",
+    "payload_path": null,
+    "payload": {
+      "scorer": "vision",
+      "scorers_used": [
+        "exact"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "qwen3.8-flash-next",
+        "advertised_models": [
+          "qwen3.8-flash-next"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-28T19:53:02Z",
+    "finished_at": "2026-08-28T19:56:55Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "NVIDIA DGX Spark (ASUS Ascent GX10, GB10 / SM121, 128 GB unified memory, ~121 GiB usable) on Ubuntu 24.04.4 LTS, kernel 6.17.0-1029-nvidia aarch64, driver 580.173.02, CUDA 13.0. Swap is off. Engine is the container from the long-context recipe of github.com/0xBakeer/qwen38-flash-next-spark (commit 1611340), which builds github.com/blazux/qwen3.8-Flash-DGX (Apache-2.0) at 82ed48d; pip reports the build as vLLM 0.1.dev20073+g8e685d198, i.e. upstream commit 8e685d198 plus that fork's Qwen3.8-Flash-Next support. Weights are RadixArk/Qwen3.8-Flash-Next-NVFP4 at revision 7b71922, 206 safetensors shards, 135,156,121,594 bytes of tensor data. The server was started by the recipe's own recipes/vllm-longctx/serve.sh with its shipped defaults (CTX=262144, SEQS=2, GPU_MEM=0.85, MTP=3, PREWARM=1, WORKERS=32) and nothing else; the flags in args are exactly what that produced. The defining choice is VLLM_PLE_MMAP=1: the 51.2B-parameter n-gram/PLE embedding table, 47.75 GiB spread over 12 of the 206 shards, is gathered from the checkpoint on disk through the OS page cache instead of being made resident, which is the only reason a 126 GiB checkpoint runs next to a usable KV cache in 128 GB. KV was measured by the server at 18.13 GiB. The machine was fully isolated for the run: the only route to it from outside the box is an SSH tunnel opened by a reverse proxy on the same private network, and that tunnel was stopped before the first run and stayed stopped throughout, so no external client could contend for the GPU. The container publishes 127.0.0.1:8000 only and the harness connects to it directly, so no proxy sits in the measured path."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}


### PR DESCRIPTION
### Cells filled

- **Engine** — `vllm` `0.1.dev20073+g8e685d198`
- **Model / quant** — `Qwen/Qwen3.8-Flash-Next` / `nvfp4`
- **Hardware** — `nvidia-gb10-dgx-spark` x1
- **Workload** — `eval-vision-v1` (eval)
- **Headline** — accuracy **0.967**, success 1.000

One file: `results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/cb516ca371e97893--eval-vision-v1--b4c733.json`

### What failed

Nothing failed. 60/60 requests returned, success rate 1.000.

### Gotchas

- **info** — --max-num-seqs is 64 here, not the 2 the upstream recipe shipped with, and the change rests on a measured curve rather than on preference.
- **info** — Speculative decoding is ON and it is the model's own trained MTP head (--speculative-config {method: mtp, num_speculative_tokens: 3}), not n-gram drafting.
- **info** — Prefix caching must stay off (--no-enable-prefix-caching) - it is a GB10 GDN kernel bug, not a tuning choice.
- **info** — A third of this checkpoint is served from NVMe, so page-cache state is a hidden independent variable and any result from this configuration that does not state it is not reproducible.
- **info** — VLLM_PLE_CPU_OFFLOAD=1, the official pinned-host-RAM path, hangs on this box: it registers a PleOffloadLayer and then spins a core with no disk I/O, indefinitely.
- **info** — Read gpu_util_avg_pct here with care, and do NOT read a lower average at higher concurrency as evidence of stalling.

### Conditions

Dedicated box, nothing else resident on the GPU, no compile running. The one route into this machine from elsewhere on its private network is an SSH tunnel from a reverse proxy; it was stopped before the first run and stayed stopped. The harness talks to loopback with no proxy in the measured path.

n-gram table page-cache residency, `mincore(2)`: **100.0% before the workload, 100.0% after**.

| | |
|---|---:|
| peak host RAM | 111.6 GB |
| average GPU utilisation | 91.5 % |
| average / peak power | 38.8 / 45.0 W |
| max temperature | 65 C |
| thermal throttling | not detected |
| wall clock | 233.0 s |

`pnpm validate` — 0 errors. Read `gpu_util_avg_pct` with the caveat in the gotchas: it is a mean over the whole workload window including ramp-up and drain, not a steady-state figure.
