### PR TITLE
results: Qwen/Qwen3.8-Flash-Next on nvidia-gb10-dgx-spark — eval-vision-v1 at parallel 2 with vision

### DIFF
--- a/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-vision-v1--320373.json
+++ b/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-vision-v1--320373.json
@@ -1,0 +1,835 @@
+{
+  "schema_version": 1,
+  "run_id": "0cad79844e7b427c--eval-vision-v1--320373",
+  "config_id": "0cad79844e7b427c",
+  "cell_id": "1ab063de12eb",
+  "workload_id": "eval-vision-v1",
+  "kind": "eval",
+  "engine": {
+    "id": "llamacpp",
+    "version": "b50-035e227",
+    "commit": null,
+    "container": null,
+    "install_method": "source"
+  },
+  "model": {
+    "id": "Qwen/Qwen3.8-Flash-Next",
+    "quant_id": "gguf-ud-q4-k-xl",
+    "hf_id": "Qwen/Qwen3.8-Flash-Next",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "ctx-size": 262144,
+    "n-gpu-layers": 999,
+    "parallel": 2,
+    "override-tensor": "per_layer_token_embd=CPU",
+    "load-mode": "mmap",
+    "spec-type": "ngram-mod",
+    "temp": 1.0,
+    "top-p": 0.95,
+    "top-k": 20,
+    "mmproj": "mmproj-F16.gguf"
+  },
+  "args_canonical": "@dtype=auto;@quant=gguf-ud-q4-k-xl;ctx-size=262144;load-mode=mmap;mmproj=mmproj-F16.gguf;n-gpu-layers=999;override-tensor=per_layer_token_embd=CPU;parallel=2;spec-type=ngram-mod;temp=1;top-k=20",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-vision-v1",
+    "resolved_params": {
+      "dataset_id": "eval-vision-v1",
+      "suite": "vision",
+      "scorer": "vision",
+      "items": 60,
+      "concurrency": 4,
+      "max_output_tokens": 2048,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 60,
+    "requests_ok": 60,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 598.178,
+    "input_tokens_total": 10624,
+    "output_tokens_total": 19440,
+    "e2e_ms": {
+      "mean": 39002.923,
+      "p50": 26906.994,
+      "p90": 104335.401,
+      "p95": 115176.401,
+      "p99": 196791.372,
+      "min": 5784.309,
+      "max": 197896.762
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 100.965,
+    "power_avg_w": 38.42,
+    "power_peak_w": 56.49,
+    "energy_wh": 6.3812,
+    "gpu_util_avg_pct": 85.79,
+    "temp_max_c": 69.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "vision",
+    "total": 60,
+    "correct": 58,
+    "accuracy": 0.966667,
+    "success_rate": 1.0,
+    "by_category": {
+      "arrows": {
+        "total": 8,
+        "correct": 8
+      },
+      "chart": {
+        "total": 10,
+        "correct": 10
+      },
+      "clock": {
+        "total": 8,
+        "correct": 7
+      },
+      "dice": {
+        "total": 6,
+        "correct": 6
+      },
+      "grid": {
+        "total": 6,
+        "correct": 6
+      },
+      "ocr": {
+        "total": 10,
+        "correct": 10
+      },
+      "shapes": {
+        "total": 12,
+        "correct": 11
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 38,
+        "correct": 38
+      },
+      "hard": {
+        "total": 8,
+        "correct": 7
+      },
+      "medium": {
+        "total": 14,
+        "correct": 13
+      }
+    },
+    "avg_output_tokens": 324.0,
+    "avg_latency_ms": 39002.92,
+    "failures": 0,
+    "items": [
+      {
+        "id": "vis-0001",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 8120.349,
+        "output_tokens": 114,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0002",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 23943.816,
+        "output_tokens": 241,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0003",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 14568.524,
+        "output_tokens": 194,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0004",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 26660.794,
+        "output_tokens": 170,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0005",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 27304.079,
+        "output_tokens": 157,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0006",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 26098.148,
+        "output_tokens": 209,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0007",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 26899.767,
+        "output_tokens": 234,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0008",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 27786.27,
+        "output_tokens": 203,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0009",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 32489.417,
+        "output_tokens": 249,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0010",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 21771.611,
+        "output_tokens": 138,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0011",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 21714.106,
+        "output_tokens": 143,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0012",
+        "correct": false,
+        "predicted": "",
+        "expected": "bottom-right",
+        "latency_ms": 146955.328,
+        "output_tokens": 2048,
+        "category": "shapes",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0013",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 14857.655,
+        "output_tokens": 59,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0014",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 26914.222,
+        "output_tokens": 292,
+        "category": "chart",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0015",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 29176.866,
+        "output_tokens": 103,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0016",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 37282.024,
+        "output_tokens": 214,
+        "category": "chart",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0017",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 28378.624,
+        "output_tokens": 135,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0018",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 35258.591,
+        "output_tokens": 224,
+        "category": "chart",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0019",
+        "correct": true,
+        "predicted": "No",
+        "expected": "no",
+        "latency_ms": 37693.86,
+        "output_tokens": 252,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0020",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 38756.128,
+        "output_tokens": 151,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0021",
+        "correct": true,
+        "predicted": "Yes",
+        "expected": "yes",
+        "latency_ms": 34845.689,
+        "output_tokens": 196,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0022",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 28244.498,
+        "output_tokens": 138,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0023",
+        "correct": true,
+        "predicted": "104170",
+        "expected": "104170",
+        "latency_ms": 23532.023,
+        "output_tokens": 67,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0024",
+        "correct": true,
+        "predicted": "A32-9207",
+        "expected": "A32-9207",
+        "latency_ms": 17961.832,
+        "output_tokens": 55,
+        "category": "ocr",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0025",
+        "correct": true,
+        "predicted": "COMPASS",
+        "expected": "COMPASS",
+        "latency_ms": 13229.576,
+        "output_tokens": 52,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0026",
+        "correct": true,
+        "predicted": "926725",
+        "expected": "926725",
+        "latency_ms": 12796.411,
+        "output_tokens": 68,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0027",
+        "correct": true,
+        "predicted": "P10-9941",
+        "expected": "P10-9941",
+        "latency_ms": 13396.098,
+        "output_tokens": 55,
+        "category": "ocr",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0028",
+        "correct": true,
+        "predicted": "PLATFORM",
+        "expected": "PLATFORM",
+        "latency_ms": 13006.411,
+        "output_tokens": 59,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0029",
+        "correct": true,
+        "predicted": "921021",
+        "expected": "921021",
+        "latency_ms": 9556.048,
+        "output_tokens": 68,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0030",
+        "correct": true,
+        "predicted": "S33-7805",
+        "expected": "S33-7805",
+        "latency_ms": 10161.633,
+        "output_tokens": 54,
+        "category": "ocr",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0031",
+        "correct": true,
+        "predicted": "PLATFORM",
+        "expected": "PLATFORM",
+        "latency_ms": 8851.605,
+        "output_tokens": 63,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0032",
+        "correct": true,
+        "predicted": "498775",
+        "expected": "498775",
+        "latency_ms": 13181.987,
+        "output_tokens": 118,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0033",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 19504.604,
+        "output_tokens": 222,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0034",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 22328.16,
+        "output_tokens": 223,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0035",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 28016.368,
+        "output_tokens": 207,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0036",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 27391.141,
+        "output_tokens": 222,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0037",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 29215.152,
+        "output_tokens": 287,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0038",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 26477.099,
+        "output_tokens": 230,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0039",
+        "correct": true,
+        "predicted": "up",
+        "expected": "up",
+        "latency_ms": 22932.689,
+        "output_tokens": 82,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0040",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 30986.375,
+        "output_tokens": 239,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0041",
+        "correct": true,
+        "predicted": "left",
+        "expected": "left",
+        "latency_ms": 10305.029,
+        "output_tokens": 50,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0042",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 13779.765,
+        "output_tokens": 141,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0043",
+        "correct": true,
+        "predicted": "up",
+        "expected": "up",
+        "latency_ms": 12927.669,
+        "output_tokens": 82,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0044",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 21758.714,
+        "output_tokens": 188,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0045",
+        "correct": true,
+        "predicted": "up",
+        "expected": "up",
+        "latency_ms": 5784.309,
+        "output_tokens": 82,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0046",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 14728.634,
+        "output_tokens": 174,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0047",
+        "correct": true,
+        "predicted": "12:10",
+        "expected": "12:10",
+        "latency_ms": 33814.745,
+        "output_tokens": 384,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0048",
+        "correct": true,
+        "predicted": "6:10",
+        "expected": "6:10",
+        "latency_ms": 89528.522,
+        "output_tokens": 1348,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0049",
+        "correct": true,
+        "predicted": "1:25",
+        "expected": "1:25",
+        "latency_ms": 113503.826,
+        "output_tokens": 1581,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0050",
+        "correct": true,
+        "predicted": "11:20",
+        "expected": "11:20",
+        "latency_ms": 197896.762,
+        "output_tokens": 2014,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0051",
+        "correct": true,
+        "predicted": "11:00",
+        "expected": "11:00",
+        "latency_ms": 104110.683,
+        "output_tokens": 238,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0052",
+        "correct": true,
+        "predicted": "6:20",
+        "expected": "6:20",
+        "latency_ms": 109995.119,
+        "output_tokens": 1146,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0053",
+        "correct": false,
+        "predicted": "",
+        "expected": "10:35",
+        "latency_ms": 196023.219,
+        "output_tokens": 2048,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0054",
+        "correct": true,
+        "predicted": "9:20",
+        "expected": "9:20",
+        "latency_ms": 106357.864,
+        "output_tokens": 628,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0055",
+        "correct": true,
+        "predicted": "11",
+        "expected": "11",
+        "latency_ms": 59270.691,
+        "output_tokens": 267,
+        "category": "dice",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0056",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 58467.48,
+        "output_tokens": 129,
+        "category": "dice",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0057",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 40257.56,
+        "output_tokens": 263,
+        "category": "dice",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0058",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 31894.334,
+        "output_tokens": 117,
+        "category": "dice",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0059",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 35552.274,
+        "output_tokens": 203,
+        "category": "dice",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0060",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 25972.623,
+        "output_tokens": 122,
+        "category": "dice",
+        "difficulty": "easy"
+      }
+    ]
+  },
+  "failures": [],
+  "gotchas": [
+    {
+      "severity": "info",
+      "text": "--parallel is 2 here, not the 1 the recipe ships. The recipe documents that concurrency does not abort the server but does not batch either at one slot, and it never tries a second slot. Two slots were verified on this build before this run: the server reports n_slots 2 and two concurrent requests both returned 200 with coherent output on the same pid. Upstream does keep a GGML_ASSERT in qwen4exp.cpp that rejects a token belonging to more than one sequence - PLE n-gram embeddings do not support tokens shared by multiple sequences - but that is a constraint on sequence sharing, not on slot count, so independent slots are unaffected. Do not compare a concurrency cell here against one from the parallel=1 configuration without saying which is which."
+    },
+    {
+      "severity": "info",
+      "text": "--mmproj mmproj-F16.gguf is loaded, which the shipped recipe cannot do - it has no mmproj support. This matters for what the numbers mean as well as for what the model can do: the projector is ~0.9 GB of additional resident weights, and any vision workload here is exercising a code path that is simply absent from a text-only run of the same quantization. A cell from this configuration is not comparable to one without the projector."
+    },
+    {
+      "severity": "info",
+      "text": "--spec-type ngram-mod is ON. It drafts spans from repetition already in the context, so throughput varies by up to 3x with how much of the output already appears in the prompt. Speculation is exact - the target verifies every token - so output is byte-identical to running without it. Never compare a decode figure here against a cell run with a different --spec-type."
+    },
+    {
+      "severity": "info",
+      "text": "A quarter of this checkpoint is served from NVMe, so page-cache state is a hidden independent variable. Residency of the 26.82 GiB n-gram table was measured with mincore(2) immediately before this workload: 2.09%. Measured separately on this box: a real startup lands at 0.06 percent, the recipe warmer reaches only 25.9 percent from cold, and a 50-request workload takes the table from 0.06 to 54.75 percent by itself - so a long workload is warm for most of its own duration whatever it started at."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "7f9775c0e1a599886465796963a256d4f5119c05e66f59b573030364642408f1",
+    "payload_path": null,
+    "payload": {
+      "scorer": "vision",
+      "scorers_used": [
+        "exact"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:30000/v1",
+        "served_model_id": "qwen3.8-flash-next",
+        "advertised_models": [
+          "qwen3.8-flash-next"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-29T22:34:01Z",
+    "finished_at": "2026-08-29T22:44:00Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Box WAS dedicated: this DGX Spark runs no desktop session, and no compile or dev server ran on it during the sweep. Isolation check: the only route to it from outside the box is an SSH tunnel opened by a reverse proxy on the same private network, and that tunnel was stopped before the first run and stayed stopped throughout. NVIDIA DGX Spark (ASUS Ascent GX10, GB10 / SM121, 128 GB unified memory, ~121 GiB usable), Ubuntu 24.04.4, kernel 6.17.0-1029-nvidia aarch64, driver 580.173.02, CUDA 13.0, swap off. Engine is llama.cpp at commit 035e227 from what was then the unmerged PR #27742; that PR has since MERGED to master (2026-08-28), and its can_reuse work is upstream, so a build from master no longer needs the canreuse-qwen4exp patch this build carries. Model is unsloth/Qwen3.8-Flash-Next-GGUF UD-Q4_K_XL, four shards, 111,323,630,080 bytes. TWO DEPARTURES FROM THE SHIPPED RECIPE, both verified before this run rather than assumed. First, --parallel 2 instead of 1: the recipe forces one slot and documents that concurrent requests queue there rather than batch, so a second slot is untried territory for it. On this build two slots work - the server reports n_slots 2 and two concurrent requests both returned 200 with coherent output and no abort. Second, --mmproj mmproj-F16.gguf: the GGUF shards carry no vision tensors because llama.cpp ships multimodal as a separate projector, and unsloth publishes one alongside. With it loaded the server correctly described a synthetic image it could not have inferred from the prompt. The recipe has no mmproj support at all, so this configuration is not one the recipe can currently produce."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-vision-v1--320373.json
+++ b/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-vision-v1--320373.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -61,7 +61,7 @@
     "override-tensor": "per_layer_token_embd=CPU",
     "load-mode": "mmap",
     "spec-type": "ngram-mod",
-    "temp": 1.0,
+    "temp": 1,
     "top-p": 0.95,
     "top-k": 20,
     "mmproj": "mmproj-F16.gguf"
@@ -77,7 +77,7 @@
       "items": 60,
       "concurrency": 4,
       "max_output_tokens": 2048,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -90,7 +90,7 @@
     "requests_total": 60,
     "requests_ok": 60,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 598.178,
     "input_tokens_total": 10624,
     "output_tokens_total": 19440,
@@ -109,7 +109,7 @@
     "power_peak_w": 56.49,
     "energy_wh": 6.3812,
     "gpu_util_avg_pct": 85.79,
-    "temp_max_c": 69.0,
+    "temp_max_c": 69,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -117,7 +117,7 @@
     "total": 60,
     "correct": 58,
     "accuracy": 0.966667,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "arrows": {
         "total": 8,
@@ -162,7 +162,7 @@
         "correct": 13
       }
     },
-    "avg_output_tokens": 324.0,
+    "avg_output_tokens": 324,
     "avg_latency_ms": 39002.92,
     "failures": 0,
     "items": [
@@ -817,7 +817,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-29T22:34:01Z",
     "finished_at": "2026-08-29T22:44:00Z",
     "submitted_at": null,


### PR DESCRIPTION
### Cells filled

- **Engine** — `llamacpp` `b50-035e227`
- **Model / quant** — `Qwen/Qwen3.8-Flash-Next` / `gguf-ud-q4-k-xl`
- **Hardware** — `nvidia-gb10-dgx-spark` x1
- **Workload** — `eval-vision-v1` (eval)
- **Headline** — accuracy **0.967**, success 1.000

One file: `results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-vision-v1--320373.json`

### What failed

Nothing failed. 60/60 requests returned, success rate 1.000.

### Gotchas

- **info** — --parallel is 2 here, not the 1 the recipe ships.
- **info** — --mmproj mmproj-F16.gguf is loaded, which the shipped recipe cannot do - it has no mmproj support.
- **info** — --spec-type ngram-mod is ON.
- **info** — A quarter of this checkpoint is served from NVMe, so page-cache state is a hidden independent variable.

### Conditions

Dedicated box, nothing else resident on the GPU, no compile running. The one route into this machine from elsewhere on its private network is an SSH tunnel from a reverse proxy; it was stopped before the first run and stayed stopped. The harness talks to loopback with no proxy in the measured path.

n-gram table page-cache residency, `mincore(2)`: **2.09% before the workload, 45.33% after**.

| | |
|---|---:|
| peak host RAM | 101.0 GB |
| average GPU utilisation | 85.8 % |
| average / peak power | 38.4 / 56.5 W |
| max temperature | 69 C |
| thermal throttling | not detected |
| wall clock | 598.2 s |

`pnpm validate` — 0 errors. Read `gpu_util_avg_pct` with the caveat in the gotchas: it is a mean over the whole workload window including ramp-up and drain, not a steady-state figure.
