### PR TITLE
results: Qwen/Qwen3.8-Flash-Next on nvidia-gb10-dgx-spark — eval-json-v1 at parallel 2 with vision

### DIFF
--- a/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-json-v1--3b26d8.json
+++ b/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-json-v1--3b26d8.json
@@ -1,0 +1,1335 @@
+{
+  "schema_version": 1,
+  "run_id": "0cad79844e7b427c--eval-json-v1--3b26d8",
+  "config_id": "0cad79844e7b427c",
+  "cell_id": "1ab063de12eb",
+  "workload_id": "eval-json-v1",
+  "kind": "eval",
+  "engine": {
+    "id": "llamacpp",
+    "version": "b50-035e227",
+    "commit": null,
+    "container": null,
+    "install_method": "source"
+  },
+  "model": {
+    "id": "Qwen/Qwen3.8-Flash-Next",
+    "quant_id": "gguf-ud-q4-k-xl",
+    "hf_id": "Qwen/Qwen3.8-Flash-Next",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "ctx-size": 262144,
+    "n-gpu-layers": 999,
+    "parallel": 2,
+    "override-tensor": "per_layer_token_embd=CPU",
+    "load-mode": "mmap",
+    "spec-type": "ngram-mod",
+    "temp": 1.0,
+    "top-p": 0.95,
+    "top-k": 20,
+    "mmproj": "mmproj-F16.gguf"
+  },
+  "args_canonical": "@dtype=auto;@quant=gguf-ud-q4-k-xl;ctx-size=262144;load-mode=mmap;mmproj=mmproj-F16.gguf;n-gpu-layers=999;override-tensor=per_layer_token_embd=CPU;parallel=2;spec-type=ngram-mod;temp=1;top-k=20",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-json-v1",
+    "resolved_params": {
+      "dataset_id": "eval-json-v1",
+      "suite": "json",
+      "scorer": "json",
+      "items": 110,
+      "concurrency": 4,
+      "max_output_tokens": 2048,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 110,
+    "requests_ok": 110,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 465.871,
+    "input_tokens_total": 14844,
+    "output_tokens_total": 14183,
+    "e2e_ms": {
+      "mean": 16821.578,
+      "p50": 16588.01,
+      "p90": 22036.217,
+      "p95": 26114.52,
+      "p99": 27077.307,
+      "min": 6432.119,
+      "max": 27341.759
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 101.42,
+    "power_avg_w": 40.35,
+    "power_peak_w": 59.21,
+    "energy_wh": 5.2153,
+    "gpu_util_avg_pct": 83.49,
+    "temp_max_c": 69.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "json",
+    "total": 110,
+    "correct": 108,
+    "accuracy": 0.981818,
+    "success_rate": 1.0,
+    "by_category": {
+      "aggregation": {
+        "total": 10,
+        "correct": 9
+      },
+      "arrays": {
+        "total": 18,
+        "correct": 18
+      },
+      "classification": {
+        "total": 22,
+        "correct": 21
+      },
+      "extraction": {
+        "total": 40,
+        "correct": 40
+      },
+      "nested": {
+        "total": 10,
+        "correct": 10
+      },
+      "normalisation": {
+        "total": 6,
+        "correct": 6
+      },
+      "transformation": {
+        "total": 4,
+        "correct": 4
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 32,
+        "correct": 31
+      },
+      "hard": {
+        "total": 12,
+        "correct": 12
+      },
+      "medium": {
+        "total": 66,
+        "correct": 65
+      }
+    },
+    "avg_output_tokens": 128.94,
+    "avg_latency_ms": 16821.58,
+    "failures": 0,
+    "items": [
+      {
+        "id": "json-0001",
+        "correct": true,
+        "predicted": "{\"age\":64,\"city\":\"Aberholt\",\"email\":\"priya.ellery@example.org\",\"name\":\"Priya Ellery\"}",
+        "expected": "{\"age\":64,\"city\":\"Aberholt\",\"email\":\"priya.ellery@example.org\",\"name\":\"Priya Ellery\"}",
+        "latency_ms": 6432.119,
+        "output_tokens": 100,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0002",
+        "correct": true,
+        "predicted": "{\"age\":25,\"city\":\"Kesswater\",\"email\":\"dana.fairbank@example.org\",\"name\":\"Dana Fairbank\"}",
+        "expected": "{\"age\":25,\"city\":\"Kesswater\",\"email\":\"dana.fairbank@example.org\",\"name\":\"Dana Fairbank\"}",
+        "latency_ms": 9729.449,
+        "output_tokens": 140,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0003",
+        "correct": true,
+        "predicted": "{\"age\":27,\"city\":\"Valcrest\",\"email\":\"mira.ellery@example.org\",\"name\":\"Mira Ellery\"}",
+        "expected": "{\"age\":27,\"city\":\"Valcrest\",\"email\":\"mira.ellery@example.org\",\"name\":\"Mira Ellery\"}",
+        "latency_ms": 14404.492,
+        "output_tokens": 98,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0004",
+        "correct": true,
+        "predicted": "{\"age\":62,\"city\":\"Aberholt\",\"email\":\"priya.dunmore@example.org\",\"name\":\"Priya Dunmore\"}",
+        "expected": "{\"age\":62,\"city\":\"Aberholt\",\"email\":\"priya.dunmore@example.org\",\"name\":\"Priya Dunmore\"}",
+        "latency_ms": 17936.262,
+        "output_tokens": 105,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0005",
+        "correct": true,
+        "predicted": "{\"age\":62,\"city\":\"Marren Bay\",\"email\":\"gus.dunmore@example.org\",\"name\":\"Gus Dunmore\"}",
+        "expected": "{\"age\":62,\"city\":\"Marren Bay\",\"email\":\"gus.dunmore@example.org\",\"name\":\"Gus Dunmore\"}",
+        "latency_ms": 16569.095,
+        "output_tokens": 115,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0006",
+        "correct": true,
+        "predicted": "{\"age\":40,\"city\":\"Dunhallow\",\"email\":\"ines.dunmore@example.org\",\"name\":\"Ines Dunmore\"}",
+        "expected": "{\"age\":40,\"city\":\"Dunhallow\",\"email\":\"ines.dunmore@example.org\",\"name\":\"Ines Dunmore\"}",
+        "latency_ms": 16725.234,
+        "output_tokens": 106,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0007",
+        "correct": true,
+        "predicted": "{\"age\":71,\"city\":\"Kesswater\",\"email\":\"mira.braith@example.org\",\"name\":\"Mira Braith\"}",
+        "expected": "{\"age\":71,\"city\":\"Kesswater\",\"email\":\"mira.braith@example.org\",\"name\":\"Mira Braith\"}",
+        "latency_ms": 16132.036,
+        "output_tokens": 111,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0008",
+        "correct": true,
+        "predicted": "{\"age\":26,\"city\":\"Threeford\",\"email\":\"fenna.keswick@example.org\",\"name\":\"Fenna Keswick\"}",
+        "expected": "{\"age\":26,\"city\":\"Threeford\",\"email\":\"fenna.keswick@example.org\",\"name\":\"Fenna Keswick\"}",
+        "latency_ms": 18203.732,
+        "output_tokens": 134,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0009",
+        "correct": true,
+        "predicted": "{\"age\":21,\"city\":\"Marren Bay\",\"email\":\"priya.alder@example.org\",\"name\":\"Priya Alder\"}",
+        "expected": "{\"age\":21,\"city\":\"Marren Bay\",\"email\":\"priya.alder@example.org\",\"name\":\"Priya Alder\"}",
+        "latency_ms": 15853.514,
+        "output_tokens": 102,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0010",
+        "correct": true,
+        "predicted": "{\"age\":65,\"city\":\"Aberholt\",\"email\":\"dana.gale@example.org\",\"name\":\"Dana Gale\"}",
+        "expected": "{\"age\":65,\"city\":\"Aberholt\",\"email\":\"dana.gale@example.org\",\"name\":\"Dana Gale\"}",
+        "latency_ms": 16782.14,
+        "output_tokens": 95,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0011",
+        "correct": true,
+        "predicted": "{\"age\":56,\"city\":\"Valcrest\",\"email\":\"ines.ivers@example.org\",\"name\":\"Ines Ivers\"}",
+        "expected": "{\"age\":56,\"city\":\"Valcrest\",\"email\":\"ines.ivers@example.org\",\"name\":\"Ines Ivers\"}",
+        "latency_ms": 15522.858,
+        "output_tokens": 108,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0012",
+        "correct": true,
+        "predicted": "{\"age\":54,\"city\":\"Kesswater\",\"email\":\"tomas.ellery@example.org\",\"name\":\"Tomas Ellery\"}",
+        "expected": "{\"age\":54,\"city\":\"Kesswater\",\"email\":\"tomas.ellery@example.org\",\"name\":\"Tomas Ellery\"}",
+        "latency_ms": 14485.214,
+        "output_tokens": 111,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0013",
+        "correct": true,
+        "predicted": "{\"amount_cents\":17746,\"currency\":\"EUR\",\"due_days\":14,\"invoice_id\":\"INV-77315\"}",
+        "expected": "{\"amount_cents\":17746,\"currency\":\"EUR\",\"due_days\":14,\"invoice_id\":\"INV-77315\"}",
+        "latency_ms": 15502.683,
+        "output_tokens": 114,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0014",
+        "correct": true,
+        "predicted": "{\"amount_cents\":203187,\"currency\":\"GBP\",\"due_days\":30,\"invoice_id\":\"INV-82382\"}",
+        "expected": "{\"amount_cents\":203187,\"currency\":\"GBP\",\"due_days\":30,\"invoice_id\":\"INV-82382\"}",
+        "latency_ms": 16269.134,
+        "output_tokens": 121,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0015",
+        "correct": true,
+        "predicted": "{\"amount_cents\":104564,\"currency\":\"EUR\",\"due_days\":14,\"invoice_id\":\"INV-77092\"}",
+        "expected": "{\"amount_cents\":104564,\"currency\":\"EUR\",\"due_days\":14,\"invoice_id\":\"INV-77092\"}",
+        "latency_ms": 16373.953,
+        "output_tokens": 117,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0016",
+        "correct": true,
+        "predicted": "{\"amount_cents\":169877,\"currency\":\"USD\",\"due_days\":30,\"invoice_id\":\"INV-44042\"}",
+        "expected": "{\"amount_cents\":169877,\"currency\":\"USD\",\"due_days\":30,\"invoice_id\":\"INV-44042\"}",
+        "latency_ms": 16306.979,
+        "output_tokens": 117,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0017",
+        "correct": true,
+        "predicted": "{\"amount_cents\":126104,\"currency\":\"CHF\",\"due_days\":60,\"invoice_id\":\"INV-31069\"}",
+        "expected": "{\"amount_cents\":126104,\"currency\":\"CHF\",\"due_days\":60,\"invoice_id\":\"INV-31069\"}",
+        "latency_ms": 16401.732,
+        "output_tokens": 128,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0018",
+        "correct": true,
+        "predicted": "{\"amount_cents\":7610,\"currency\":\"EUR\",\"due_days\":7,\"invoice_id\":\"INV-60017\"}",
+        "expected": "{\"amount_cents\":7610,\"currency\":\"EUR\",\"due_days\":7,\"invoice_id\":\"INV-60017\"}",
+        "latency_ms": 15529.891,
+        "output_tokens": 111,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0019",
+        "correct": true,
+        "predicted": "{\"amount_cents\":248441,\"currency\":\"CHF\",\"due_days\":60,\"invoice_id\":\"INV-86413\"}",
+        "expected": "{\"amount_cents\":248441,\"currency\":\"CHF\",\"due_days\":60,\"invoice_id\":\"INV-86413\"}",
+        "latency_ms": 16405.78,
+        "output_tokens": 117,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0020",
+        "correct": true,
+        "predicted": "{\"amount_cents\":175564,\"currency\":\"CHF\",\"due_days\":60,\"invoice_id\":\"INV-82818\"}",
+        "expected": "{\"amount_cents\":175564,\"currency\":\"CHF\",\"due_days\":60,\"invoice_id\":\"INV-82818\"}",
+        "latency_ms": 15616.311,
+        "output_tokens": 103,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0021",
+        "correct": true,
+        "predicted": "{\"amount_cents\":236148,\"currency\":\"GBP\",\"due_days\":60,\"invoice_id\":\"INV-94680\"}",
+        "expected": "{\"amount_cents\":236148,\"currency\":\"GBP\",\"due_days\":60,\"invoice_id\":\"INV-94680\"}",
+        "latency_ms": 16128.19,
+        "output_tokens": 121,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0022",
+        "correct": true,
+        "predicted": "{\"amount_cents\":167374,\"currency\":\"CHF\",\"due_days\":7,\"invoice_id\":\"INV-50802\"}",
+        "expected": "{\"amount_cents\":167374,\"currency\":\"CHF\",\"due_days\":7,\"invoice_id\":\"INV-50802\"}",
+        "latency_ms": 15520.509,
+        "output_tokens": 122,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0023",
+        "correct": true,
+        "predicted": "{\"amount_cents\":219295,\"currency\":\"USD\",\"due_days\":14,\"invoice_id\":\"INV-28572\"}",
+        "expected": "{\"amount_cents\":219295,\"currency\":\"USD\",\"due_days\":14,\"invoice_id\":\"INV-28572\"}",
+        "latency_ms": 16606.925,
+        "output_tokens": 121,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0024",
+        "correct": true,
+        "predicted": "{\"amount_cents\":14140,\"currency\":\"EUR\",\"due_days\":7,\"invoice_id\":\"INV-24541\"}",
+        "expected": "{\"amount_cents\":14140,\"currency\":\"EUR\",\"due_days\":7,\"invoice_id\":\"INV-24541\"}",
+        "latency_ms": 16108.037,
+        "output_tokens": 112,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0025",
+        "correct": true,
+        "predicted": "{\"latency_ms\":8944,\"level\":\"INFO\",\"service\":\"payments\",\"status\":200,\"tenant\":\"t-5887\"}",
+        "expected": "{\"latency_ms\":8944,\"level\":\"INFO\",\"service\":\"payments\",\"status\":200,\"tenant\":\"t-5887\"}",
+        "latency_ms": 19790.283,
+        "output_tokens": 165,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0026",
+        "correct": true,
+        "predicted": "{\"latency_ms\":1508,\"level\":\"ERROR\",\"service\":\"search\",\"status\":429,\"tenant\":\"t-5649\"}",
+        "expected": "{\"latency_ms\":1508,\"level\":\"ERROR\",\"service\":\"search\",\"status\":429,\"tenant\":\"t-5649\"}",
+        "latency_ms": 19623.355,
+        "output_tokens": 163,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0027",
+        "correct": true,
+        "predicted": "{\"latency_ms\":8337,\"level\":\"DEBUG\",\"service\":\"identity\",\"status\":500,\"tenant\":\"t-5422\"}",
+        "expected": "{\"latency_ms\":8337,\"level\":\"DEBUG\",\"service\":\"identity\",\"status\":500,\"tenant\":\"t-5422\"}",
+        "latency_ms": 22632.171,
+        "output_tokens": 177,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0028",
+        "correct": true,
+        "predicted": "{\"latency_ms\":3642,\"level\":\"INFO\",\"service\":\"identity\",\"status\":200,\"tenant\":\"t-3827\"}",
+        "expected": "{\"latency_ms\":3642,\"level\":\"INFO\",\"service\":\"identity\",\"status\":200,\"tenant\":\"t-3827\"}",
+        "latency_ms": 21970.0,
+        "output_tokens": 166,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0029",
+        "correct": true,
+        "predicted": "{\"latency_ms\":1571,\"level\":\"ERROR\",\"service\":\"media\",\"status\":404,\"tenant\":\"t-1804\"}",
+        "expected": "{\"latency_ms\":1571,\"level\":\"ERROR\",\"service\":\"media\",\"status\":404,\"tenant\":\"t-1804\"}",
+        "latency_ms": 21695.268,
+        "output_tokens": 151,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0030",
+        "correct": true,
+        "predicted": "{\"latency_ms\":8597,\"level\":\"ERROR\",\"service\":\"billing\",\"status\":400,\"tenant\":\"t-7618\"}",
+        "expected": "{\"latency_ms\":8597,\"level\":\"ERROR\",\"service\":\"billing\",\"status\":400,\"tenant\":\"t-7618\"}",
+        "latency_ms": 20935.929,
+        "output_tokens": 168,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0031",
+        "correct": true,
+        "predicted": "{\"latency_ms\":1804,\"level\":\"WARN\",\"service\":\"payments\",\"status\":500,\"tenant\":\"t-9922\"}",
+        "expected": "{\"latency_ms\":1804,\"level\":\"WARN\",\"service\":\"payments\",\"status\":500,\"tenant\":\"t-9922\"}",
+        "latency_ms": 20649.31,
+        "output_tokens": 151,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0032",
+        "correct": true,
+        "predicted": "{\"latency_ms\":7083,\"level\":\"WARN\",\"service\":\"notify\",\"status\":500,\"tenant\":\"t-8774\"}",
+        "expected": "{\"latency_ms\":7083,\"level\":\"WARN\",\"service\":\"notify\",\"status\":500,\"tenant\":\"t-8774\"}",
+        "latency_ms": 21888.29,
+        "output_tokens": 184,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0033",
+        "correct": true,
+        "predicted": "{\"latency_ms\":4504,\"level\":\"INFO\",\"service\":\"search\",\"status\":429,\"tenant\":\"t-2998\"}",
+        "expected": "{\"latency_ms\":4504,\"level\":\"INFO\",\"service\":\"search\",\"status\":429,\"tenant\":\"t-2998\"}",
+        "latency_ms": 20837.881,
+        "output_tokens": 176,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0034",
+        "correct": true,
+        "predicted": "{\"latency_ms\":2395,\"level\":\"WARN\",\"service\":\"billing\",\"status\":401,\"tenant\":\"t-9000\"}",
+        "expected": "{\"latency_ms\":2395,\"level\":\"WARN\",\"service\":\"billing\",\"status\":401,\"tenant\":\"t-9000\"}",
+        "latency_ms": 19837.492,
+        "output_tokens": 166,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0035",
+        "correct": true,
+        "predicted": "{\"latency_ms\":6641,\"level\":\"DEBUG\",\"service\":\"payments\",\"status\":429,\"tenant\":\"t-9435\"}",
+        "expected": "{\"latency_ms\":6641,\"level\":\"DEBUG\",\"service\":\"payments\",\"status\":429,\"tenant\":\"t-9435\"}",
+        "latency_ms": 23316.419,
+        "output_tokens": 168,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0036",
+        "correct": true,
+        "predicted": "{\"latency_ms\":3628,\"level\":\"ERROR\",\"service\":\"notify\",\"status\":400,\"tenant\":\"t-7170\"}",
+        "expected": "{\"latency_ms\":3628,\"level\":\"ERROR\",\"service\":\"notify\",\"status\":400,\"tenant\":\"t-7170\"}",
+        "latency_ms": 17496.341,
+        "output_tokens": 151,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0037",
+        "correct": true,
+        "predicted": "{\"depth\":266,\"level\":\"high\",\"service\":\"search\"}",
+        "expected": "{\"depth\":266,\"level\":\"high\",\"service\":\"search\"}",
+        "latency_ms": 20286.544,
+        "output_tokens": 171,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0038",
+        "correct": true,
+        "predicted": "{\"depth\":302,\"level\":\"high\",\"service\":\"notify\"}",
+        "expected": "{\"depth\":302,\"level\":\"high\",\"service\":\"notify\"}",
+        "latency_ms": 17069.858,
+        "output_tokens": 89,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0039",
+        "correct": true,
+        "predicted": "{\"depth\":320,\"level\":\"high\",\"service\":\"payments\"}",
+        "expected": "{\"depth\":320,\"level\":\"high\",\"service\":\"payments\"}",
+        "latency_ms": 15868.537,
+        "output_tokens": 100,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0040",
+        "correct": false,
+        "predicted": "{\"depth\":355,\"level\":\"high\",\"service\":\"media service\"}",
+        "expected": "{\"depth\":355,\"level\":\"high\",\"service\":\"media\"}",
+        "latency_ms": 19213.773,
+        "output_tokens": 221,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0041",
+        "correct": true,
+        "predicted": "{\"depth\":30,\"level\":\"low\",\"service\":\"notify\"}",
+        "expected": "{\"depth\":30,\"level\":\"low\",\"service\":\"notify\"}",
+        "latency_ms": 15296.249,
+        "output_tokens": 93,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0042",
+        "correct": true,
+        "predicted": "{\"depth\":171,\"level\":\"low\",\"service\":\"media\"}",
+        "expected": "{\"depth\":171,\"level\":\"low\",\"service\":\"media\"}",
+        "latency_ms": 21245.069,
+        "output_tokens": 125,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0043",
+        "correct": true,
+        "predicted": "{\"depth\":257,\"level\":\"high\",\"service\":\"payments\"}",
+        "expected": "{\"depth\":257,\"level\":\"high\",\"service\":\"payments\"}",
+        "latency_ms": 11462.284,
+        "output_tokens": 56,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0044",
+        "correct": true,
+        "predicted": "{\"depth\":63,\"level\":\"low\",\"service\":\"notify\"}",
+        "expected": "{\"depth\":63,\"level\":\"low\",\"service\":\"notify\"}",
+        "latency_ms": 11752.543,
+        "output_tokens": 82,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0045",
+        "correct": true,
+        "predicted": "{\"depth\":60,\"level\":\"low\",\"service\":\"search\"}",
+        "expected": "{\"depth\":60,\"level\":\"low\",\"service\":\"search\"}",
+        "latency_ms": 15237.99,
+        "output_tokens": 119,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0046",
+        "correct": true,
+        "predicted": "{\"depth\":20,\"level\":\"low\",\"service\":\"billing\"}",
+        "expected": "{\"depth\":20,\"level\":\"low\",\"service\":\"billing\"}",
+        "latency_ms": 12171.931,
+        "output_tokens": 94,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0047",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"cancel\"}",
+        "expected": "{\"confident\":true,\"intent\":\"cancel\"}",
+        "latency_ms": 14754.459,
+        "output_tokens": 87,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0048",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"track\"}",
+        "expected": "{\"confident\":true,\"intent\":\"track\"}",
+        "latency_ms": 10929.794,
+        "output_tokens": 67,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0049",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"billing\"}",
+        "expected": "{\"confident\":true,\"intent\":\"billing\"}",
+        "latency_ms": 11864.178,
+        "output_tokens": 90,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0050",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"reschedule\"}",
+        "expected": "{\"confident\":true,\"intent\":\"reschedule\"}",
+        "latency_ms": 12259.029,
+        "output_tokens": 90,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0051",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"close_account\"}",
+        "expected": "{\"confident\":true,\"intent\":\"close_account\"}",
+        "latency_ms": 10911.706,
+        "output_tokens": 76,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0052",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"return\"}",
+        "expected": "{\"confident\":true,\"intent\":\"return\"}",
+        "latency_ms": 11872.534,
+        "output_tokens": 82,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0053",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"cancel\"}",
+        "expected": "{\"confident\":true,\"intent\":\"cancel\"}",
+        "latency_ms": 9871.307,
+        "output_tokens": 85,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0054",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"track\"}",
+        "expected": "{\"confident\":true,\"intent\":\"track\"}",
+        "latency_ms": 10506.977,
+        "output_tokens": 75,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0055",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"billing\"}",
+        "expected": "{\"confident\":true,\"intent\":\"billing\"}",
+        "latency_ms": 11097.347,
+        "output_tokens": 84,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0056",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"reschedule\"}",
+        "expected": "{\"confident\":true,\"intent\":\"reschedule\"}",
+        "latency_ms": 11479.282,
+        "output_tokens": 93,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0057",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"close_account\"}",
+        "expected": "{\"confident\":true,\"intent\":\"close_account\"}",
+        "latency_ms": 11271.908,
+        "output_tokens": 87,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0058",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"return\"}",
+        "expected": "{\"confident\":true,\"intent\":\"return\"}",
+        "latency_ms": 11860.205,
+        "output_tokens": 82,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0059",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-730\",\"item_count\":9,\"ship_to\":\"Valcrest\"},\"user\":{\"id\":8899,\"name\":\"Priya Alder\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-730\",\"item_count\":9,\"ship_to\":\"Valcrest\"},\"user\":{\"id\":8899,\"name\":\"Priya Alder\"}}",
+        "latency_ms": 18317.143,
+        "output_tokens": 212,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0060",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-830\",\"item_count\":9,\"ship_to\":\"Threeford\"},\"user\":{\"id\":3305,\"name\":\"Fenna Fairbank\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-830\",\"item_count\":9,\"ship_to\":\"Threeford\"},\"user\":{\"id\":3305,\"name\":\"Fenna Fairbank\"}}",
+        "latency_ms": 18849.369,
+        "output_tokens": 206,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0061",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-990\",\"item_count\":2,\"ship_to\":\"Threeford\"},\"user\":{\"id\":1173,\"name\":\"Bo Ellery\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-990\",\"item_count\":2,\"ship_to\":\"Threeford\"},\"user\":{\"id\":1173,\"name\":\"Bo Ellery\"}}",
+        "latency_ms": 26084.23,
+        "output_tokens": 209,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0062",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-833\",\"item_count\":8,\"ship_to\":\"Threeford\"},\"user\":{\"id\":7315,\"name\":\"Emre Ivers\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-833\",\"item_count\":8,\"ship_to\":\"Threeford\"},\"user\":{\"id\":7315,\"name\":\"Emre Ivers\"}}",
+        "latency_ms": 26139.303,
+        "output_tokens": 206,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0063",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-574\",\"item_count\":3,\"ship_to\":\"Threeford\"},\"user\":{\"id\":1379,\"name\":\"Mira Keswick\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-574\",\"item_count\":3,\"ship_to\":\"Threeford\"},\"user\":{\"id\":1379,\"name\":\"Mira Keswick\"}}",
+        "latency_ms": 26389.919,
+        "output_tokens": 206,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0064",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-462\",\"item_count\":2,\"ship_to\":\"Kesswater\"},\"user\":{\"id\":1731,\"name\":\"Bo Corvin\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-462\",\"item_count\":2,\"ship_to\":\"Kesswater\"},\"user\":{\"id\":1731,\"name\":\"Bo Corvin\"}}",
+        "latency_ms": 27117.696,
+        "output_tokens": 212,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0065",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-220\",\"item_count\":9,\"ship_to\":\"Valcrest\"},\"user\":{\"id\":7418,\"name\":\"Bo Ellery\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-220\",\"item_count\":9,\"ship_to\":\"Valcrest\"},\"user\":{\"id\":7418,\"name\":\"Bo Ellery\"}}",
+        "latency_ms": 26668.934,
+        "output_tokens": 203,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0066",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-855\",\"item_count\":2,\"ship_to\":\"Threeford\"},\"user\":{\"id\":3038,\"name\":\"Bo Gale\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-855\",\"item_count\":2,\"ship_to\":\"Threeford\"},\"user\":{\"id\":3038,\"name\":\"Bo Gale\"}}",
+        "latency_ms": 27341.759,
+        "output_tokens": 200,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0067",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-357\",\"item_count\":8,\"ship_to\":\"Dunhallow\"},\"user\":{\"id\":1558,\"name\":\"Hana Lund\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-357\",\"item_count\":8,\"ship_to\":\"Dunhallow\"},\"user\":{\"id\":1558,\"name\":\"Hana Lund\"}}",
+        "latency_ms": 26457.317,
+        "output_tokens": 209,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0068",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-743\",\"item_count\":7,\"ship_to\":\"Kesswater\"},\"user\":{\"id\":4894,\"name\":\"Lars Ellery\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-743\",\"item_count\":7,\"ship_to\":\"Kesswater\"},\"user\":{\"id\":4894,\"name\":\"Lars Ellery\"}}",
+        "latency_ms": 24900.642,
+        "output_tokens": 208,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0069",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-3547\",\"t-4456\",\"t-7824\",\"t-8174\",\"t-4279\",\"t-7816\"]}",
+        "expected": "{\"tenants\":[\"t-3547\",\"t-4456\",\"t-7824\",\"t-8174\",\"t-4279\",\"t-7816\"]}",
+        "latency_ms": 22643.171,
+        "output_tokens": 160,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0070",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-7567\",\"t-7968\",\"t-8928\",\"t-7983\"]}",
+        "expected": "{\"tenants\":[\"t-7567\",\"t-7968\",\"t-8928\",\"t-7983\"]}",
+        "latency_ms": 20788.964,
+        "output_tokens": 126,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0071",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-1022\",\"t-6879\",\"t-2365\",\"t-6799\"]}",
+        "expected": "{\"tenants\":[\"t-1022\",\"t-6879\",\"t-2365\",\"t-6799\"]}",
+        "latency_ms": 18441.947,
+        "output_tokens": 126,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0072",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-2838\",\"t-4070\",\"t-8165\",\"t-3012\"]}",
+        "expected": "{\"tenants\":[\"t-2838\",\"t-4070\",\"t-8165\",\"t-3012\"]}",
+        "latency_ms": 17914.433,
+        "output_tokens": 123,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0073",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-3759\",\"t-4899\",\"t-1657\",\"t-2263\"]}",
+        "expected": "{\"tenants\":[\"t-3759\",\"t-4899\",\"t-1657\",\"t-2263\"]}",
+        "latency_ms": 17570.296,
+        "output_tokens": 135,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0074",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-6700\",\"t-3630\",\"t-3979\"]}",
+        "expected": "{\"tenants\":[\"t-6700\",\"t-3630\",\"t-3979\"]}",
+        "latency_ms": 16794.799,
+        "output_tokens": 110,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0075",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-8440\",\"t-4890\",\"t-3932\",\"t-5058\",\"t-9497\",\"t-6146\"]}",
+        "expected": "{\"tenants\":[\"t-8440\",\"t-4890\",\"t-3932\",\"t-5058\",\"t-9497\",\"t-6146\"]}",
+        "latency_ms": 18903.943,
+        "output_tokens": 160,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0076",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-8659\",\"t-6014\",\"t-6867\",\"t-8175\",\"t-9729\"]}",
+        "expected": "{\"tenants\":[\"t-8659\",\"t-6014\",\"t-6867\",\"t-8175\",\"t-9729\"]}",
+        "latency_ms": 15601.211,
+        "output_tokens": 143,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0077",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-7083\",\"t-6458\",\"t-6179\"]}",
+        "expected": "{\"tenants\":[\"t-7083\",\"t-6458\",\"t-6179\"]}",
+        "latency_ms": 16399.348,
+        "output_tokens": 110,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0078",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-7886\",\"t-2715\",\"t-8504\",\"t-4462\",\"t-1039\"]}",
+        "expected": "{\"tenants\":[\"t-7886\",\"t-2715\",\"t-8504\",\"t-4462\",\"t-1039\"]}",
+        "latency_ms": 17719.734,
+        "output_tokens": 140,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0079",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":26,\"name\":\"Nadia Ivers\"},{\"age\":56,\"name\":\"Lars Corvin\"},{\"age\":34,\"name\":\"Juno Keswick\"}]}",
+        "expected": "{\"people\":[{\"age\":26,\"name\":\"Nadia Ivers\"},{\"age\":56,\"name\":\"Lars Corvin\"},{\"age\":34,\"name\":\"Juno Keswick\"}]}",
+        "latency_ms": 17228.985,
+        "output_tokens": 154,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0080",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":53,\"name\":\"Tomas Lund\"},{\"age\":51,\"name\":\"Lars Ivers\"},{\"age\":27,\"name\":\"Cai Braith\"}]}",
+        "expected": "{\"people\":[{\"age\":53,\"name\":\"Tomas Lund\"},{\"age\":51,\"name\":\"Lars Ivers\"},{\"age\":27,\"name\":\"Cai Braith\"}]}",
+        "latency_ms": 18161.781,
+        "output_tokens": 151,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0081",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":28,\"name\":\"Bo Jarrow\"},{\"age\":21,\"name\":\"Cai Braith\"},{\"age\":41,\"name\":\"Rafael Dunmore\"}]}",
+        "expected": "{\"people\":[{\"age\":28,\"name\":\"Bo Jarrow\"},{\"age\":21,\"name\":\"Cai Braith\"},{\"age\":41,\"name\":\"Rafael Dunmore\"}]}",
+        "latency_ms": 19309.611,
+        "output_tokens": 150,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0082",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":52,\"name\":\"Mira Holt\"},{\"age\":51,\"name\":\"Cai Corvin\"},{\"age\":49,\"name\":\"Dana Keswick\"}]}",
+        "expected": "{\"people\":[{\"age\":52,\"name\":\"Mira Holt\"},{\"age\":51,\"name\":\"Cai Corvin\"},{\"age\":49,\"name\":\"Dana Keswick\"}]}",
+        "latency_ms": 18269.297,
+        "output_tokens": 133,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0083",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":33,\"name\":\"Ines Corvin\"},{\"age\":29,\"name\":\"Hana Corvin\"},{\"age\":43,\"name\":\"Mira Corvin\"}]}",
+        "expected": "{\"people\":[{\"age\":33,\"name\":\"Ines Corvin\"},{\"age\":29,\"name\":\"Hana Corvin\"},{\"age\":43,\"name\":\"Mira Corvin\"}]}",
+        "latency_ms": 19337.285,
+        "output_tokens": 153,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0084",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":31,\"name\":\"Ines Ivers\"},{\"age\":32,\"name\":\"Nadia Ellery\"},{\"age\":63,\"name\":\"Fenna Fairbank\"}]}",
+        "expected": "{\"people\":[{\"age\":31,\"name\":\"Ines Ivers\"},{\"age\":32,\"name\":\"Nadia Ellery\"},{\"age\":63,\"name\":\"Fenna Fairbank\"}]}",
+        "latency_ms": 18392.091,
+        "output_tokens": 156,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0085",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":51,\"name\":\"Tomas Braith\"},{\"age\":22,\"name\":\"Bo Jarrow\"},{\"age\":46,\"name\":\"Fenna Fairbank\"}]}",
+        "expected": "{\"people\":[{\"age\":51,\"name\":\"Tomas Braith\"},{\"age\":22,\"name\":\"Bo Jarrow\"},{\"age\":46,\"name\":\"Fenna Fairbank\"}]}",
+        "latency_ms": 18769.875,
+        "output_tokens": 154,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0086",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":55,\"name\":\"Cai Lund\"},{\"age\":63,\"name\":\"Emre Holt\"},{\"age\":39,\"name\":\"Mira Fairbank\"}]}",
+        "expected": "{\"people\":[{\"age\":55,\"name\":\"Cai Lund\"},{\"age\":63,\"name\":\"Emre Holt\"},{\"age\":39,\"name\":\"Mira Fairbank\"}]}",
+        "latency_ms": 19895.906,
+        "output_tokens": 152,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0087",
+        "correct": false,
+        "predicted": "{\"count\":4,\"max\":304,\"min\":88,\"total\":723}",
+        "expected": "{\"count\":4,\"max\":304,\"min\":58,\"total\":723}",
+        "latency_ms": 17361.887,
+        "output_tokens": 125,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0088",
+        "correct": true,
+        "predicted": "{\"count\":3,\"max\":298,\"min\":86,\"total\":651}",
+        "expected": "{\"count\":3,\"max\":298,\"min\":86,\"total\":651}",
+        "latency_ms": 17438.803,
+        "output_tokens": 111,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0089",
+        "correct": true,
+        "predicted": "{\"count\":6,\"max\":327,\"min\":89,\"total\":1519}",
+        "expected": "{\"count\":6,\"max\":327,\"min\":89,\"total\":1519}",
+        "latency_ms": 17002.513,
+        "output_tokens": 134,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0090",
+        "correct": true,
+        "predicted": "{\"count\":5,\"max\":211,\"min\":29,\"total\":560}",
+        "expected": "{\"count\":5,\"max\":211,\"min\":29,\"total\":560}",
+        "latency_ms": 16361.45,
+        "output_tokens": 137,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0091",
+        "correct": true,
+        "predicted": "{\"count\":4,\"max\":374,\"min\":63,\"total\":907}",
+        "expected": "{\"count\":4,\"max\":374,\"min\":63,\"total\":907}",
+        "latency_ms": 18143.157,
+        "output_tokens": 133,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0092",
+        "correct": true,
+        "predicted": "{\"count\":5,\"max\":331,\"min\":22,\"total\":756}",
+        "expected": "{\"count\":5,\"max\":331,\"min\":22,\"total\":756}",
+        "latency_ms": 18820.437,
+        "output_tokens": 138,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0093",
+        "correct": true,
+        "predicted": "{\"count\":3,\"max\":397,\"min\":354,\"total\":1135}",
+        "expected": "{\"count\":3,\"max\":397,\"min\":354,\"total\":1135}",
+        "latency_ms": 16867.529,
+        "output_tokens": 109,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0094",
+        "correct": true,
+        "predicted": "{\"count\":4,\"max\":334,\"min\":63,\"total\":741}",
+        "expected": "{\"count\":4,\"max\":334,\"min\":63,\"total\":741}",
+        "latency_ms": 19122.938,
+        "output_tokens": 138,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0095",
+        "correct": true,
+        "predicted": "{\"count\":6,\"max\":380,\"min\":130,\"total\":1638}",
+        "expected": "{\"count\":6,\"max\":380,\"min\":130,\"total\":1638}",
+        "latency_ms": 15621.273,
+        "output_tokens": 113,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0096",
+        "correct": true,
+        "predicted": "{\"count\":5,\"max\":359,\"min\":30,\"total\":1122}",
+        "expected": "{\"count\":5,\"max\":359,\"min\":30,\"total\":1122}",
+        "latency_ms": 18449.848,
+        "output_tokens": 136,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0097",
+        "correct": true,
+        "predicted": "{\"date\":\"2019-05-13\",\"weekday_known\":false}",
+        "expected": "{\"date\":\"2019-05-13\",\"weekday_known\":false}",
+        "latency_ms": 14600.493,
+        "output_tokens": 124,
+        "category": "normalisation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0098",
+        "correct": true,
+        "predicted": "{\"date\":\"2025-03-15\",\"weekday_known\":false}",
+        "expected": "{\"date\":\"2025-03-15\",\"weekday_known\":false}",
+        "latency_ms": 15675.415,
+        "output_tokens": 98,
+        "category": "normalisation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0099",
+        "correct": true,
+        "predicted": "{\"date\":\"2019-06-10\",\"weekday_known\":false}",
+        "expected": "{\"date\":\"2019-06-10\",\"weekday_known\":false}",
+        "latency_ms": 13461.493,
+        "output_tokens": 98,
+        "category": "normalisation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0100",
+        "correct": true,
+        "predicted": "{\"date\":\"2023-11-15\",\"weekday_known\":false}",
+        "expected": "{\"date\":\"2023-11-15\",\"weekday_known\":false}",
+        "latency_ms": 13056.489,
+        "output_tokens": 107,
+        "category": "normalisation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0101",
+        "correct": true,
+        "predicted": "{\"date\":\"2030-04-05\",\"weekday_known\":false}",
+        "expected": "{\"date\":\"2030-04-05\",\"weekday_known\":false}",
+        "latency_ms": 13798.078,
+        "output_tokens": 97,
+        "category": "normalisation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0102",
+        "correct": true,
+        "predicted": "{\"date\":\"2029-04-04\",\"weekday_known\":false}",
+        "expected": "{\"date\":\"2029-04-04\",\"weekday_known\":false}",
+        "latency_ms": 12038.404,
+        "output_tokens": 97,
+        "category": "normalisation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0103",
+        "correct": true,
+        "predicted": "{\"enabled\":true,\"region\":\"eu-west\",\"retries\":1}",
+        "expected": "{\"enabled\":true,\"region\":\"eu-west\",\"retries\":1}",
+        "latency_ms": 12228.521,
+        "output_tokens": 76,
+        "category": "transformation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0104",
+        "correct": true,
+        "predicted": "{\"enabled\":true,\"region\":\"eu-central\",\"retries\":5}",
+        "expected": "{\"enabled\":true,\"region\":\"eu-central\",\"retries\":5}",
+        "latency_ms": 11581.447,
+        "output_tokens": 90,
+        "category": "transformation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0105",
+        "correct": true,
+        "predicted": "{\"enabled\":true,\"region\":\"eu-west\",\"retries\":0}",
+        "expected": "{\"enabled\":true,\"region\":\"eu-west\",\"retries\":0}",
+        "latency_ms": 10476.802,
+        "output_tokens": 77,
+        "category": "transformation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0106",
+        "correct": true,
+        "predicted": "{\"enabled\":false,\"region\":\"eu-central\",\"retries\":1}",
+        "expected": "{\"enabled\":false,\"region\":\"eu-central\",\"retries\":1}",
+        "latency_ms": 12755.313,
+        "output_tokens": 90,
+        "category": "transformation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0107",
+        "correct": true,
+        "predicted": "{\"name\":\"Cai Holt\",\"phone\":null}",
+        "expected": "{\"name\":\"Cai Holt\",\"phone\":null}",
+        "latency_ms": 11677.003,
+        "output_tokens": 119,
+        "category": "extraction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0108",
+        "correct": true,
+        "predicted": "{\"name\":\"Tomas Jarrow\",\"phone\":null}",
+        "expected": "{\"name\":\"Tomas Jarrow\",\"phone\":null}",
+        "latency_ms": 12125.412,
+        "output_tokens": 122,
+        "category": "extraction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0109",
+        "correct": true,
+        "predicted": "{\"name\":\"Hana Fairbank\",\"phone\":null}",
+        "expected": "{\"name\":\"Hana Fairbank\",\"phone\":null}",
+        "latency_ms": 11972.3,
+        "output_tokens": 122,
+        "category": "extraction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0110",
+        "correct": true,
+        "predicted": "{\"name\":\"Cai Ivers\",\"phone\":null}",
+        "expected": "{\"name\":\"Cai Ivers\",\"phone\":null}",
+        "latency_ms": 8825.113,
+        "output_tokens": 122,
+        "category": "extraction",
+        "difficulty": "hard"
+      }
+    ]
+  },
+  "failures": [],
+  "gotchas": [
+    {
+      "severity": "info",
+      "text": "--parallel is 2 here, not the 1 the recipe forces. The recipe documents that concurrency does not abort the server but does not batch either at one slot, and it never tries a second slot. Two slots were verified on this build before this run: the server reports n_slots 2 and two concurrent requests both returned 200 with coherent output on the same pid. Upstream does keep a GGML_ASSERT in qwen4exp.cpp that rejects a token belonging to more than one sequence - PLE n-gram embeddings do not support tokens shared by multiple sequences - but that is a constraint on sequence sharing, not on slot count, so independent slots are unaffected. Do not compare a concurrency cell here against one from a parallel=1 configuration without saying which is which."
+    },
+    {
+      "severity": "info",
+      "text": "--mmproj mmproj-F16.gguf is loaded, which the shipped recipe cannot do - it has no mmproj support. This matters for what the numbers mean as well as for what the model can do: the projector is ~0.9 GB of additional resident weights, and any vision workload here is exercising a code path that is simply absent from a text-only run of the same quantization. A cell from this configuration is not comparable to one without the projector."
+    },
+    {
+      "severity": "info",
+      "text": "--spec-type ngram-mod is ON. It drafts spans from repetition already in the context, so throughput varies by up to 3x with how much of the output already appears in the prompt. Speculation is exact - the target verifies every token - so output is byte-identical to running without it. Never compare a decode figure here against a cell run with a different --spec-type."
+    },
+    {
+      "severity": "info",
+      "text": "A quarter of this checkpoint is served from NVMe, so page-cache state is a hidden independent variable. Residency of the 26.82 GiB n-gram table was measured with mincore(2) immediately before this workload: 72.49%. Measured separately on this box: a real startup lands at 0.06 percent, the recipe warmer reaches only 25.9 percent from cold, and a 50-request workload takes the table from 0.06 to 54.75 percent by itself - so a long workload is warm for most of its own duration whatever it started at."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "df69a55e46f158bcde1852602d11842123f642beeb88f4aa5c6b93ab5b411a9d",
+    "payload_path": null,
+    "payload": {
+      "scorer": "json",
+      "scorers_used": [
+        "json"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:30000/v1",
+        "served_model_id": "qwen3.8-flash-next",
+        "advertised_models": [
+          "qwen3.8-flash-next"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-29T23:54:55Z",
+    "finished_at": "2026-08-30T00:02:41Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Box WAS dedicated: this DGX Spark runs no desktop session, and no compile or dev server ran on it during the sweep. Isolation check: the only route to it from outside the box is an SSH tunnel opened by a reverse proxy on the same private network, and that tunnel was stopped before the first run and stayed stopped throughout. NVIDIA DGX Spark (ASUS Ascent GX10, GB10 / SM121, 128 GB unified memory, ~121 GiB usable), Ubuntu 24.04.4, kernel 6.17.0-1029-nvidia aarch64, driver 580.173.02, CUDA 13.0, swap off. Engine is llama.cpp at commit 035e227 from what was then the unmerged PR #27742; that PR has since MERGED to master (2026-08-28), and its can_reuse work is upstream, so a build from master no longer needs the canreuse-qwen4exp patch this build carries. Model is unsloth/Qwen3.8-Flash-Next-GGUF UD-Q4_K_XL, four shards, 111,323,630,080 bytes. TWO DEPARTURES FROM THE SHIPPED RECIPE, both verified before this run rather than assumed. First, --parallel 2 instead of 1: the recipe forces one slot and documents that concurrent requests queue there rather than batch, so a second slot is untried territory for it. On this build two slots work - the server reports n_slots 2 and two concurrent requests both returned 200 with coherent output and no abort. Second, --mmproj mmproj-F16.gguf: the GGUF shards carry no vision tensors because llama.cpp ships multimodal as a separate projector, and unsloth publishes one alongside. With it loaded the server correctly described a synthetic image it could not have inferred from the prompt. The recipe has no mmproj support at all, so this configuration is not one the recipe can currently produce."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-json-v1--3b26d8.json
+++ b/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-json-v1--3b26d8.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -61,7 +61,7 @@
     "override-tensor": "per_layer_token_embd=CPU",
     "load-mode": "mmap",
     "spec-type": "ngram-mod",
-    "temp": 1.0,
+    "temp": 1,
     "top-p": 0.95,
     "top-k": 20,
     "mmproj": "mmproj-F16.gguf"
@@ -77,7 +77,7 @@
       "items": 110,
       "concurrency": 4,
       "max_output_tokens": 2048,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -90,7 +90,7 @@
     "requests_total": 110,
     "requests_ok": 110,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 465.871,
     "input_tokens_total": 14844,
     "output_tokens_total": 14183,
@@ -109,7 +109,7 @@
     "power_peak_w": 59.21,
     "energy_wh": 5.2153,
     "gpu_util_avg_pct": 83.49,
-    "temp_max_c": 69.0,
+    "temp_max_c": 69,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -117,7 +117,7 @@
     "total": 110,
     "correct": 108,
     "accuracy": 0.981818,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "aggregation": {
         "total": 10,
@@ -441,7 +441,7 @@
         "correct": true,
         "predicted": "{\"latency_ms\":3642,\"level\":\"INFO\",\"service\":\"identity\",\"status\":200,\"tenant\":\"t-3827\"}",
         "expected": "{\"latency_ms\":3642,\"level\":\"INFO\",\"service\":\"identity\",\"status\":200,\"tenant\":\"t-3827\"}",
-        "latency_ms": 21970.0,
+        "latency_ms": 21970,
         "output_tokens": 166,
         "category": "extraction",
         "difficulty": "medium"
@@ -1317,7 +1317,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-29T23:54:55Z",
     "finished_at": "2026-08-30T00:02:41Z",
     "submitted_at": null,


### PR DESCRIPTION
### Cells filled

- **Engine** — `llamacpp` `b50-035e227`
- **Model / quant** — `Qwen/Qwen3.8-Flash-Next` / `gguf-ud-q4-k-xl`
- **Hardware** — `nvidia-gb10-dgx-spark` x1
- **Workload** — `eval-json-v1` (eval)
- **Headline** — accuracy **0.982**, success 1.000

One file: `results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-json-v1--3b26d8.json`

### What failed

Nothing failed. 110/110 requests returned, success rate 1.000.

### Gotchas

- **info** — --parallel is 2 here, not the 1 the recipe forces.
- **info** — --mmproj mmproj-F16.gguf is loaded, which the shipped recipe cannot do - it has no mmproj support.
- **info** — --spec-type ngram-mod is ON.
- **info** — A quarter of this checkpoint is served from NVMe, so page-cache state is a hidden independent variable.

### Conditions

Dedicated box, nothing else resident on the GPU, no compile running. The one route into this machine from elsewhere on its private network is an SSH tunnel from a reverse proxy; it was stopped before the first run and stayed stopped. The harness talks to loopback with no proxy in the measured path.

n-gram table page-cache residency, `mincore(2)`: **72.49% before the workload, 73.4% after**.

| | |
|---|---:|
| peak host RAM | 101.4 GB |
| average GPU utilisation | 83.5 % |
| average / peak power | 40.4 / 59.2 W |
| max temperature | 69 C |
| thermal throttling | not detected |
| wall clock | 465.9 s |

`pnpm validate` — 0 errors. Read `gpu_util_avg_pct` with the caveat in the gotchas: it is a mean over the whole workload window including ramp-up and drain, not a steady-state figure.
