### PR TITLE
results: Qwen/Qwen3.8-Flash-Next on nvidia-gb10-dgx-spark — longctx-depth-sweep-v1 at max-num-seqs 2

### DIFF
--- a/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/c2da0164b1ba1ffc--longctx-depth-sweep-v1--0edba4.json
+++ b/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/c2da0164b1ba1ffc--longctx-depth-sweep-v1--0edba4.json
@@ -1,0 +1,1020 @@
+{
+  "schema_version": 1,
+  "run_id": "c2da0164b1ba1ffc--longctx-depth-sweep-v1--0edba4",
+  "config_id": "c2da0164b1ba1ffc",
+  "cell_id": "146e5bfec676",
+  "workload_id": "longctx-depth-sweep-v1",
+  "kind": "longctx",
+  "engine": {
+    "id": "vllm",
+    "version": "0.1.dev20073+g8e685d198",
+    "commit": "8e685d198",
+    "container": "qwen38-flash-dgx (built from blazux/qwen3.8-Flash-DGX at 82ed48d)",
+    "install_method": "docker"
+  },
+  "model": {
+    "id": "Qwen/Qwen3.8-Flash-Next",
+    "quant_id": "nvfp4",
+    "hf_id": "Qwen/Qwen3.8-Flash-Next",
+    "revision": "7b719225242aacd3dbd3f9407468c2ee9a9d2594",
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "load-format": "safetensors",
+    "max-model-len": 262144,
+    "max-num-seqs": 2,
+    "gpu-memory-utilization": 0.85,
+    "enable-prefix-caching": false,
+    "enable-chunked-prefill": true,
+    "max-num-batched-tokens": 8192,
+    "compilation-config": {
+      "cudagraph_mode": "PIECEWISE",
+      "splitting_ops": [
+        "vllm::unified_attention_with_output",
+        "vllm::unified_mla_attention_with_output",
+        "vllm::mamba_mixer2",
+        "vllm::mamba_mixer",
+        "vllm::short_conv",
+        "vllm::qwen3_8_flash_next_ple_short_conv",
+        "vllm::qwen3_8_flash_next_qsa_with_output",
+        "vllm::linear_attention",
+        "vllm::qwen_gdn_attention_core",
+        "vllm::qwen_gdn_attention_core_fused_norm_packed",
+        "vllm::sparse_attn_indexer",
+        "vllm::ple_mmap_lookup"
+      ]
+    },
+    "enable-flashinfer-autotune": false,
+    "enable-auto-tool-choice": true,
+    "tool-call-parser": "qwen3_coder",
+    "reasoning-parser": "qwen3",
+    "speculative-config": {
+      "method": "mtp",
+      "num_speculative_tokens": 3
+    },
+    "vllm-ple-mmap": 1,
+    "vllm-ple-mmap-workers": 32,
+    "vllm-ple-mmap-prewarm": 1,
+    "vllm-use-flashinfer-sampler": 1
+  },
+  "args_canonical": "@dtype=auto;@quant=nvfp4;compilation-config={\"cudagraph_mode\":\"PIECEWISE\",\"splitting_ops\":[\"vllm::linear_attention\",\"vllm::mamba_mixer\",\"vllm::mamba_mixer2\",\"vllm::ple_mmap_lookup\",\"vllm::qwen3_8_flash_next_ple_short_conv\",\"vllm::qwen3_8_flash_next_qsa_with_output\",\"vllm::qwen_gdn_attention_core\",\"vllm::qwen_gdn_attention_core_fused_norm_packed\",\"vllm::short_conv\",\"vllm::sparse_attn_indexer\",\"vllm::unified_attention_with_output\",\"vllm::unified_mla_attention_with_output\"]};enable-auto-tool-choice=true;enable-chunked-prefill=true;enable-flashinfer-autotune=false;enable-prefix-caching=false;gpu-memory-utilization=0.85;load-format=safetensors;max-model-len=262144;max-num-batched-tokens=8192;max-num-seqs=2;reasoning-parser=qwen3;speculative-config={\"method\":\"mtp\",\"num_speculative_tokens\":3};tool-call-parser=qwen3_coder;vllm-ple-mmap=1;vllm-ple-mmap-prewarm=1;vllm-ple-mmap-workers=32;vllm-use-flashinfer-sampler=1",
+  "serve_command": null,
+  "workload": {
+    "id": "longctx-depth-sweep-v1",
+    "resolved_params": {
+      "axis": "input_tokens",
+      "points": [
+        [
+          1024,
+          90.0
+        ],
+        [
+          4096,
+          90.0
+        ],
+        [
+          8192,
+          90.0
+        ],
+        [
+          16384,
+          90.0
+        ],
+        [
+          32768,
+          90.0
+        ],
+        [
+          65536,
+          90.0
+        ],
+        [
+          131072,
+          90.0
+        ],
+        [
+          262144,
+          90.0
+        ]
+      ],
+      "output_tokens": 256,
+      "needle_check": true,
+      "needle_depth": 0.9,
+      "headline_input_tokens": 131072,
+      "needles_found": 7,
+      "needles_total": 7,
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "timeout_s": 1800.0,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 1,
+    "requests_ok": 1,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 80.149,
+    "input_tokens_total": 160868,
+    "output_tokens_total": 122,
+    "output_tok_s": 1.522,
+    "total_tok_s": 2008.644,
+    "req_s": 0.012,
+    "prefill_tok_s": 2102.995,
+    "ttft_ms": {
+      "mean": 76494.697,
+      "p50": 76494.697,
+      "p90": 76494.697,
+      "p95": 76494.697,
+      "p99": 76494.697,
+      "min": 76494.697,
+      "max": 76494.697
+    },
+    "tpot_ms": {
+      "mean": 30.196,
+      "p50": 30.196,
+      "p90": 30.196,
+      "p95": 30.196,
+      "p99": 30.196,
+      "min": 30.196,
+      "max": 30.196
+    },
+    "itl_ms": {
+      "mean": 96.134,
+      "p50": 96.743,
+      "p90": 102.606,
+      "p95": 106.612,
+      "p99": 122.136,
+      "min": 26.72,
+      "max": 125.269
+    },
+    "e2e_ms": {
+      "mean": 80148.459,
+      "p50": 80148.459,
+      "p90": 80148.459,
+      "p95": 80148.459,
+      "p99": 80148.459,
+      "min": 80148.459,
+      "max": 80148.459
+    },
+    "decode_tok_s_per_request": {
+      "mean": 33.117,
+      "p50": 33.117,
+      "p90": 33.117,
+      "p95": 33.117,
+      "p99": 33.117,
+      "min": 33.117,
+      "max": 33.117
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 112.749,
+    "kv_cache_tokens": null,
+    "power_avg_w": 60.77,
+    "power_peak_w": 63.75,
+    "energy_wh": 1.3505,
+    "gpu_util_avg_pct": 95.68,
+    "temp_max_c": 76.0,
+    "thermal_throttle_detected": false
+  },
+  "sweep": [
+    {
+      "input_tokens": 1024,
+      "output_tokens": 256,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 2.999,
+        "input_tokens_total": 1401,
+        "output_tokens_total": 88,
+        "output_tok_s": 29.344,
+        "total_tok_s": 496.52,
+        "req_s": 0.333,
+        "prefill_tok_s": 1700.657,
+        "ttft_ms": {
+          "mean": 823.799,
+          "p50": 823.799,
+          "p90": 823.799,
+          "p95": 823.799,
+          "p99": 823.799,
+          "min": 823.799,
+          "max": 823.799
+        },
+        "tpot_ms": {
+          "mean": 24.999,
+          "p50": 24.999,
+          "p90": 24.999,
+          "p95": 24.999,
+          "p99": 24.999,
+          "min": 24.999,
+          "max": 24.999
+        },
+        "itl_ms": {
+          "mean": 94.522,
+          "p50": 93.95,
+          "p90": 100.427,
+          "p95": 101.622,
+          "p99": 103.488,
+          "min": 87.384,
+          "max": 103.98
+        },
+        "e2e_ms": {
+          "mean": 2998.692,
+          "p50": 2998.692,
+          "p90": 2998.692,
+          "p95": 2998.692,
+          "p99": 2998.692,
+          "min": 2998.692,
+          "max": 2998.692
+        },
+        "decode_tok_s_per_request": {
+          "mean": 40.002,
+          "p50": 40.002,
+          "p90": 40.002,
+          "p95": 40.002,
+          "p99": 40.002,
+          "min": 40.002,
+          "max": 40.002
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 112.692,
+        "kv_cache_tokens": null,
+        "power_avg_w": 30.85,
+        "power_peak_w": 48.4,
+        "energy_wh": 0.0204,
+        "gpu_util_avg_pct": 59.33,
+        "temp_max_c": 55.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 4096,
+      "output_tokens": 256,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 4.511,
+        "input_tokens_total": 5192,
+        "output_tokens_total": 72,
+        "output_tok_s": 15.962,
+        "total_tok_s": 1166.969,
+        "req_s": 0.222,
+        "prefill_tok_s": 2237.434,
+        "ttft_ms": {
+          "mean": 2320.516,
+          "p50": 2320.516,
+          "p90": 2320.516,
+          "p95": 2320.516,
+          "p99": 2320.516,
+          "min": 2320.516,
+          "max": 2320.516
+        },
+        "tpot_ms": {
+          "mean": 30.846,
+          "p50": 30.846,
+          "p90": 30.846,
+          "p95": 30.846,
+          "p99": 30.846,
+          "min": 30.846,
+          "max": 30.846
+        },
+        "itl_ms": {
+          "mean": 95.188,
+          "p50": 94.225,
+          "p90": 97.238,
+          "p95": 97.273,
+          "p99": 116.35,
+          "min": 89.586,
+          "max": 121.729
+        },
+        "e2e_ms": {
+          "mean": 4510.585,
+          "p50": 4510.585,
+          "p90": 4510.585,
+          "p95": 4510.585,
+          "p99": 4510.585,
+          "min": 4510.585,
+          "max": 4510.585
+        },
+        "decode_tok_s_per_request": {
+          "mean": 32.419,
+          "p50": 32.419,
+          "p90": 32.419,
+          "p95": 32.419,
+          "p99": 32.419,
+          "min": 32.419,
+          "max": 32.419
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 112.694,
+        "kv_cache_tokens": null,
+        "power_avg_w": 43.28,
+        "power_peak_w": 57.68,
+        "energy_wh": 0.0533,
+        "gpu_util_avg_pct": 91.0,
+        "temp_max_c": 56.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 8192,
+      "output_tokens": 256,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 6.713,
+        "input_tokens_total": 10175,
+        "output_tokens_total": 79,
+        "output_tok_s": 11.768,
+        "total_tok_s": 1527.482,
+        "req_s": 0.149,
+        "prefill_tok_s": 2244.612,
+        "ttft_ms": {
+          "mean": 4533.078,
+          "p50": 4533.078,
+          "p90": 4533.078,
+          "p95": 4533.078,
+          "p99": 4533.078,
+          "min": 4533.078,
+          "max": 4533.078
+        },
+        "tpot_ms": {
+          "mean": 27.945,
+          "p50": 27.945,
+          "p90": 27.945,
+          "p95": 27.945,
+          "p99": 27.945,
+          "min": 27.945,
+          "max": 27.945
+        },
+        "itl_ms": {
+          "mean": 94.742,
+          "p50": 94.041,
+          "p90": 100.996,
+          "p95": 103.339,
+          "p99": 105.399,
+          "min": 84.89,
+          "max": 105.907
+        },
+        "e2e_ms": {
+          "mean": 6712.8,
+          "p50": 6712.8,
+          "p90": 6712.8,
+          "p95": 6712.8,
+          "p99": 6712.8,
+          "min": 6712.8,
+          "max": 6712.8
+        },
+        "decode_tok_s_per_request": {
+          "mean": 35.784,
+          "p50": 35.784,
+          "p90": 35.784,
+          "p95": 35.784,
+          "p99": 35.784,
+          "min": 35.784,
+          "max": 35.784
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 112.692,
+        "kv_cache_tokens": null,
+        "power_avg_w": 47.75,
+        "power_peak_w": 58.53,
+        "energy_wh": 0.088,
+        "gpu_util_avg_pct": 94.57,
+        "temp_max_c": 59.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 16384,
+      "output_tokens": 256,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 11.601,
+        "input_tokens_total": 20014,
+        "output_tokens_total": 105,
+        "output_tok_s": 9.051,
+        "total_tok_s": 1734.23,
+        "req_s": 0.086,
+        "prefill_tok_s": 2316.715,
+        "ttft_ms": {
+          "mean": 8638.956,
+          "p50": 8638.956,
+          "p90": 8638.956,
+          "p95": 8638.956,
+          "p99": 8638.956,
+          "min": 8638.956,
+          "max": 8638.956
+        },
+        "tpot_ms": {
+          "mean": 28.481,
+          "p50": 28.481,
+          "p90": 28.481,
+          "p95": 28.481,
+          "p99": 28.481,
+          "min": 28.481,
+          "max": 28.481
+        },
+        "itl_ms": {
+          "mean": 95.529,
+          "p50": 94.814,
+          "p90": 99.227,
+          "p95": 101.158,
+          "p99": 103.065,
+          "min": 88.441,
+          "max": 103.301
+        },
+        "e2e_ms": {
+          "mean": 11600.94,
+          "p50": 11600.94,
+          "p90": 11600.94,
+          "p95": 11600.94,
+          "p99": 11600.94,
+          "min": 11600.94,
+          "max": 11600.94
+        },
+        "decode_tok_s_per_request": {
+          "mean": 35.112,
+          "p50": 35.112,
+          "p90": 35.112,
+          "p95": 35.112,
+          "p99": 35.112,
+          "min": 35.112,
+          "max": 35.112
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 112.692,
+        "kv_cache_tokens": null,
+        "power_avg_w": 50.43,
+        "power_peak_w": 59.15,
+        "energy_wh": 0.1669,
+        "gpu_util_avg_pct": 94.42,
+        "temp_max_c": 62.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 32768,
+      "output_tokens": 256,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 21.269,
+        "input_tokens_total": 40356,
+        "output_tokens_total": 103,
+        "output_tok_s": 4.843,
+        "total_tok_s": 1902.268,
+        "req_s": 0.047,
+        "prefill_tok_s": 2242.77,
+        "ttft_ms": {
+          "mean": 17993.819,
+          "p50": 17993.819,
+          "p90": 17993.819,
+          "p95": 17993.819,
+          "p99": 17993.819,
+          "min": 17993.819,
+          "max": 17993.819
+        },
+        "tpot_ms": {
+          "mean": 32.106,
+          "p50": 32.106,
+          "p90": 32.106,
+          "p95": 32.106,
+          "p99": 32.106,
+          "min": 32.106,
+          "max": 32.106
+        },
+        "itl_ms": {
+          "mean": 96.29,
+          "p50": 95.017,
+          "p90": 100.742,
+          "p95": 101.315,
+          "p99": 116.424,
+          "min": 70.774,
+          "max": 123.392
+        },
+        "e2e_ms": {
+          "mean": 21268.617,
+          "p50": 21268.617,
+          "p90": 21268.617,
+          "p95": 21268.617,
+          "p99": 21268.617,
+          "min": 21268.617,
+          "max": 21268.617
+        },
+        "decode_tok_s_per_request": {
+          "mean": 31.147,
+          "p50": 31.147,
+          "p90": 31.147,
+          "p95": 31.147,
+          "p99": 31.147,
+          "min": 31.147,
+          "max": 31.147
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 112.7,
+        "kv_cache_tokens": null,
+        "power_avg_w": 53.74,
+        "power_peak_w": 61.32,
+        "energy_wh": 0.319,
+        "gpu_util_avg_pct": 95.33,
+        "temp_max_c": 66.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 65536,
+      "output_tokens": 256,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 38.155,
+        "input_tokens_total": 80504,
+        "output_tokens_total": 77,
+        "output_tok_s": 2.018,
+        "total_tok_s": 2111.954,
+        "req_s": 0.026,
+        "prefill_tok_s": 2239.004,
+        "ttft_ms": {
+          "mean": 35955.271,
+          "p50": 35955.271,
+          "p90": 35955.271,
+          "p95": 35955.271,
+          "p99": 35955.271,
+          "min": 35955.271,
+          "max": 35955.271
+        },
+        "tpot_ms": {
+          "mean": 28.938,
+          "p50": 28.938,
+          "p90": 28.938,
+          "p95": 28.938,
+          "p99": 28.938,
+          "min": 28.938,
+          "max": 28.938
+        },
+        "itl_ms": {
+          "mean": 95.59,
+          "p50": 96.456,
+          "p90": 101.806,
+          "p95": 103.159,
+          "p99": 106.301,
+          "min": 83.563,
+          "max": 107.145
+        },
+        "e2e_ms": {
+          "mean": 38154.526,
+          "p50": 38154.526,
+          "p90": 38154.526,
+          "p95": 38154.526,
+          "p99": 38154.526,
+          "min": 38154.526,
+          "max": 38154.526
+        },
+        "decode_tok_s_per_request": {
+          "mean": 34.557,
+          "p50": 34.557,
+          "p90": 34.557,
+          "p95": 34.557,
+          "p99": 34.557,
+          "min": 34.557,
+          "max": 34.557
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 112.726,
+        "kv_cache_tokens": null,
+        "power_avg_w": 58.62,
+        "power_peak_w": 62.18,
+        "energy_wh": 0.6207,
+        "gpu_util_avg_pct": 94.97,
+        "temp_max_c": 72.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 131072,
+      "output_tokens": 256,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 80.149,
+        "input_tokens_total": 160868,
+        "output_tokens_total": 122,
+        "output_tok_s": 1.522,
+        "total_tok_s": 2008.644,
+        "req_s": 0.012,
+        "prefill_tok_s": 2102.995,
+        "ttft_ms": {
+          "mean": 76494.697,
+          "p50": 76494.697,
+          "p90": 76494.697,
+          "p95": 76494.697,
+          "p99": 76494.697,
+          "min": 76494.697,
+          "max": 76494.697
+        },
+        "tpot_ms": {
+          "mean": 30.196,
+          "p50": 30.196,
+          "p90": 30.196,
+          "p95": 30.196,
+          "p99": 30.196,
+          "min": 30.196,
+          "max": 30.196
+        },
+        "itl_ms": {
+          "mean": 96.134,
+          "p50": 96.743,
+          "p90": 102.606,
+          "p95": 106.612,
+          "p99": 122.136,
+          "min": 26.72,
+          "max": 125.269
+        },
+        "e2e_ms": {
+          "mean": 80148.459,
+          "p50": 80148.459,
+          "p90": 80148.459,
+          "p95": 80148.459,
+          "p99": 80148.459,
+          "min": 80148.459,
+          "max": 80148.459
+        },
+        "decode_tok_s_per_request": {
+          "mean": 33.117,
+          "p50": 33.117,
+          "p90": 33.117,
+          "p95": 33.117,
+          "p99": 33.117,
+          "min": 33.117,
+          "max": 33.117
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 112.749,
+        "kv_cache_tokens": null,
+        "power_avg_w": 60.77,
+        "power_peak_w": 63.75,
+        "energy_wh": 1.3505,
+        "gpu_util_avg_pct": 95.68,
+        "temp_max_c": 76.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 262144,
+      "output_tokens": 256,
+      "label": "depth 90% · needle n/a",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 0,
+        "requests_failed": 1,
+        "success_rate": 0.0,
+        "duration_s": 0.953,
+        "input_tokens_total": 0,
+        "output_tokens_total": 0,
+        "output_tok_s": 0.0,
+        "total_tok_s": 0.0,
+        "req_s": 0.0,
+        "prefill_tok_s": null,
+        "ttft_ms": null,
+        "tpot_ms": null,
+        "itl_ms": null,
+        "e2e_ms": null,
+        "decode_tok_s_per_request": null,
+        "vram_peak_gb": null,
+        "ram_peak_gb": 112.72,
+        "kv_cache_tokens": null,
+        "power_avg_w": 37.74,
+        "power_peak_w": 37.74,
+        "energy_wh": 0.0,
+        "gpu_util_avg_pct": 91.0,
+        "temp_max_c": 68.0,
+        "thermal_throttle_detected": false
+      }
+    }
+  ],
+  "failures": [
+    {
+      "at": "request",
+      "count": 1,
+      "category": "context-overflow",
+      "message": "{\"error\":{\"message\":\"This model's maximum context length is 262144 tokens. However, you requested 256 output tokens and your prompt contains at least 261889 input tokens, for a total of at least 262145 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=261889)\",\"type\":\"BadRequestError\",\"param\":\"input_tokens\",\"code\":400}}",
+      "sample_request_id": "ctx262144-r00000"
+    }
+  ],
+  "gotchas": [
+    {
+      "severity": "warn",
+      "text": "Requests exceeded the model's context window; the workload's input length does not fit this configuration."
+    },
+    {
+      "severity": "info",
+      "text": "--max-num-seqs is 2 here. That is the value the upstream container ships, and this arm exists to measure it rather than to recommend it: the paired arm of this cell runs the identical configuration at 64. Two slots is a scheduler cap and not a memory limit - at GPU_MEM=0.85 the server reports a KV pool of 654,635 tokens while 64 concurrent 1.3k-token requests need about 83,000 - so every workload here above concurrency 2 measures QUEUE DEPTH against a two-slot server, not parallelism at 8 or 16 or 64. Read those cells that way: aggregate throughput stays near the two-stream number and per-request latency grows with N/2, and at high N, against a workload timeout of 300 s, tail requests can exceed it and depress success_rate. That is the cap, not a failure of the engine. Aggregate decode against N concurrent 256-token requests on this box was measured at 24.3 tok/s at N=1, 56.2 at 2, 80.2 at 4, 114.6 at 8, 220.5 at 16, 210.9 at 32 and 236.2 at 64, so the cap costs roughly a factor of four at the plateau. Never compare a cell from this arm against one from the 64 arm without saying which is which."
+    },
+    {
+      "severity": "info",
+      "text": "Speculative decoding is ON and it is the model's own trained MTP head (--speculative-config {method: mtp, num_speculative_tokens: 3}), not n-gram drafting. Because the head is trained rather than copying from the prompt, throughput is nearly flat across task shapes - the recipe measures a 1.2x spread over four editing and prose tasks where the llama.cpp/ngram-mod recipe for the same model swings 3.2x. Never compare a decode figure here against a cell run with different speculation."
+    },
+    {
+      "severity": "info",
+      "text": "Prefix caching must stay off (--no-enable-prefix-caching) - it is a GB10 GDN kernel bug, not a tuning choice. One upside: the prefill figures here are honest, because nothing is served from cache. Full torch.compile is also off (an Inductor int64-indexing assert on sm_121); the recipe instead declares the n-gram gather a splitting op and captures PIECEWISE CUDA graphs, and switching to a FULL capture mode breaks the run."
+    },
+    {
+      "severity": "info",
+      "text": "A third of this checkpoint is served from NVMe, so page-cache state is a hidden independent variable and any result from this configuration that does not state it is not reproducible. Residency of the 47.75 GiB n-gram table was measured with mincore(2) immediately before this workload started: 100.0% of it was in the page cache."
+    },
+    {
+      "severity": "info",
+      "text": "VLLM_PLE_CPU_OFFLOAD=1, the official pinned-host-RAM path, hangs on this box: it registers a PleOffloadLayer and then spins a core with no disk I/O, indefinitely. Only VLLM_PLE_MMAP works here. The four VLLM_PLE_* / VLLM_USE_* environment variables are recorded in args for that reason - they are not CLI flags, but VLLM_PLE_MMAP is the difference between the model loading and not loading."
+    },
+    {
+      "severity": "info",
+      "text": "Read gpu_util_avg_pct here with care, and do NOT read a lower average at higher concurrency as evidence of stalling. It is a mean over the ENTIRE workload window - the sampler runs for the whole measured window and summarize() averages every sample it took, with no filtering of warmup, ramp-up or drain - so it is not a steady-state figure. A workload that completes few waves spends proportionally more of its window ramping up and draining with the batch half empty, and that alone drags the mean down: serve-chat-c32 runs 12.5 waves at 76.8 s per wave against serve-short-c16 at 20 waves and 13.5 s, and reports 80.3 percent against 90.7. power_avg_w is averaged the same way and carries the same artefact. An earlier version of this note treated that c16-to-c32 difference as a stall signature on a unified-memory part; that inference was not supported by these numbers and is withdrawn. What IS verified, by sampling utilization.gpu directly during active generation on this box, is that the instantaneous figure does track real work - 88 to 96 percent with four requests generating - so unlike some unified-memory utilisation counters this one is not measuring something unrelated. Two further caveats on the telemetry itself: vram_peak_gb is null in every result here because there is no separate device memory to measure and nvidia-smi reports fb_memory_total as 0, so ram_peak_gb is the real occupancy figure; and the power figures are whatever the driver exposes on this part, which may not account for the whole SoC, so treat them as a relative signal across these runs rather than as absolute wall power."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": 0.025,
+    "tok_s_per_gb_bandwidth": 0.121308,
+    "bandwidth_efficiency": 0.435619,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "f8c022d7dae319da09bdff57809ef2088916c2201a66c34b9fd0243b838ce7a1",
+    "payload_path": null,
+    "payload": {
+      "points": [
+        {
+          "id": "hay-1k-d90",
+          "input_tokens": 1024,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 29.344,
+          "decode_tok_s": 40.002,
+          "ttft_ms": 823.799,
+          "success_rate": 1.0
+        },
+        {
+          "id": "hay-4k-d90",
+          "input_tokens": 4096,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 15.962,
+          "decode_tok_s": 32.419,
+          "ttft_ms": 2320.516,
+          "success_rate": 1.0
+        },
+        {
+          "id": "hay-8k-d90",
+          "input_tokens": 8192,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 11.768,
+          "decode_tok_s": 35.784,
+          "ttft_ms": 4533.078,
+          "success_rate": 1.0
+        },
+        {
+          "id": "hay-16k-d90",
+          "input_tokens": 16384,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 9.051,
+          "decode_tok_s": 35.112,
+          "ttft_ms": 8638.956,
+          "success_rate": 1.0
+        },
+        {
+          "id": "hay-32k-d90",
+          "input_tokens": 32768,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 4.843,
+          "decode_tok_s": 31.147,
+          "ttft_ms": 17993.819,
+          "success_rate": 1.0
+        },
+        {
+          "id": "hay-64k-d90",
+          "input_tokens": 65536,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 2.018,
+          "decode_tok_s": 34.557,
+          "ttft_ms": 35955.271,
+          "success_rate": 1.0
+        },
+        {
+          "id": "hay-128k-d90",
+          "input_tokens": 131072,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 1.522,
+          "decode_tok_s": 33.117,
+          "ttft_ms": 76494.697,
+          "success_rate": 1.0
+        },
+        {
+          "id": "hay-256k-d90",
+          "input_tokens": 262144,
+          "depth_pct": 90.0,
+          "needle_correct": null,
+          "output_tok_s": 0.0,
+          "decode_tok_s": null,
+          "ttft_ms": null,
+          "success_rate": 0.0
+        }
+      ],
+      "requests": [
+        {
+          "id": "ctx1024-r00000",
+          "prompt_id": "hay-1k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 823.799,
+          "e2e_ms": 2998.692,
+          "prompt_tokens": 1401,
+          "completion_tokens": 88,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx4096-r00000",
+          "prompt_id": "hay-4k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 2320.516,
+          "e2e_ms": 4510.585,
+          "prompt_tokens": 5192,
+          "completion_tokens": 72,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx8192-r00000",
+          "prompt_id": "hay-8k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 4533.078,
+          "e2e_ms": 6712.8,
+          "prompt_tokens": 10175,
+          "completion_tokens": 79,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx16384-r00000",
+          "prompt_id": "hay-16k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 8638.956,
+          "e2e_ms": 11600.94,
+          "prompt_tokens": 20014,
+          "completion_tokens": 105,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx32768-r00000",
+          "prompt_id": "hay-32k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 17993.819,
+          "e2e_ms": 21268.617,
+          "prompt_tokens": 40356,
+          "completion_tokens": 103,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx65536-r00000",
+          "prompt_id": "hay-64k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 35955.271,
+          "e2e_ms": 38154.526,
+          "prompt_tokens": 80504,
+          "completion_tokens": 77,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx131072-r00000",
+          "prompt_id": "hay-128k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 76494.697,
+          "e2e_ms": 80148.459,
+          "prompt_tokens": 160868,
+          "completion_tokens": 122,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx262144-r00000",
+          "prompt_id": "hay-256k-d90",
+          "warmup": false,
+          "status": "error",
+          "ttft_ms": null,
+          "e2e_ms": 445.424,
+          "prompt_tokens": null,
+          "completion_tokens": null,
+          "token_source": "usage",
+          "finish_reason": null,
+          "error_category": "context-overflow"
+        }
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "qwen3.8-flash-next",
+        "advertised_models": [
+          "qwen3.8-flash-next"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-29T19:47:44Z",
+    "finished_at": "2026-08-29T19:50:31Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Box WAS dedicated: this DGX Spark runs no desktop session, and no compile or dev server ran on it during the sweep. Isolation check: the only route to it from outside the box is an SSH tunnel opened by a reverse proxy on the same private network, and that tunnel was stopped before the first run and stayed stopped throughout, so no external client could contend for the GPU. The GPU compute-app list sampled immediately before this workload contained exactly: VLLM::EngineCore. NVIDIA DGX Spark (ASUS Ascent GX10, GB10 / SM121, 128 GB unified memory, ~121 GiB usable) on Ubuntu 24.04.4 LTS, kernel 6.17.0-1029-nvidia aarch64, driver 580.173.02, CUDA 13.0. Swap is off. Engine is the container from the long-context recipe of github.com/0xBakeer/qwen38-flash-next-spark (commit 1611340), which builds github.com/blazux/qwen3.8-Flash-DGX (Apache-2.0) at 82ed48d; pip reports the build as vLLM 0.1.dev20073+g8e685d198, i.e. upstream commit 8e685d198 plus that fork's Qwen3.8-Flash-Next support. Weights are RadixArk/Qwen3.8-Flash-Next-NVFP4 at revision 7b71922, 206 safetensors shards, 135,156,121,594 bytes of tensor data. The server was started by the recipe's own recipes/vllm-longctx/serve.sh with its shipped defaults (CTX=262144, SEQS=2, GPU_MEM=0.85, MTP=3, PREWARM=1, WORKERS=32) and nothing else; the flags in args are exactly what that produced. The defining choice is VLLM_PLE_MMAP=1: the 51.2B-parameter n-gram/PLE embedding table, 47.75 GiB spread over 12 of the 206 shards, is gathered from the checkpoint on disk through the OS page cache instead of being made resident, which is the only reason a 126 GiB checkpoint runs next to a usable KV cache in 128 GB. KV was measured by the server at 18.13 GiB. The container publishes 127.0.0.1:8000 only and the harness connects to it directly, so no proxy sits in the measured path."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/c2da0164b1ba1ffc--longctx-depth-sweep-v1--0edba4.json
+++ b/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/c2da0164b1ba1ffc--longctx-depth-sweep-v1--0edba4.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -101,35 +101,35 @@
       "points": [
         [
           1024,
-          90.0
+          90
         ],
         [
           4096,
-          90.0
+          90
         ],
         [
           8192,
-          90.0
+          90
         ],
         [
           16384,
-          90.0
+          90
         ],
         [
           32768,
-          90.0
+          90
         ],
         [
           65536,
-          90.0
+          90
         ],
         [
           131072,
-          90.0
+          90
         ],
         [
           262144,
-          90.0
+          90
         ]
       ],
       "output_tokens": 256,
@@ -140,7 +140,7 @@
       "needles_total": 7,
       "dataset_categories": null,
       "dataset_target_tokens": null,
-      "timeout_s": 1800.0,
+      "timeout_s": 1800,
       "seed": 42
     }
   },
@@ -148,7 +148,7 @@
     "requests_total": 1,
     "requests_ok": 1,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 80.149,
     "input_tokens_total": 160868,
     "output_tokens_total": 122,
@@ -208,7 +208,7 @@
     "power_peak_w": 63.75,
     "energy_wh": 1.3505,
     "gpu_util_avg_pct": 95.68,
-    "temp_max_c": 76.0,
+    "temp_max_c": 76,
     "thermal_throttle_detected": false
   },
   "sweep": [
@@ -220,7 +220,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 2.999,
         "input_tokens_total": 1401,
         "output_tokens_total": 88,
@@ -280,7 +280,7 @@
         "power_peak_w": 48.4,
         "energy_wh": 0.0204,
         "gpu_util_avg_pct": 59.33,
-        "temp_max_c": 55.0,
+        "temp_max_c": 55,
         "thermal_throttle_detected": false
       }
     },
@@ -292,7 +292,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 4.511,
         "input_tokens_total": 5192,
         "output_tokens_total": 72,
@@ -351,8 +351,8 @@
         "power_avg_w": 43.28,
         "power_peak_w": 57.68,
         "energy_wh": 0.0533,
-        "gpu_util_avg_pct": 91.0,
-        "temp_max_c": 56.0,
+        "gpu_util_avg_pct": 91,
+        "temp_max_c": 56,
         "thermal_throttle_detected": false
       }
     },
@@ -364,7 +364,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 6.713,
         "input_tokens_total": 10175,
         "output_tokens_total": 79,
@@ -424,7 +424,7 @@
         "power_peak_w": 58.53,
         "energy_wh": 0.088,
         "gpu_util_avg_pct": 94.57,
-        "temp_max_c": 59.0,
+        "temp_max_c": 59,
         "thermal_throttle_detected": false
       }
     },
@@ -436,7 +436,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 11.601,
         "input_tokens_total": 20014,
         "output_tokens_total": 105,
@@ -496,7 +496,7 @@
         "power_peak_w": 59.15,
         "energy_wh": 0.1669,
         "gpu_util_avg_pct": 94.42,
-        "temp_max_c": 62.0,
+        "temp_max_c": 62,
         "thermal_throttle_detected": false
       }
     },
@@ -508,7 +508,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 21.269,
         "input_tokens_total": 40356,
         "output_tokens_total": 103,
@@ -568,7 +568,7 @@
         "power_peak_w": 61.32,
         "energy_wh": 0.319,
         "gpu_util_avg_pct": 95.33,
-        "temp_max_c": 66.0,
+        "temp_max_c": 66,
         "thermal_throttle_detected": false
       }
     },
@@ -580,7 +580,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 38.155,
         "input_tokens_total": 80504,
         "output_tokens_total": 77,
@@ -640,7 +640,7 @@
         "power_peak_w": 62.18,
         "energy_wh": 0.6207,
         "gpu_util_avg_pct": 94.97,
-        "temp_max_c": 72.0,
+        "temp_max_c": 72,
         "thermal_throttle_detected": false
       }
     },
@@ -652,7 +652,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 80.149,
         "input_tokens_total": 160868,
         "output_tokens_total": 122,
@@ -712,7 +712,7 @@
         "power_peak_w": 63.75,
         "energy_wh": 1.3505,
         "gpu_util_avg_pct": 95.68,
-        "temp_max_c": 76.0,
+        "temp_max_c": 76,
         "thermal_throttle_detected": false
       }
     },
@@ -724,13 +724,13 @@
         "requests_total": 1,
         "requests_ok": 0,
         "requests_failed": 1,
-        "success_rate": 0.0,
+        "success_rate": 0,
         "duration_s": 0.953,
         "input_tokens_total": 0,
         "output_tokens_total": 0,
-        "output_tok_s": 0.0,
-        "total_tok_s": 0.0,
-        "req_s": 0.0,
+        "output_tok_s": 0,
+        "total_tok_s": 0,
+        "req_s": 0,
         "prefill_tok_s": null,
         "ttft_ms": null,
         "tpot_ms": null,
@@ -742,9 +742,9 @@
         "kv_cache_tokens": null,
         "power_avg_w": 37.74,
         "power_peak_w": 37.74,
-        "energy_wh": 0.0,
-        "gpu_util_avg_pct": 91.0,
-        "temp_max_c": 68.0,
+        "energy_wh": 0,
+        "gpu_util_avg_pct": 91,
+        "temp_max_c": 68,
         "thermal_throttle_detected": false
       }
     }
@@ -805,82 +805,82 @@
         {
           "id": "hay-1k-d90",
           "input_tokens": 1024,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 29.344,
           "decode_tok_s": 40.002,
           "ttft_ms": 823.799,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "hay-4k-d90",
           "input_tokens": 4096,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 15.962,
           "decode_tok_s": 32.419,
           "ttft_ms": 2320.516,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "hay-8k-d90",
           "input_tokens": 8192,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 11.768,
           "decode_tok_s": 35.784,
           "ttft_ms": 4533.078,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "hay-16k-d90",
           "input_tokens": 16384,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 9.051,
           "decode_tok_s": 35.112,
           "ttft_ms": 8638.956,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "hay-32k-d90",
           "input_tokens": 32768,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 4.843,
           "decode_tok_s": 31.147,
           "ttft_ms": 17993.819,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "hay-64k-d90",
           "input_tokens": 65536,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 2.018,
           "decode_tok_s": 34.557,
           "ttft_ms": 35955.271,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "hay-128k-d90",
           "input_tokens": 131072,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 1.522,
           "decode_tok_s": 33.117,
           "ttft_ms": 76494.697,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "hay-256k-d90",
           "input_tokens": 262144,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": null,
-          "output_tok_s": 0.0,
+          "output_tok_s": 0,
           "decode_tok_s": null,
           "ttft_ms": null,
-          "success_rate": 0.0
+          "success_rate": 0
         }
       ],
       "requests": [
@@ -1002,7 +1002,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-29T19:47:44Z",
     "finished_at": "2026-08-29T19:50:31Z",
     "submitted_at": null,


### PR DESCRIPTION
### Cells filled

- **Engine** — `vllm` `0.1.dev20073+g8e685d198`
- **Model / quant** — `Qwen/Qwen3.8-Flash-Next` / `nvfp4`
- **Hardware** — `nvidia-gb10-dgx-spark` x1
- **Workload** — `longctx-depth-sweep-v1` (longctx)
- **Headline** — **1.5 output tok/s** aggregate, 33.1 tok/s per request, TTFT p50 76,494.7 ms, success 1.000

One file: `results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/c2da0164b1ba1ffc--longctx-depth-sweep-v1--0edba4.json`

### What failed

- `None` x1 — {"error":{"message":"This model's maximum context length is 262144 tokens. However, you requested 256 output tokens and your prompt contains at least 261889 input tokens, for a total of at least 262145 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=261889)","type":"BadRequestError","param":"input_tokens","code":400}}

### Gotchas

- **warn** — Requests exceeded the model's context window; the workload's input length does not fit this configuration..
- **info** — --max-num-seqs is 2 here.
- **info** — Speculative decoding is ON and it is the model's own trained MTP head (--speculative-config {method: mtp, num_speculative_tokens: 3}), not n-gram drafting.
- **info** — Prefix caching must stay off (--no-enable-prefix-caching) - it is a GB10 GDN kernel bug, not a tuning choice.
- **info** — A third of this checkpoint is served from NVMe, so page-cache state is a hidden independent variable and any result from this configuration that does not state it is not reproducible.
- **info** — VLLM_PLE_CPU_OFFLOAD=1, the official pinned-host-RAM path, hangs on this box: it registers a PleOffloadLayer and then spins a core with no disk I/O, indefinitely.
- **info** — Read gpu_util_avg_pct here with care, and do NOT read a lower average at higher concurrency as evidence of stalling.

### Conditions

Dedicated box, nothing else resident on the GPU, no compile running. The one route into this machine from elsewhere on its private network is an SSH tunnel from a reverse proxy; it was stopped before the first run and stayed stopped. The harness talks to loopback with no proxy in the measured path.

n-gram table page-cache residency, `mincore(2)`: **100.0% before the workload, 100.0% after**.

| | |
|---|---:|
| peak host RAM | 112.7 GB |
| average GPU utilisation | 95.7 % |
| average / peak power | 60.8 / 63.8 W |
| max temperature | 76 C |
| thermal throttling | not detected |
| wall clock | 80.1 s |

`pnpm validate` — 0 errors. Read `gpu_util_avg_pct` with the caveat in the gotchas: it is a mean over the whole workload window including ramp-up and drain, not a steady-state figure.
