### PR TITLE
A pull request from a fork cannot post its own validation report

### DIFF
--- a/.github/workflows/validate-comment.yml
+++ b/.github/workflows/validate-comment.yml
@@ -1,0 +1,82 @@
+name: validate-comment
+
+# Posts the validation report onto pull requests from forks.
+#
+# validate.yml runs on `pull_request`, which for a fork hands the job a read-only token: it
+# can check the contribution but cannot say anything back. That is the wrong way round -
+# a first-time contributor is precisely the person who needs the report. This workflow runs
+# on `workflow_run`, which executes with the repository's own permissions, and posts what
+# the other one found.
+#
+# It deliberately checks out nothing and runs no contributor code. It downloads two small
+# artifacts, reads JSON out of them, and calls the issues API. Anything else here would be
+# handing write permissions to an untrusted branch.
+
+on:
+  workflow_run:
+    workflows: [validate]
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    # Same-repo pull requests are already commented on by validate.yml itself.
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name != github.repository
+    steps:
+      - name: Download the report
+        uses: actions/download-artifact@v6
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pattern: validate-*
+          merge-multiple: true
+
+      - name: Post it
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('validate.json') || !fs.existsSync('pr-number.txt')) {
+              core.info('no report artifact — the validate job failed before writing one');
+              return;
+            }
+            const report = JSON.parse(fs.readFileSync('validate.json', 'utf8'));
+            const issue_number = Number(fs.readFileSync('pr-number.txt', 'utf8').trim());
+            if (!Number.isInteger(issue_number) || issue_number <= 0) {
+              core.setFailed(`unusable pull request number in artifact`);
+              return;
+            }
+
+            const marker = '<!-- inference-atlas: validate -->';
+            const body = [
+              marker,
+              '### Validation',
+              '',
+              report.markdown,
+              '',
+              '<sub>`pnpm validate` runs the same checks locally.</sub>',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find((c) => c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+            const codes = new Set(report.codes ?? []);
+            const wanted = [];
+            if (codes.has('needs-review')) wanted.push('needs-review');
+            if ((report.changed_results ?? 0) > 0) wanted.push('results');
+            if (wanted.length > 0) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: wanted });
+            }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -85,8 +85,39 @@ jobs:
           echo "exit=$?" >> "$GITHUB_OUTPUT"
           set -e
           node -e "const r=require('./validate.json');console.log(r.markdown)"
+          # Also into the run summary. A pull request from a fork gets a read-only token, so
+          # the comment step below cannot speak; the summary is visible to everyone regardless.
+          {
+            echo "### Validation"
+            echo
+            node -e "const r=require('./validate.json');console.log(r.markdown)"
+          } >> "$GITHUB_STEP_SUMMARY"
 
+      # Handed to the companion workflow, which has the permissions a fork's token lacks.
+      - name: Save the report for the comment workflow
+        uses: actions/upload-artifact@v5
+        with:
+          name: validate-report
+          path: |
+            validate.json
+          retention-days: 3
+
+      - name: Save the pull request number
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+      - uses: actions/upload-artifact@v5
+        with:
+          name: validate-pr-number
+          path: pr-number.txt
+          retention-days: 3
+
+      # Only for branches in this repository. A pull request from a fork gets a read-only
+      # GITHUB_TOKEN no matter what the permissions block above says, so this step 403s and
+      # used to fail the whole job - showing a red cross on a contribution whose validation
+      # had actually passed, to exactly the contributors least able to tell the difference.
+      # Forks are commented on by validate-comment.yml instead.
       - name: Comment on the pull request
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |

--- a/tools/src/validate.ts
+++ b/tools/src/validate.ts
@@ -287,6 +287,10 @@ export function main(argv: string[]): number {
         warnings: outcome.issues.filter((i) => i.level === 'warn'),
         codes: outcome.codes,
         code_counts: codeCounts(outcome.issues),
+        // Consumed by the workflow that comments on pull requests from forks, which has no
+        // checkout to count changed files for itself.
+        changed_results: (args.list('changed') ?? []).filter((f) => f.startsWith('results/'))
+          .length,
         markdown: renderMarkdown(outcome.issues, { counts: outcome.counts }),
       },
       null,


### PR DESCRIPTION
#112 arrived from a fork and showed a **red cross** on a run whose validation said `ok — 0 errors, 2 warning(s)`.

The job did not fail on the data. It failed here:

```
##[error]Unhandled error: HttpError: Resource not accessible by integration
  url: 'https://api.github.com/repos/0xBakeer/inference-atlas/issues/112/comments',
  status: 403
```

`validate.yml` runs on `pull_request`, and a pull request from a fork gets a read-only `GITHUB_TOKEN` no matter what the `permissions:` block says. So the workflow can check the contribution but cannot say anything back — and since the comment was a plain step, its 403 took the whole job down with it.

This repo's own workflow header says it: *"a contributor whose first contribution fails a check they cannot see will not send a second one."* The breakage lands on exactly those people.

## Changes

- **The report goes to `$GITHUB_STEP_SUMMARY` as well.** That path needs no token, so the findings are readable on every run, fork or not.
- **The inline comment step is limited to same-repo branches and made `continue-on-error`.** It can never again fail a job whose validation passed. The real gate — "Fail if validation found errors" — is untouched.
- **New `validate-comment.yml`** runs on `workflow_run` with the repository's own permissions and posts the report onto fork pull requests. It **checks out nothing and runs no contributor code**: it downloads two small artifacts, reads JSON, and calls the issues API. That restriction is the whole reason this is a second workflow rather than `pull_request_target`.
- `validate.ts` emits `changed_results` so the companion can apply the `results` label without a checkout to count files in.

Locally: `pnpm test` 384 passed, typecheck, lint and `format:check` clean.