### PR TITLE
results: Qwen/Qwen3.8-Flash-Next on nvidia-gb10-dgx-spark — longctx-needle-32k-v1 at max-num-seqs 2

### DIFF
--- a/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/c2da0164b1ba1ffc--longctx-needle-32k-v1--91f008.json
+++ b/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/c2da0164b1ba1ffc--longctx-needle-32k-v1--91f008.json
@@ -1,0 +1,852 @@
+{
+  "schema_version": 1,
+  "run_id": "c2da0164b1ba1ffc--longctx-needle-32k-v1--91f008",
+  "config_id": "c2da0164b1ba1ffc",
+  "cell_id": "146e5bfec676",
+  "workload_id": "longctx-needle-32k-v1",
+  "kind": "longctx",
+  "engine": {
+    "id": "vllm",
+    "version": "0.1.dev20073+g8e685d198",
+    "commit": "8e685d198",
+    "container": "qwen38-flash-dgx (built from blazux/qwen3.8-Flash-DGX at 82ed48d)",
+    "install_method": "docker"
+  },
+  "model": {
+    "id": "Qwen/Qwen3.8-Flash-Next",
+    "quant_id": "nvfp4",
+    "hf_id": "Qwen/Qwen3.8-Flash-Next",
+    "revision": "7b719225242aacd3dbd3f9407468c2ee9a9d2594",
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "load-format": "safetensors",
+    "max-model-len": 262144,
+    "max-num-seqs": 2,
+    "gpu-memory-utilization": 0.85,
+    "enable-prefix-caching": false,
+    "enable-chunked-prefill": true,
+    "max-num-batched-tokens": 8192,
+    "compilation-config": {
+      "cudagraph_mode": "PIECEWISE",
+      "splitting_ops": [
+        "vllm::unified_attention_with_output",
+        "vllm::unified_mla_attention_with_output",
+        "vllm::mamba_mixer2",
+        "vllm::mamba_mixer",
+        "vllm::short_conv",
+        "vllm::qwen3_8_flash_next_ple_short_conv",
+        "vllm::qwen3_8_flash_next_qsa_with_output",
+        "vllm::linear_attention",
+        "vllm::qwen_gdn_attention_core",
+        "vllm::qwen_gdn_attention_core_fused_norm_packed",
+        "vllm::sparse_attn_indexer",
+        "vllm::ple_mmap_lookup"
+      ]
+    },
+    "enable-flashinfer-autotune": false,
+    "enable-auto-tool-choice": true,
+    "tool-call-parser": "qwen3_coder",
+    "reasoning-parser": "qwen3",
+    "speculative-config": {
+      "method": "mtp",
+      "num_speculative_tokens": 3
+    },
+    "vllm-ple-mmap": 1,
+    "vllm-ple-mmap-workers": 32,
+    "vllm-ple-mmap-prewarm": 1,
+    "vllm-use-flashinfer-sampler": 1
+  },
+  "args_canonical": "@dtype=auto;@quant=nvfp4;compilation-config={\"cudagraph_mode\":\"PIECEWISE\",\"splitting_ops\":[\"vllm::linear_attention\",\"vllm::mamba_mixer\",\"vllm::mamba_mixer2\",\"vllm::ple_mmap_lookup\",\"vllm::qwen3_8_flash_next_ple_short_conv\",\"vllm::qwen3_8_flash_next_qsa_with_output\",\"vllm::qwen_gdn_attention_core\",\"vllm::qwen_gdn_attention_core_fused_norm_packed\",\"vllm::short_conv\",\"vllm::sparse_attn_indexer\",\"vllm::unified_attention_with_output\",\"vllm::unified_mla_attention_with_output\"]};enable-auto-tool-choice=true;enable-chunked-prefill=true;enable-flashinfer-autotune=false;enable-prefix-caching=false;gpu-memory-utilization=0.85;load-format=safetensors;max-model-len=262144;max-num-batched-tokens=8192;max-num-seqs=2;reasoning-parser=qwen3;speculative-config={\"method\":\"mtp\",\"num_speculative_tokens\":3};tool-call-parser=qwen3_coder;vllm-ple-mmap=1;vllm-ple-mmap-prewarm=1;vllm-ple-mmap-workers=32;vllm-use-flashinfer-sampler=1",
+  "serve_command": null,
+  "workload": {
+    "id": "longctx-needle-32k-v1",
+    "resolved_params": {
+      "axis": "input_tokens",
+      "points": [
+        [
+          32768,
+          10.0
+        ],
+        [
+          32768,
+          10.0
+        ],
+        [
+          32768,
+          50.0
+        ],
+        [
+          32768,
+          50.0
+        ],
+        [
+          32768,
+          90.0
+        ],
+        [
+          32768,
+          90.0
+        ]
+      ],
+      "output_tokens": 128,
+      "needle_check": true,
+      "needle_depth": null,
+      "headline_input_tokens": 32768,
+      "needles_found": 6,
+      "needles_total": 6,
+      "dataset_categories": [
+        "needle"
+      ],
+      "dataset_target_tokens": 32768,
+      "timeout_s": 1800.0,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 1,
+    "requests_ok": 1,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 29.53,
+    "input_tokens_total": 40443,
+    "output_tokens_total": 95,
+    "output_tok_s": 3.217,
+    "total_tok_s": 1372.769,
+    "req_s": 0.034,
+    "prefill_tok_s": 1525.255,
+    "ttft_ms": {
+      "mean": 26515.573,
+      "p50": 26515.573,
+      "p90": 26515.573,
+      "p95": 26515.573,
+      "p99": 26515.573,
+      "min": 26515.573,
+      "max": 26515.573
+    },
+    "tpot_ms": {
+      "mean": 32.068,
+      "p50": 32.068,
+      "p90": 32.068,
+      "p95": 32.068,
+      "p99": 32.068,
+      "min": 32.068,
+      "max": 32.068
+    },
+    "itl_ms": {
+      "mean": 97.217,
+      "p50": 98.176,
+      "p90": 103.557,
+      "p95": 104.056,
+      "p99": 115.714,
+      "min": 76.754,
+      "max": 120.608
+    },
+    "e2e_ms": {
+      "mean": 29529.996,
+      "p50": 29529.996,
+      "p90": 29529.996,
+      "p95": 29529.996,
+      "p99": 29529.996,
+      "min": 29529.996,
+      "max": 29529.996
+    },
+    "decode_tok_s_per_request": {
+      "mean": 31.183,
+      "p50": 31.183,
+      "p90": 31.183,
+      "p95": 31.183,
+      "p99": 31.183,
+      "min": 31.183,
+      "max": 31.183
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 113.078,
+    "kv_cache_tokens": null,
+    "power_avg_w": 41.47,
+    "power_peak_w": 59.24,
+    "energy_wh": 0.3424,
+    "gpu_util_avg_pct": 86.52,
+    "temp_max_c": 61.0,
+    "thermal_throttle_detected": false
+  },
+  "sweep": [
+    {
+      "input_tokens": 32768,
+      "output_tokens": 128,
+      "label": "depth 10% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 29.53,
+        "input_tokens_total": 40443,
+        "output_tokens_total": 95,
+        "output_tok_s": 3.217,
+        "total_tok_s": 1372.769,
+        "req_s": 0.034,
+        "prefill_tok_s": 1525.255,
+        "ttft_ms": {
+          "mean": 26515.573,
+          "p50": 26515.573,
+          "p90": 26515.573,
+          "p95": 26515.573,
+          "p99": 26515.573,
+          "min": 26515.573,
+          "max": 26515.573
+        },
+        "tpot_ms": {
+          "mean": 32.068,
+          "p50": 32.068,
+          "p90": 32.068,
+          "p95": 32.068,
+          "p99": 32.068,
+          "min": 32.068,
+          "max": 32.068
+        },
+        "itl_ms": {
+          "mean": 97.217,
+          "p50": 98.176,
+          "p90": 103.557,
+          "p95": 104.056,
+          "p99": 115.714,
+          "min": 76.754,
+          "max": 120.608
+        },
+        "e2e_ms": {
+          "mean": 29529.996,
+          "p50": 29529.996,
+          "p90": 29529.996,
+          "p95": 29529.996,
+          "p99": 29529.996,
+          "min": 29529.996,
+          "max": 29529.996
+        },
+        "decode_tok_s_per_request": {
+          "mean": 31.183,
+          "p50": 31.183,
+          "p90": 31.183,
+          "p95": 31.183,
+          "p99": 31.183,
+          "min": 31.183,
+          "max": 31.183
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 113.078,
+        "kv_cache_tokens": null,
+        "power_avg_w": 41.47,
+        "power_peak_w": 59.24,
+        "energy_wh": 0.3424,
+        "gpu_util_avg_pct": 86.52,
+        "temp_max_c": 61.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 32768,
+      "output_tokens": 128,
+      "label": "depth 10% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 23.266,
+        "input_tokens_total": 40165,
+        "output_tokens_total": 90,
+        "output_tok_s": 3.868,
+        "total_tok_s": 1730.188,
+        "req_s": 0.043,
+        "prefill_tok_s": 1950.766,
+        "ttft_ms": {
+          "mean": 20589.349,
+          "p50": 20589.349,
+          "p90": 20589.349,
+          "p95": 20589.349,
+          "p99": 20589.349,
+          "min": 20589.349,
+          "max": 20589.349
+        },
+        "tpot_ms": {
+          "mean": 30.076,
+          "p50": 30.076,
+          "p90": 30.076,
+          "p95": 30.076,
+          "p99": 30.076,
+          "min": 30.076,
+          "max": 30.076
+        },
+        "itl_ms": {
+          "mean": 95.574,
+          "p50": 95.146,
+          "p90": 101.01,
+          "p95": 103.318,
+          "p99": 113.477,
+          "min": 76.372,
+          "max": 116.892
+        },
+        "e2e_ms": {
+          "mean": 23266.08,
+          "p50": 23266.08,
+          "p90": 23266.08,
+          "p95": 23266.08,
+          "p99": 23266.08,
+          "min": 23266.08,
+          "max": 23266.08
+        },
+        "decode_tok_s_per_request": {
+          "mean": 33.25,
+          "p50": 33.25,
+          "p90": 33.25,
+          "p95": 33.25,
+          "p99": 33.25,
+          "min": 33.25,
+          "max": 33.25
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 113.111,
+        "kv_cache_tokens": null,
+        "power_avg_w": 49.5,
+        "power_peak_w": 60.63,
+        "energy_wh": 0.3234,
+        "gpu_util_avg_pct": 92.52,
+        "temp_max_c": 65.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 32768,
+      "output_tokens": 128,
+      "label": "depth 50% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 22.366,
+        "input_tokens_total": 40143,
+        "output_tokens_total": 87,
+        "output_tok_s": 3.89,
+        "total_tok_s": 1798.748,
+        "req_s": 0.045,
+        "prefill_tok_s": 2072.544,
+        "ttft_ms": {
+          "mean": 19368.952,
+          "p50": 19368.952,
+          "p90": 19368.952,
+          "p95": 19368.952,
+          "p99": 19368.952,
+          "min": 19368.952,
+          "max": 19368.952
+        },
+        "tpot_ms": {
+          "mean": 34.842,
+          "p50": 34.842,
+          "p90": 34.842,
+          "p95": 34.842,
+          "p99": 34.842,
+          "min": 34.842,
+          "max": 34.842
+        },
+        "itl_ms": {
+          "mean": 96.64,
+          "p50": 96.23,
+          "p90": 100.145,
+          "p95": 102.205,
+          "p99": 113.594,
+          "min": 77.009,
+          "max": 118.257
+        },
+        "e2e_ms": {
+          "mean": 22365.401,
+          "p50": 22365.401,
+          "p90": 22365.401,
+          "p95": 22365.401,
+          "p99": 22365.401,
+          "min": 22365.401,
+          "max": 22365.401
+        },
+        "decode_tok_s_per_request": {
+          "mean": 28.701,
+          "p50": 28.701,
+          "p90": 28.701,
+          "p95": 28.701,
+          "p99": 28.701,
+          "min": 28.701,
+          "max": 28.701
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 113.102,
+        "kv_cache_tokens": null,
+        "power_avg_w": 52.01,
+        "power_peak_w": 61.16,
+        "energy_wh": 0.3257,
+        "gpu_util_avg_pct": 95.18,
+        "temp_max_c": 67.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 32768,
+      "output_tokens": 128,
+      "label": "depth 50% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 19.634,
+        "input_tokens_total": 40251,
+        "output_tokens_total": 83,
+        "output_tok_s": 4.227,
+        "total_tok_s": 2054.285,
+        "req_s": 0.051,
+        "prefill_tok_s": 2298.814,
+        "ttft_ms": {
+          "mean": 17509.467,
+          "p50": 17509.467,
+          "p90": 17509.467,
+          "p95": 17509.467,
+          "p99": 17509.467,
+          "min": 17509.467,
+          "max": 17509.467
+        },
+        "tpot_ms": {
+          "mean": 25.909,
+          "p50": 25.909,
+          "p90": 25.909,
+          "p95": 25.909,
+          "p99": 25.909,
+          "min": 25.909,
+          "max": 25.909
+        },
+        "itl_ms": {
+          "mean": 96.54,
+          "p50": 98.111,
+          "p90": 100.456,
+          "p95": 101.512,
+          "p99": 103.128,
+          "min": 83.017,
+          "max": 103.544
+        },
+        "e2e_ms": {
+          "mean": 19633.966,
+          "p50": 19633.966,
+          "p90": 19633.966,
+          "p95": 19633.966,
+          "p99": 19633.966,
+          "min": 19633.966,
+          "max": 19633.966
+        },
+        "decode_tok_s_per_request": {
+          "mean": 38.597,
+          "p50": 38.597,
+          "p90": 38.597,
+          "p95": 38.597,
+          "p99": 38.597,
+          "min": 38.597,
+          "max": 38.597
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 112.664,
+        "kv_cache_tokens": null,
+        "power_avg_w": 56.81,
+        "power_peak_w": 61.72,
+        "energy_wh": 0.305,
+        "gpu_util_avg_pct": 92.42,
+        "temp_max_c": 68.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 32768,
+      "output_tokens": 128,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 19.876,
+        "input_tokens_total": 40314,
+        "output_tokens_total": 85,
+        "output_tok_s": 4.277,
+        "total_tok_s": 2032.598,
+        "req_s": 0.05,
+        "prefill_tok_s": 2305.684,
+        "ttft_ms": {
+          "mean": 17484.618,
+          "p50": 17484.618,
+          "p90": 17484.618,
+          "p95": 17484.618,
+          "p99": 17484.618,
+          "min": 17484.618,
+          "max": 17484.618
+        },
+        "tpot_ms": {
+          "mean": 28.459,
+          "p50": 28.459,
+          "p90": 28.459,
+          "p95": 28.459,
+          "p99": 28.459,
+          "min": 28.459,
+          "max": 28.459
+        },
+        "itl_ms": {
+          "mean": 95.59,
+          "p50": 95.297,
+          "p90": 103.591,
+          "p95": 107.267,
+          "p99": 113.127,
+          "min": 69.479,
+          "max": 114.707
+        },
+        "e2e_ms": {
+          "mean": 19875.195,
+          "p50": 19875.195,
+          "p90": 19875.195,
+          "p95": 19875.195,
+          "p99": 19875.195,
+          "min": 19875.195,
+          "max": 19875.195
+        },
+        "decode_tok_s_per_request": {
+          "mean": 35.138,
+          "p50": 35.138,
+          "p90": 35.138,
+          "p95": 35.138,
+          "p99": 35.138,
+          "min": 35.138,
+          "max": 35.138
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 113.083,
+        "kv_cache_tokens": null,
+        "power_avg_w": 57.44,
+        "power_peak_w": 61.91,
+        "energy_wh": 0.3089,
+        "gpu_util_avg_pct": 93.53,
+        "temp_max_c": 71.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 32768,
+      "output_tokens": 128,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 20.942,
+        "input_tokens_total": 40316,
+        "output_tokens_total": 83,
+        "output_tok_s": 3.963,
+        "total_tok_s": 1929.088,
+        "req_s": 0.048,
+        "prefill_tok_s": 2173.399,
+        "ttft_ms": {
+          "mean": 18549.746,
+          "p50": 18549.746,
+          "p90": 18549.746,
+          "p95": 18549.746,
+          "p99": 18549.746,
+          "min": 18549.746,
+          "max": 18549.746
+        },
+        "tpot_ms": {
+          "mean": 29.172,
+          "p50": 29.172,
+          "p90": 29.172,
+          "p95": 29.172,
+          "p99": 29.172,
+          "min": 29.172,
+          "max": 29.172
+        },
+        "itl_ms": {
+          "mean": 95.648,
+          "p50": 95.003,
+          "p90": 101.608,
+          "p95": 103.226,
+          "p99": 115.03,
+          "min": 75.352,
+          "max": 118.679
+        },
+        "e2e_ms": {
+          "mean": 20941.814,
+          "p50": 20941.814,
+          "p90": 20941.814,
+          "p95": 20941.814,
+          "p99": 20941.814,
+          "min": 20941.814,
+          "max": 20941.814
+        },
+        "decode_tok_s_per_request": {
+          "mean": 34.28,
+          "p50": 34.28,
+          "p90": 34.28,
+          "p95": 34.28,
+          "p99": 34.28,
+          "min": 34.28,
+          "max": 34.28
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 113.094,
+        "kv_cache_tokens": null,
+        "power_avg_w": 56.06,
+        "power_peak_w": 62.42,
+        "energy_wh": 0.317,
+        "gpu_util_avg_pct": 93.5,
+        "temp_max_c": 73.0,
+        "thermal_throttle_detected": false
+      }
+    }
+  ],
+  "failures": [],
+  "gotchas": [
+    {
+      "severity": "info",
+      "text": "--max-num-seqs is 2 here. That is the value the upstream container ships, and this arm exists to measure it rather than to recommend it: the paired arm of this cell runs the identical configuration at 64. Two slots is a scheduler cap and not a memory limit - at GPU_MEM=0.85 the server reports a KV pool of 654,635 tokens while 64 concurrent 1.3k-token requests need about 83,000 - so every workload here above concurrency 2 measures QUEUE DEPTH against a two-slot server, not parallelism at 8 or 16 or 64. Read those cells that way: aggregate throughput stays near the two-stream number and per-request latency grows with N/2, and at high N, against a workload timeout of 300 s, tail requests can exceed it and depress success_rate. That is the cap, not a failure of the engine. Aggregate decode against N concurrent 256-token requests on this box was measured at 24.3 tok/s at N=1, 56.2 at 2, 80.2 at 4, 114.6 at 8, 220.5 at 16, 210.9 at 32 and 236.2 at 64, so the cap costs roughly a factor of four at the plateau. Never compare a cell from this arm against one from the 64 arm without saying which is which."
+    },
+    {
+      "severity": "info",
+      "text": "Speculative decoding is ON and it is the model's own trained MTP head (--speculative-config {method: mtp, num_speculative_tokens: 3}), not n-gram drafting. Because the head is trained rather than copying from the prompt, throughput is nearly flat across task shapes - the recipe measures a 1.2x spread over four editing and prose tasks where the llama.cpp/ngram-mod recipe for the same model swings 3.2x. Never compare a decode figure here against a cell run with different speculation."
+    },
+    {
+      "severity": "info",
+      "text": "Prefix caching must stay off (--no-enable-prefix-caching) - it is a GB10 GDN kernel bug, not a tuning choice. One upside: the prefill figures here are honest, because nothing is served from cache. Full torch.compile is also off (an Inductor int64-indexing assert on sm_121); the recipe instead declares the n-gram gather a splitting op and captures PIECEWISE CUDA graphs, and switching to a FULL capture mode breaks the run."
+    },
+    {
+      "severity": "info",
+      "text": "A third of this checkpoint is served from NVMe, so page-cache state is a hidden independent variable and any result from this configuration that does not state it is not reproducible. Residency of the 47.75 GiB n-gram table was measured with mincore(2) immediately before this workload started: 100.0% of it was in the page cache."
+    },
+    {
+      "severity": "info",
+      "text": "VLLM_PLE_CPU_OFFLOAD=1, the official pinned-host-RAM path, hangs on this box: it registers a PleOffloadLayer and then spins a core with no disk I/O, indefinitely. Only VLLM_PLE_MMAP works here. The four VLLM_PLE_* / VLLM_USE_* environment variables are recorded in args for that reason - they are not CLI flags, but VLLM_PLE_MMAP is the difference between the model loading and not loading."
+    },
+    {
+      "severity": "info",
+      "text": "Read gpu_util_avg_pct here with care, and do NOT read a lower average at higher concurrency as evidence of stalling. It is a mean over the ENTIRE workload window - the sampler runs for the whole measured window and summarize() averages every sample it took, with no filtering of warmup, ramp-up or drain - so it is not a steady-state figure. A workload that completes few waves spends proportionally more of its window ramping up and draining with the batch half empty, and that alone drags the mean down: serve-chat-c32 runs 12.5 waves at 76.8 s per wave against serve-short-c16 at 20 waves and 13.5 s, and reports 80.3 percent against 90.7. power_avg_w is averaged the same way and carries the same artefact. An earlier version of this note treated that c16-to-c32 difference as a stall signature on a unified-memory part; that inference was not supported by these numbers and is withdrawn. What IS verified, by sampling utilization.gpu directly during active generation on this box, is that the instantaneous figure does track real work - 88 to 96 percent with four requests generating - so unlike some unified-memory utilisation counters this one is not measuring something unrelated. Two further caveats on the telemetry itself: vram_peak_gb is null in every result here because there is no separate device memory to measure and nvidia-smi reports fb_memory_total as 0, so ram_peak_gb is the real occupancy figure; and the power figures are whatever the driver exposes on this part, which may not account for the whole SoC, so treat them as a relative signal across these runs rather than as absolute wall power."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": 0.0776,
+    "tok_s_per_gb_bandwidth": 0.114223,
+    "bandwidth_efficiency": 0.410179,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "4521f502345012de1948f7764226244e4a0f52062636e4a8dc9bdf017b7401b5",
+    "payload_path": null,
+    "payload": {
+      "points": [
+        {
+          "id": "lctx-0043",
+          "input_tokens": 32768,
+          "depth_pct": 10.0,
+          "needle_correct": true,
+          "output_tok_s": 3.217,
+          "decode_tok_s": 31.183,
+          "ttft_ms": 26515.573,
+          "success_rate": 1.0
+        },
+        {
+          "id": "lctx-0044",
+          "input_tokens": 32768,
+          "depth_pct": 10.0,
+          "needle_correct": true,
+          "output_tok_s": 3.868,
+          "decode_tok_s": 33.25,
+          "ttft_ms": 20589.349,
+          "success_rate": 1.0
+        },
+        {
+          "id": "lctx-0045",
+          "input_tokens": 32768,
+          "depth_pct": 50.0,
+          "needle_correct": true,
+          "output_tok_s": 3.89,
+          "decode_tok_s": 28.701,
+          "ttft_ms": 19368.952,
+          "success_rate": 1.0
+        },
+        {
+          "id": "lctx-0046",
+          "input_tokens": 32768,
+          "depth_pct": 50.0,
+          "needle_correct": true,
+          "output_tok_s": 4.227,
+          "decode_tok_s": 38.597,
+          "ttft_ms": 17509.467,
+          "success_rate": 1.0
+        },
+        {
+          "id": "lctx-0047",
+          "input_tokens": 32768,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 4.277,
+          "decode_tok_s": 35.138,
+          "ttft_ms": 17484.618,
+          "success_rate": 1.0
+        },
+        {
+          "id": "lctx-0048",
+          "input_tokens": 32768,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 3.963,
+          "decode_tok_s": 34.28,
+          "ttft_ms": 18549.746,
+          "success_rate": 1.0
+        }
+      ],
+      "requests": [
+        {
+          "id": "ctx32768-r00000",
+          "prompt_id": "lctx-0043",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 26515.573,
+          "e2e_ms": 29529.996,
+          "prompt_tokens": 40443,
+          "completion_tokens": 95,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx32768-r00000",
+          "prompt_id": "lctx-0044",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 20589.349,
+          "e2e_ms": 23266.08,
+          "prompt_tokens": 40165,
+          "completion_tokens": 90,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx32768-r00000",
+          "prompt_id": "lctx-0045",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 19368.952,
+          "e2e_ms": 22365.401,
+          "prompt_tokens": 40143,
+          "completion_tokens": 87,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx32768-r00000",
+          "prompt_id": "lctx-0046",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 17509.467,
+          "e2e_ms": 19633.966,
+          "prompt_tokens": 40251,
+          "completion_tokens": 83,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx32768-r00000",
+          "prompt_id": "lctx-0047",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 17484.618,
+          "e2e_ms": 19875.195,
+          "prompt_tokens": 40314,
+          "completion_tokens": 85,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx32768-r00000",
+          "prompt_id": "lctx-0048",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 18549.746,
+          "e2e_ms": 20941.814,
+          "prompt_tokens": 40316,
+          "completion_tokens": 83,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        }
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "qwen3.8-flash-next",
+        "advertised_models": [
+          "qwen3.8-flash-next"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-29T19:30:38Z",
+    "finished_at": "2026-08-29T19:32:54Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Box WAS dedicated: this DGX Spark runs no desktop session, and no compile or dev server ran on it during the sweep. Isolation check: the only route to it from outside the box is an SSH tunnel opened by a reverse proxy on the same private network, and that tunnel was stopped before the first run and stayed stopped throughout, so no external client could contend for the GPU. The GPU compute-app list sampled immediately before this workload contained exactly: VLLM::EngineCore. NVIDIA DGX Spark (ASUS Ascent GX10, GB10 / SM121, 128 GB unified memory, ~121 GiB usable) on Ubuntu 24.04.4 LTS, kernel 6.17.0-1029-nvidia aarch64, driver 580.173.02, CUDA 13.0. Swap is off. Engine is the container from the long-context recipe of github.com/0xBakeer/qwen38-flash-next-spark (commit 1611340), which builds github.com/blazux/qwen3.8-Flash-DGX (Apache-2.0) at 82ed48d; pip reports the build as vLLM 0.1.dev20073+g8e685d198, i.e. upstream commit 8e685d198 plus that fork's Qwen3.8-Flash-Next support. Weights are RadixArk/Qwen3.8-Flash-Next-NVFP4 at revision 7b71922, 206 safetensors shards, 135,156,121,594 bytes of tensor data. The server was started by the recipe's own recipes/vllm-longctx/serve.sh with its shipped defaults (CTX=262144, SEQS=2, GPU_MEM=0.85, MTP=3, PREWARM=1, WORKERS=32) and nothing else; the flags in args are exactly what that produced. The defining choice is VLLM_PLE_MMAP=1: the 51.2B-parameter n-gram/PLE embedding table, 47.75 GiB spread over 12 of the 206 shards, is gathered from the checkpoint on disk through the OS page cache instead of being made resident, which is the only reason a 126 GiB checkpoint runs next to a usable KV cache in 128 GB. KV was measured by the server at 18.13 GiB. The container publishes 127.0.0.1:8000 only and the harness connects to it directly, so no proxy sits in the measured path."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/c2da0164b1ba1ffc--longctx-needle-32k-v1--91f008.json
+++ b/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/c2da0164b1ba1ffc--longctx-needle-32k-v1--91f008.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -101,27 +101,27 @@
       "points": [
         [
           32768,
-          10.0
+          10
         ],
         [
           32768,
-          10.0
+          10
         ],
         [
           32768,
-          50.0
+          50
         ],
         [
           32768,
-          50.0
+          50
         ],
         [
           32768,
-          90.0
+          90
         ],
         [
           32768,
-          90.0
+          90
         ]
       ],
       "output_tokens": 128,
@@ -134,7 +134,7 @@
         "needle"
       ],
       "dataset_target_tokens": 32768,
-      "timeout_s": 1800.0,
+      "timeout_s": 1800,
       "seed": 42
     }
   },
@@ -142,7 +142,7 @@
     "requests_total": 1,
     "requests_ok": 1,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 29.53,
     "input_tokens_total": 40443,
     "output_tokens_total": 95,
@@ -202,7 +202,7 @@
     "power_peak_w": 59.24,
     "energy_wh": 0.3424,
     "gpu_util_avg_pct": 86.52,
-    "temp_max_c": 61.0,
+    "temp_max_c": 61,
     "thermal_throttle_detected": false
   },
   "sweep": [
@@ -214,7 +214,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 29.53,
         "input_tokens_total": 40443,
         "output_tokens_total": 95,
@@ -274,7 +274,7 @@
         "power_peak_w": 59.24,
         "energy_wh": 0.3424,
         "gpu_util_avg_pct": 86.52,
-        "temp_max_c": 61.0,
+        "temp_max_c": 61,
         "thermal_throttle_detected": false
       }
     },
@@ -286,7 +286,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 23.266,
         "input_tokens_total": 40165,
         "output_tokens_total": 90,
@@ -346,7 +346,7 @@
         "power_peak_w": 60.63,
         "energy_wh": 0.3234,
         "gpu_util_avg_pct": 92.52,
-        "temp_max_c": 65.0,
+        "temp_max_c": 65,
         "thermal_throttle_detected": false
       }
     },
@@ -358,7 +358,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 22.366,
         "input_tokens_total": 40143,
         "output_tokens_total": 87,
@@ -418,7 +418,7 @@
         "power_peak_w": 61.16,
         "energy_wh": 0.3257,
         "gpu_util_avg_pct": 95.18,
-        "temp_max_c": 67.0,
+        "temp_max_c": 67,
         "thermal_throttle_detected": false
       }
     },
@@ -430,7 +430,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 19.634,
         "input_tokens_total": 40251,
         "output_tokens_total": 83,
@@ -490,7 +490,7 @@
         "power_peak_w": 61.72,
         "energy_wh": 0.305,
         "gpu_util_avg_pct": 92.42,
-        "temp_max_c": 68.0,
+        "temp_max_c": 68,
         "thermal_throttle_detected": false
       }
     },
@@ -502,7 +502,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 19.876,
         "input_tokens_total": 40314,
         "output_tokens_total": 85,
@@ -562,7 +562,7 @@
         "power_peak_w": 61.91,
         "energy_wh": 0.3089,
         "gpu_util_avg_pct": 93.53,
-        "temp_max_c": 71.0,
+        "temp_max_c": 71,
         "thermal_throttle_detected": false
       }
     },
@@ -574,7 +574,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 20.942,
         "input_tokens_total": 40316,
         "output_tokens_total": 83,
@@ -634,7 +634,7 @@
         "power_peak_w": 62.42,
         "energy_wh": 0.317,
         "gpu_util_avg_pct": 93.5,
-        "temp_max_c": 73.0,
+        "temp_max_c": 73,
         "thermal_throttle_detected": false
       }
     }
@@ -683,62 +683,62 @@
         {
           "id": "lctx-0043",
           "input_tokens": 32768,
-          "depth_pct": 10.0,
+          "depth_pct": 10,
           "needle_correct": true,
           "output_tok_s": 3.217,
           "decode_tok_s": 31.183,
           "ttft_ms": 26515.573,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "lctx-0044",
           "input_tokens": 32768,
-          "depth_pct": 10.0,
+          "depth_pct": 10,
           "needle_correct": true,
           "output_tok_s": 3.868,
           "decode_tok_s": 33.25,
           "ttft_ms": 20589.349,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "lctx-0045",
           "input_tokens": 32768,
-          "depth_pct": 50.0,
+          "depth_pct": 50,
           "needle_correct": true,
           "output_tok_s": 3.89,
           "decode_tok_s": 28.701,
           "ttft_ms": 19368.952,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "lctx-0046",
           "input_tokens": 32768,
-          "depth_pct": 50.0,
+          "depth_pct": 50,
           "needle_correct": true,
           "output_tok_s": 4.227,
           "decode_tok_s": 38.597,
           "ttft_ms": 17509.467,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "lctx-0047",
           "input_tokens": 32768,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 4.277,
           "decode_tok_s": 35.138,
           "ttft_ms": 17484.618,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "lctx-0048",
           "input_tokens": 32768,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 3.963,
           "decode_tok_s": 34.28,
           "ttft_ms": 18549.746,
-          "success_rate": 1.0
+          "success_rate": 1
         }
       ],
       "requests": [
@@ -834,7 +834,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-29T19:30:38Z",
     "finished_at": "2026-08-29T19:32:54Z",
     "submitted_at": null,


### PR DESCRIPTION
### Cells filled

- **Engine** — `vllm` `0.1.dev20073+g8e685d198`
- **Model / quant** — `Qwen/Qwen3.8-Flash-Next` / `nvfp4`
- **Hardware** — `nvidia-gb10-dgx-spark` x1
- **Workload** — `longctx-needle-32k-v1` (longctx)
- **Headline** — **3.2 output tok/s** aggregate, 31.2 tok/s per request, TTFT p50 26,515.6 ms, success 1.000

One file: `results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/c2da0164b1ba1ffc--longctx-needle-32k-v1--91f008.json`

### What failed

Nothing failed. 1/1 requests returned, success rate 1.000.

### Gotchas

- **info** — --max-num-seqs is 2 here.
- **info** — Speculative decoding is ON and it is the model's own trained MTP head (--speculative-config {method: mtp, num_speculative_tokens: 3}), not n-gram drafting.
- **info** — Prefix caching must stay off (--no-enable-prefix-caching) - it is a GB10 GDN kernel bug, not a tuning choice.
- **info** — A third of this checkpoint is served from NVMe, so page-cache state is a hidden independent variable and any result from this configuration that does not state it is not reproducible.
- **info** — VLLM_PLE_CPU_OFFLOAD=1, the official pinned-host-RAM path, hangs on this box: it registers a PleOffloadLayer and then spins a core with no disk I/O, indefinitely.
- **info** — Read gpu_util_avg_pct here with care, and do NOT read a lower average at higher concurrency as evidence of stalling.

### Conditions

Dedicated box, nothing else resident on the GPU, no compile running. The one route into this machine from elsewhere on its private network is an SSH tunnel from a reverse proxy; it was stopped before the first run and stayed stopped. The harness talks to loopback with no proxy in the measured path.

n-gram table page-cache residency, `mincore(2)`: **100.0% before the workload, 100.0% after**.

| | |
|---|---:|
| peak host RAM | 113.1 GB |
| average GPU utilisation | 86.5 % |
| average / peak power | 41.5 / 59.2 W |
| max temperature | 61 C |
| thermal throttling | not detected |
| wall clock | 29.5 s |

`pnpm validate` — 0 errors. Read `gpu_util_avg_pct` with the caveat in the gotchas: it is a mean over the whole workload window including ramp-up and drain, not a steady-state figure.
