### PR TITLE
chore: stamp github_user_id for the FP8 two-node cell

### DIFF
--- a/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/3c6d5b151ad6b0c1--longctx-needle-32k-v1--cbc816.json
+++ b/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/3c6d5b151ad6b0c1--longctx-needle-32k-v1--cbc816.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -75,27 +75,27 @@
       "points": [
         [
           32768,
-          10.0
+          10
         ],
         [
           32768,
-          10.0
+          10
         ],
         [
           32768,
-          50.0
+          50
         ],
         [
           32768,
-          50.0
+          50
         ],
         [
           32768,
-          90.0
+          90
         ],
         [
           32768,
-          90.0
+          90
         ]
       ],
       "output_tokens": 128,
@@ -108,7 +108,7 @@
         "needle"
       ],
       "dataset_target_tokens": 32768,
-      "timeout_s": 1800.0,
+      "timeout_s": 1800,
       "seed": 42
     }
   },
@@ -116,7 +116,7 @@
     "requests_total": 1,
     "requests_ok": 1,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 20.044,
     "input_tokens_total": 40443,
     "output_tokens_total": 87,
@@ -176,19 +176,19 @@
     "power_peak_w": 64.49,
     "energy_wh": 0.3292,
     "gpu_util_avg_pct": 91.2,
-    "temp_max_c": 77.0,
+    "temp_max_c": 77,
     "thermal_throttle_detected": false
   },
   "sweep": [
     {
       "input_tokens": 32768,
       "output_tokens": 128,
-      "label": "depth 10% \u00b7 needle found",
+      "label": "depth 10% · needle found",
       "metrics": {
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 20.044,
         "input_tokens_total": 40443,
         "output_tokens_total": 87,
@@ -248,19 +248,19 @@
         "power_peak_w": 64.49,
         "energy_wh": 0.3292,
         "gpu_util_avg_pct": 91.2,
-        "temp_max_c": 77.0,
+        "temp_max_c": 77,
         "thermal_throttle_detected": false
       }
     },
     {
       "input_tokens": 32768,
       "output_tokens": 128,
-      "label": "depth 10% \u00b7 needle found",
+      "label": "depth 10% · needle found",
       "metrics": {
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 19.659,
         "input_tokens_total": 40165,
         "output_tokens_total": 85,
@@ -320,19 +320,19 @@
         "power_peak_w": 64.87,
         "energy_wh": 0.3209,
         "gpu_util_avg_pct": 95.53,
-        "temp_max_c": 77.0,
+        "temp_max_c": 77,
         "thermal_throttle_detected": false
       }
     },
     {
       "input_tokens": 32768,
       "output_tokens": 128,
-      "label": "depth 50% \u00b7 needle found",
+      "label": "depth 50% · needle found",
       "metrics": {
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 19.792,
         "input_tokens_total": 40143,
         "output_tokens_total": 84,
@@ -392,19 +392,19 @@
         "power_peak_w": 64.63,
         "energy_wh": 0.3209,
         "gpu_util_avg_pct": 92.53,
-        "temp_max_c": 77.0,
+        "temp_max_c": 77,
         "thermal_throttle_detected": false
       }
     },
     {
       "input_tokens": 32768,
       "output_tokens": 128,
-      "label": "depth 50% \u00b7 needle found",
+      "label": "depth 50% · needle found",
       "metrics": {
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 19.837,
         "input_tokens_total": 40251,
         "output_tokens_total": 86,
@@ -464,19 +464,19 @@
         "power_peak_w": 64.87,
         "energy_wh": 0.3221,
         "gpu_util_avg_pct": 95.11,
-        "temp_max_c": 77.0,
+        "temp_max_c": 77,
         "thermal_throttle_detected": false
       }
     },
     {
       "input_tokens": 32768,
       "output_tokens": 128,
-      "label": "depth 90% \u00b7 needle found",
+      "label": "depth 90% · needle found",
       "metrics": {
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 20.412,
         "input_tokens_total": 40314,
         "output_tokens_total": 85,
@@ -536,19 +536,19 @@
         "power_peak_w": 64.65,
         "energy_wh": 0.3293,
         "gpu_util_avg_pct": 95.6,
-        "temp_max_c": 74.0,
+        "temp_max_c": 74,
         "thermal_throttle_detected": false
       }
     },
     {
       "input_tokens": 32768,
       "output_tokens": 128,
-      "label": "depth 90% \u00b7 needle found",
+      "label": "depth 90% · needle found",
       "metrics": {
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 19.62,
         "input_tokens_total": 40316,
         "output_tokens_total": 83,
@@ -608,7 +608,7 @@
         "power_peak_w": 64.83,
         "energy_wh": 0.3221,
         "gpu_util_avg_pct": 95.11,
-        "temp_max_c": 77.0,
+        "temp_max_c": 77,
         "thermal_throttle_detected": false
       }
     }
@@ -649,62 +649,62 @@
         {
           "id": "lctx-0043",
           "input_tokens": 32768,
-          "depth_pct": 10.0,
+          "depth_pct": 10,
           "needle_correct": true,
           "output_tok_s": 4.34,
           "decode_tok_s": 33.023,
           "ttft_ms": 17439.958,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "lctx-0044",
           "input_tokens": 32768,
-          "depth_pct": 10.0,
+          "depth_pct": 10,
           "needle_correct": true,
           "output_tok_s": 4.324,
           "decode_tok_s": 34.368,
           "ttft_ms": 17215.053,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "lctx-0045",
           "input_tokens": 32768,
-          "depth_pct": 50.0,
+          "depth_pct": 50,
           "needle_correct": true,
           "output_tok_s": 4.244,
           "decode_tok_s": 32.62,
           "ttft_ms": 17247.732,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "lctx-0046",
           "input_tokens": 32768,
-          "depth_pct": 50.0,
+          "depth_pct": 50,
           "needle_correct": true,
           "output_tok_s": 4.335,
           "decode_tok_s": 34.199,
           "ttft_ms": 17351.08,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "lctx-0047",
           "input_tokens": 32768,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 4.164,
           "decode_tok_s": 34.325,
           "ttft_ms": 17964.196,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "lctx-0048",
           "input_tokens": 32768,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 4.23,
           "decode_tok_s": 35.056,
           "ttft_ms": 17280.668,
-          "success_rate": 1.0
+          "success_rate": 1
         }
       ],
       "requests": [
@@ -800,7 +800,7 @@
   },
   "provenance": {
     "github_login": "johntdavies",
-    "github_user_id": null,
+    "github_user_id": 1065484,
     "started_at": "2026-08-30T00:13:31Z",
     "finished_at": "2026-08-30T00:15:30Z",
     "submitted_at": null,

--- a/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/3c6d5b151ad6b0c1--prefill-32k-v1--ea56b6.json
+++ b/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/3c6d5b151ad6b0c1--prefill-32k-v1--ea56b6.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -78,7 +78,7 @@
       "warmup_requests": 1,
       "prompts_padded": false,
       "needle_check": false,
-      "timeout_s": 900.0,
+      "timeout_s": 900,
       "seed": 42
     }
   },
@@ -86,7 +86,7 @@
     "requests_total": 10,
     "requests_ok": 10,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 179.76,
     "input_tokens_total": 403331,
     "output_tokens_total": 160,
@@ -146,7 +146,7 @@
     "power_peak_w": 65.23,
     "energy_wh": 3.3938,
     "gpu_util_avg_pct": 93.42,
-    "temp_max_c": 78.0,
+    "temp_max_c": 78,
     "thermal_throttle_detected": false
   },
   "failures": [],
@@ -339,7 +339,7 @@
   },
   "provenance": {
     "github_login": "johntdavies",
-    "github_user_id": null,
+    "github_user_id": 1065484,
     "started_at": "2026-08-30T00:10:09Z",
     "finished_at": "2026-08-30T00:13:30Z",
     "submitted_at": null,

--- a/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/3c6d5b151ad6b0c1--prefill-8k-v1--2a78d4.json
+++ b/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/3c6d5b151ad6b0c1--prefill-8k-v1--2a78d4.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -78,7 +78,7 @@
       "warmup_requests": 1,
       "prompts_padded": false,
       "needle_check": false,
-      "timeout_s": 900.0,
+      "timeout_s": 900,
       "seed": 42
     }
   },
@@ -86,7 +86,7 @@
     "requests_total": 10,
     "requests_ok": 10,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 52.329,
     "input_tokens_total": 101962,
     "output_tokens_total": 160,
@@ -146,7 +146,7 @@
     "power_peak_w": 63.36,
     "energy_wh": 0.9144,
     "gpu_util_avg_pct": 88.22,
-    "temp_max_c": 75.0,
+    "temp_max_c": 75,
     "thermal_throttle_detected": false
   },
   "failures": [],
@@ -339,7 +339,7 @@
   },
   "provenance": {
     "github_login": "johntdavies",
-    "github_user_id": null,
+    "github_user_id": 1065484,
     "started_at": "2026-08-30T00:09:07Z",
     "finished_at": "2026-08-30T00:10:08Z",
     "submitted_at": null,

--- a/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/3c6d5b151ad6b0c1--serve-short-c16-i128-o128-v1--41a5f0.json
+++ b/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/3c6d5b151ad6b0c1--serve-short-c16-i128-o128-v1--41a5f0.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -79,7 +79,7 @@
       "repeat": 3,
       "seed": 42,
       "temperature": 0,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "dataset_buckets": [
         "xs",
         "s"
@@ -93,7 +93,7 @@
     "requests_total": 320,
     "requests_ok": 320,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 291.853,
     "input_tokens_total": 55484,
     "output_tokens_total": 40960,
@@ -153,7 +153,7 @@
     "power_peak_w": 54.15,
     "energy_wh": 3.5467,
     "gpu_util_avg_pct": 87.33,
-    "temp_max_c": 67.0,
+    "temp_max_c": 67,
     "thermal_throttle_detected": false
   },
   "failures": [],
@@ -193,7 +193,7 @@
           "requests_total": 320,
           "requests_ok": 320,
           "requests_failed": 0,
-          "success_rate": 1.0,
+          "success_rate": 1,
           "duration_s": 297.196,
           "input_tokens_total": 55484,
           "output_tokens_total": 40960,
@@ -253,14 +253,14 @@
           "power_peak_w": 55.33,
           "energy_wh": 3.793,
           "gpu_util_avg_pct": 85.99,
-          "temp_max_c": 70.0,
+          "temp_max_c": 70,
           "thermal_throttle_detected": false
         },
         {
           "requests_total": 320,
           "requests_ok": 320,
           "requests_failed": 0,
-          "success_rate": 1.0,
+          "success_rate": 1,
           "duration_s": 291.853,
           "input_tokens_total": 55484,
           "output_tokens_total": 40960,
@@ -320,14 +320,14 @@
           "power_peak_w": 54.15,
           "energy_wh": 3.5467,
           "gpu_util_avg_pct": 87.33,
-          "temp_max_c": 67.0,
+          "temp_max_c": 67,
           "thermal_throttle_detected": false
         },
         {
           "requests_total": 320,
           "requests_ok": 320,
           "requests_failed": 0,
-          "success_rate": 1.0,
+          "success_rate": 1,
           "duration_s": 291.249,
           "input_tokens_total": 55484,
           "output_tokens_total": 40960,
@@ -387,7 +387,7 @@
           "power_peak_w": 51.45,
           "energy_wh": 3.55,
           "gpu_util_avg_pct": 88.62,
-          "temp_max_c": 67.0,
+          "temp_max_c": 67,
           "thermal_throttle_detected": false
         }
       ],
@@ -5533,7 +5533,7 @@
           "prompt_id": "mix-0066",
           "warmup": false,
           "status": "ok",
-          "ttft_ms": 892.0,
+          "ttft_ms": 892,
           "e2e_ms": 14116.56,
           "prompt_tokens": 175,
           "completion_tokens": 128,
@@ -5607,7 +5607,7 @@
   },
   "provenance": {
     "github_login": "johntdavies",
-    "github_user_id": null,
+    "github_user_id": 1065484,
     "started_at": "2026-08-30T00:15:30Z",
     "finished_at": "2026-08-30T00:30:27Z",
     "submitted_at": null,

--- a/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/3c6d5b151ad6b0c1--serve-single-i256-o256-v1--316125.json
+++ b/results/vllm/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/3c6d5b151ad6b0c1--serve-single-i256-o256-v1--316125.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -79,7 +79,7 @@
       "repeat": 1,
       "seed": 42,
       "temperature": 0,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "dataset_buckets": [
         "s",
         "m"
@@ -93,7 +93,7 @@
     "requests_total": 50,
     "requests_ok": 50,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 424.275,
     "input_tokens_total": 13779,
     "output_tokens_total": 12800,
@@ -153,7 +153,7 @@
     "power_peak_w": 41.78,
     "energy_wh": 4.4381,
     "gpu_util_avg_pct": 89.16,
-    "temp_max_c": 65.0,
+    "temp_max_c": 65,
     "thermal_throttle_detected": false
   },
   "failures": [],
@@ -193,7 +193,7 @@
           "requests_total": 50,
           "requests_ok": 50,
           "requests_failed": 0,
-          "success_rate": 1.0,
+          "success_rate": 1,
           "duration_s": 424.275,
           "input_tokens_total": 13779,
           "output_tokens_total": 12800,
@@ -253,7 +253,7 @@
           "power_peak_w": 41.78,
           "energy_wh": 4.4381,
           "gpu_util_avg_pct": 89.16,
-          "temp_max_c": 65.0,
+          "temp_max_c": 65,
           "thermal_throttle_detected": false
         }
       ],
@@ -962,7 +962,7 @@
   },
   "provenance": {
     "github_login": "johntdavies",
-    "github_user_id": null,
+    "github_user_id": 1065484,
     "started_at": "2026-08-30T00:01:36Z",
     "finished_at": "2026-08-30T00:09:06Z",
     "submitted_at": null,


### PR DESCRIPTION
`stamp-user-ids` only runs for branches in this repository — a fork's branch cannot be pushed to with the default token — so #112 merged with `provenance.github_user_id` null on all five files.

The contributors page keys on the login, so [@johntdavies](https://github.com/johntdavies) appears either way; the numeric id is the part that survives a rename, and without it the avatar falls back to a login-derived URL. Resolved to `1065484` with the same tool CI uses (`tools/src/resolve-user.ts`). Nothing else in the files is touched.

The five `ci-owned-field` warnings are expected — that check exists to stop *contributors* pre-filling the field, and this is the stamp it is waiting for.

Worth a follow-up: nothing stamps fork contributions today, so every outside contributor's results keep a null id until someone notices. A scheduled or post-merge job on `main` would close that.