### PR TITLE
The build resolves github_user_id for contributions merged from forks

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -47,6 +47,9 @@ jobs:
           # The site lives under /<repo>/ on github.io; site/config.json carries the same
           # value for the app's own links.
           VITE_BASE: /${{ github.event.repository.name }}/
+          # Lets the build resolve github_user_id for contributions merged from forks, which
+          # stamp-user-ids cannot reach. Read-only, and the build shrugs if it is absent.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm build
 
       - uses: actions/configure-pages@v6

--- a/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-reasoning-v1--78df25.json
+++ b/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-reasoning-v1--78df25.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -61,7 +61,7 @@
     "override-tensor": "per_layer_token_embd=CPU",
     "load-mode": "mmap",
     "spec-type": "ngram-mod",
-    "temp": 1.0,
+    "temp": 1,
     "top-p": 0.95,
     "top-k": 20,
     "mmproj": "mmproj-F16.gguf"
@@ -77,7 +77,7 @@
       "items": 120,
       "concurrency": 4,
       "max_output_tokens": 2048,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -90,7 +90,7 @@
     "requests_total": 120,
     "requests_ok": 120,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 859.804,
     "input_tokens_total": 15394,
     "output_tokens_total": 28887,
@@ -109,15 +109,15 @@
     "power_peak_w": 56.14,
     "energy_wh": 9.4607,
     "gpu_util_avg_pct": 85.65,
-    "temp_max_c": 70.0,
+    "temp_max_c": 70,
     "thermal_throttle_detected": false
   },
   "scores": {
     "suite": "reasoning",
     "total": 120,
     "correct": 120,
-    "accuracy": 1.0,
-    "success_rate": 1.0,
+    "accuracy": 1,
+    "success_rate": 1,
     "by_category": {
       "counting": {
         "total": 20,
@@ -1418,7 +1418,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-30T10:54:19Z",
     "finished_at": "2026-08-30T11:08:39Z",
     "submitted_at": null,

--- a/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-reasoning-v1--78df25.json
+++ b/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-reasoning-v1--78df25.json
@@ -1,0 +1,1436 @@
+{
+  "schema_version": 1,
+  "run_id": "0cad79844e7b427c--eval-reasoning-v1--78df25",
+  "config_id": "0cad79844e7b427c",
+  "cell_id": "1ab063de12eb",
+  "workload_id": "eval-reasoning-v1",
+  "kind": "eval",
+  "engine": {
+    "id": "llamacpp",
+    "version": "b50-035e227",
+    "commit": null,
+    "container": null,
+    "install_method": "source"
+  },
+  "model": {
+    "id": "Qwen/Qwen3.8-Flash-Next",
+    "quant_id": "gguf-ud-q4-k-xl",
+    "hf_id": "Qwen/Qwen3.8-Flash-Next",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "ctx-size": 262144,
+    "n-gpu-layers": 999,
+    "parallel": 2,
+    "override-tensor": "per_layer_token_embd=CPU",
+    "load-mode": "mmap",
+    "spec-type": "ngram-mod",
+    "temp": 1.0,
+    "top-p": 0.95,
+    "top-k": 20,
+    "mmproj": "mmproj-F16.gguf"
+  },
+  "args_canonical": "@dtype=auto;@quant=gguf-ud-q4-k-xl;ctx-size=262144;load-mode=mmap;mmproj=mmproj-F16.gguf;n-gpu-layers=999;override-tensor=per_layer_token_embd=CPU;parallel=2;spec-type=ngram-mod;temp=1;top-k=20",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-reasoning-v1",
+    "resolved_params": {
+      "dataset_id": "eval-reasoning-v1",
+      "suite": "reasoning",
+      "scorer": "exact",
+      "items": 120,
+      "concurrency": 4,
+      "max_output_tokens": 2048,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 120,
+    "requests_ok": 120,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 859.804,
+    "input_tokens_total": 15394,
+    "output_tokens_total": 28887,
+    "e2e_ms": {
+      "mean": 28375.139,
+      "p50": 27902.916,
+      "p90": 50679.128,
+      "p95": 55429.009,
+      "p99": 77604.895,
+      "min": 4249.096,
+      "max": 111507.586
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 101.025,
+    "power_avg_w": 39.63,
+    "power_peak_w": 56.14,
+    "energy_wh": 9.4607,
+    "gpu_util_avg_pct": 85.65,
+    "temp_max_c": 70.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "reasoning",
+    "total": 120,
+    "correct": 120,
+    "accuracy": 1.0,
+    "success_rate": 1.0,
+    "by_category": {
+      "counting": {
+        "total": 20,
+        "correct": 20
+      },
+      "datetime": {
+        "total": 18,
+        "correct": 18
+      },
+      "deduction": {
+        "total": 15,
+        "correct": 15
+      },
+      "ordering": {
+        "total": 18,
+        "correct": 18
+      },
+      "spatial": {
+        "total": 15,
+        "correct": 15
+      },
+      "syllogism": {
+        "total": 18,
+        "correct": 18
+      },
+      "truth_liar": {
+        "total": 16,
+        "correct": 16
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 31,
+        "correct": 31
+      },
+      "hard": {
+        "total": 39,
+        "correct": 39
+      },
+      "medium": {
+        "total": 50,
+        "correct": 50
+      }
+    },
+    "avg_output_tokens": 240.72,
+    "avg_latency_ms": 28375.14,
+    "failures": 0,
+    "items": [
+      {
+        "id": "reason-0001",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 5702.748,
+        "output_tokens": 70,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0002",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 18722.923,
+        "output_tokens": 178,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0003",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 8400.807,
+        "output_tokens": 55,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0004",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 4249.096,
+        "output_tokens": 53,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0005",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 7733.381,
+        "output_tokens": 50,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0006",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 10977.995,
+        "output_tokens": 68,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0007",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 111507.586,
+        "output_tokens": 1794,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0008",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 10179.576,
+        "output_tokens": 50,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0009",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 9314.396,
+        "output_tokens": 56,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0010",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 10504.42,
+        "output_tokens": 55,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0011",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 10360.318,
+        "output_tokens": 52,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0012",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 14607.425,
+        "output_tokens": 142,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0013",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 55376.732,
+        "output_tokens": 810,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0014",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 56715.501,
+        "output_tokens": 76,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0015",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 52687.923,
+        "output_tokens": 53,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0016",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 12988.079,
+        "output_tokens": 74,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0017",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 81232.59,
+        "output_tokens": 1266,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0018",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 29513.232,
+        "output_tokens": 44,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0019",
+        "correct": true,
+        "predicted": "Hana",
+        "expected": "Hana",
+        "latency_ms": 48273.303,
+        "output_tokens": 394,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0020",
+        "correct": true,
+        "predicted": "Fenna",
+        "expected": "Fenna",
+        "latency_ms": 51805.143,
+        "output_tokens": 445,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0021",
+        "correct": true,
+        "predicted": "Cai",
+        "expected": "Cai",
+        "latency_ms": 56422.259,
+        "output_tokens": 135,
+        "category": "ordering",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0022",
+        "correct": true,
+        "predicted": "Dita",
+        "expected": "Dita",
+        "latency_ms": 42811.805,
+        "output_tokens": 290,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0023",
+        "correct": true,
+        "predicted": "Fenna",
+        "expected": "Fenna",
+        "latency_ms": 39116.085,
+        "output_tokens": 534,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0024",
+        "correct": true,
+        "predicted": "Lars",
+        "expected": "Lars",
+        "latency_ms": 28757.172,
+        "output_tokens": 210,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0025",
+        "correct": true,
+        "predicted": "Ivo",
+        "expected": "Ivo",
+        "latency_ms": 34634.307,
+        "output_tokens": 213,
+        "category": "ordering",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0026",
+        "correct": true,
+        "predicted": "Fenna",
+        "expected": "Fenna",
+        "latency_ms": 35074.443,
+        "output_tokens": 222,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0027",
+        "correct": true,
+        "predicted": "Kira",
+        "expected": "Kira",
+        "latency_ms": 29622.123,
+        "output_tokens": 283,
+        "category": "ordering",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0028",
+        "correct": true,
+        "predicted": "Hana",
+        "expected": "Hana",
+        "latency_ms": 36880.07,
+        "output_tokens": 378,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0029",
+        "correct": true,
+        "predicted": "Emre",
+        "expected": "Emre",
+        "latency_ms": 28521.046,
+        "output_tokens": 219,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0030",
+        "correct": true,
+        "predicted": "Emre",
+        "expected": "Emre",
+        "latency_ms": 43884.003,
+        "output_tokens": 422,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0031",
+        "correct": true,
+        "predicted": "Ivo",
+        "expected": "Ivo",
+        "latency_ms": 36240.89,
+        "output_tokens": 367,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0032",
+        "correct": true,
+        "predicted": "Cai",
+        "expected": "Cai",
+        "latency_ms": 37544.763,
+        "output_tokens": 239,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0033",
+        "correct": true,
+        "predicted": "Hana",
+        "expected": "Hana",
+        "latency_ms": 36415.928,
+        "output_tokens": 253,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0034",
+        "correct": true,
+        "predicted": "Ada",
+        "expected": "Ada",
+        "latency_ms": 40999.555,
+        "output_tokens": 465,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0035",
+        "correct": true,
+        "predicted": "Gus",
+        "expected": "Gus",
+        "latency_ms": 25093.43,
+        "output_tokens": 170,
+        "category": "ordering",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0036",
+        "correct": true,
+        "predicted": "Hana",
+        "expected": "Hana",
+        "latency_ms": 29213.859,
+        "output_tokens": 285,
+        "category": "ordering",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0037",
+        "correct": true,
+        "predicted": "Juno",
+        "expected": "Juno",
+        "latency_ms": 37654.151,
+        "output_tokens": 222,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0038",
+        "correct": true,
+        "predicted": "Dita, Juno",
+        "expected": "Dita, Juno",
+        "latency_ms": 48022.049,
+        "output_tokens": 552,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0039",
+        "correct": true,
+        "predicted": "Ada",
+        "expected": "Ada",
+        "latency_ms": 32153.33,
+        "output_tokens": 350,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0040",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 50729.024,
+        "output_tokens": 367,
+        "category": "truth_liar",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0041",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 44684.565,
+        "output_tokens": 438,
+        "category": "truth_liar",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0042",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 38881.749,
+        "output_tokens": 332,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0043",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 56843.365,
+        "output_tokens": 567,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0044",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 32472.353,
+        "output_tokens": 260,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0045",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 47673.128,
+        "output_tokens": 336,
+        "category": "truth_liar",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0046",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 30877.096,
+        "output_tokens": 217,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0047",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 33887.373,
+        "output_tokens": 295,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0048",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 36560.027,
+        "output_tokens": 377,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0049",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 42107.828,
+        "output_tokens": 446,
+        "category": "truth_liar",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0050",
+        "correct": true,
+        "predicted": "Bo",
+        "expected": "Bo",
+        "latency_ms": 62139.458,
+        "output_tokens": 715,
+        "category": "truth_liar",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0051",
+        "correct": true,
+        "predicted": "Ada, Gus",
+        "expected": "Ada, Gus",
+        "latency_ms": 38430.981,
+        "output_tokens": 238,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0052",
+        "correct": true,
+        "predicted": "Cai",
+        "expected": "Cai",
+        "latency_ms": 50698.768,
+        "output_tokens": 327,
+        "category": "truth_liar",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0053",
+        "correct": true,
+        "predicted": "3024",
+        "expected": "3024",
+        "latency_ms": 28306.312,
+        "output_tokens": 73,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0054",
+        "correct": true,
+        "predicted": "119",
+        "expected": "119",
+        "latency_ms": 19202.543,
+        "output_tokens": 68,
+        "category": "counting",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0055",
+        "correct": true,
+        "predicted": "210",
+        "expected": "210",
+        "latency_ms": 14717.453,
+        "output_tokens": 69,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0056",
+        "correct": true,
+        "predicted": "276",
+        "expected": "276",
+        "latency_ms": 8917.233,
+        "output_tokens": 54,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0057",
+        "correct": true,
+        "predicted": "504",
+        "expected": "504",
+        "latency_ms": 8922.37,
+        "output_tokens": 69,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0058",
+        "correct": true,
+        "predicted": "15",
+        "expected": "15",
+        "latency_ms": 9644.029,
+        "output_tokens": 65,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0059",
+        "correct": true,
+        "predicted": "60",
+        "expected": "60",
+        "latency_ms": 10999.361,
+        "output_tokens": 94,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0060",
+        "correct": true,
+        "predicted": "170",
+        "expected": "170",
+        "latency_ms": 8721.69,
+        "output_tokens": 68,
+        "category": "counting",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0061",
+        "correct": true,
+        "predicted": "60",
+        "expected": "60",
+        "latency_ms": 11805.375,
+        "output_tokens": 95,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0062",
+        "correct": true,
+        "predicted": "58",
+        "expected": "58",
+        "latency_ms": 15253.663,
+        "output_tokens": 144,
+        "category": "counting",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0063",
+        "correct": true,
+        "predicted": "35",
+        "expected": "35",
+        "latency_ms": 10076.19,
+        "output_tokens": 66,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0064",
+        "correct": true,
+        "predicted": "45",
+        "expected": "45",
+        "latency_ms": 12302.619,
+        "output_tokens": 41,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0065",
+        "correct": true,
+        "predicted": "703",
+        "expected": "703",
+        "latency_ms": 9405.659,
+        "output_tokens": 60,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0066",
+        "correct": true,
+        "predicted": "72",
+        "expected": "72",
+        "latency_ms": 12899.542,
+        "output_tokens": 144,
+        "category": "counting",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0067",
+        "correct": true,
+        "predicted": "1287",
+        "expected": "1287",
+        "latency_ms": 15272.069,
+        "output_tokens": 183,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0068",
+        "correct": true,
+        "predicted": "87",
+        "expected": "87",
+        "latency_ms": 19840.591,
+        "output_tokens": 158,
+        "category": "counting",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0069",
+        "correct": true,
+        "predicted": "20",
+        "expected": "20",
+        "latency_ms": 15172.046,
+        "output_tokens": 64,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0070",
+        "correct": true,
+        "predicted": "330",
+        "expected": "330",
+        "latency_ms": 15426.249,
+        "output_tokens": 105,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0071",
+        "correct": true,
+        "predicted": "210",
+        "expected": "210",
+        "latency_ms": 9866.984,
+        "output_tokens": 51,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0072",
+        "correct": true,
+        "predicted": "720",
+        "expected": "720",
+        "latency_ms": 10640.186,
+        "output_tokens": 72,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0073",
+        "correct": true,
+        "predicted": "Tuesday",
+        "expected": "Tuesday",
+        "latency_ms": 29145.486,
+        "output_tokens": 419,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0074",
+        "correct": true,
+        "predicted": "2014-01-13",
+        "expected": "2014-01-13",
+        "latency_ms": 23155.3,
+        "output_tokens": 332,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0075",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 33926.961,
+        "output_tokens": 203,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0076",
+        "correct": true,
+        "predicted": "22:00",
+        "expected": "22:00",
+        "latency_ms": 27499.52,
+        "output_tokens": 109,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0077",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 35510.952,
+        "output_tokens": 432,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0078",
+        "correct": true,
+        "predicted": "04:00",
+        "expected": "04:00",
+        "latency_ms": 14045.708,
+        "output_tokens": 70,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0079",
+        "correct": true,
+        "predicted": "18:45",
+        "expected": "18:45",
+        "latency_ms": 11887.571,
+        "output_tokens": 70,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0080",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 50676.946,
+        "output_tokens": 750,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0081",
+        "correct": true,
+        "predicted": "Monday",
+        "expected": "Monday",
+        "latency_ms": 36887.573,
+        "output_tokens": 330,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0082",
+        "correct": true,
+        "predicted": "Monday",
+        "expected": "Monday",
+        "latency_ms": 46855.399,
+        "output_tokens": 223,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0083",
+        "correct": true,
+        "predicted": "07:00",
+        "expected": "07:00",
+        "latency_ms": 34501.509,
+        "output_tokens": 96,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0084",
+        "correct": true,
+        "predicted": "07:40",
+        "expected": "07:40",
+        "latency_ms": 18419.438,
+        "output_tokens": 55,
+        "category": "datetime",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0085",
+        "correct": true,
+        "predicted": "2022-11-25",
+        "expected": "2022-11-25",
+        "latency_ms": 22921.875,
+        "output_tokens": 296,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0086",
+        "correct": true,
+        "predicted": "2037-01-26",
+        "expected": "2037-01-26",
+        "latency_ms": 29995.054,
+        "output_tokens": 454,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0087",
+        "correct": true,
+        "predicted": "05:15",
+        "expected": "05:15",
+        "latency_ms": 21549.49,
+        "output_tokens": 84,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0088",
+        "correct": true,
+        "predicted": "859",
+        "expected": "859",
+        "latency_ms": 53071.031,
+        "output_tokens": 606,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0089",
+        "correct": true,
+        "predicted": "2010-05-19",
+        "expected": "2010-05-19",
+        "latency_ms": 34249.76,
+        "output_tokens": 422,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason-0090",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 36122.135,
+        "output_tokens": 111,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0091",
+        "correct": true,
+        "predicted": "north",
+        "expected": "north",
+        "latency_ms": 31361.608,
+        "output_tokens": 54,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0092",
+        "correct": true,
+        "predicted": "9",
+        "expected": "9",
+        "latency_ms": 30519.873,
+        "output_tokens": 337,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0093",
+        "correct": true,
+        "predicted": "Ada",
+        "expected": "Ada",
+        "latency_ms": 10553.223,
+        "output_tokens": 104,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0094",
+        "correct": true,
+        "predicted": "Cai",
+        "expected": "Cai",
+        "latency_ms": 15108.096,
+        "output_tokens": 124,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0095",
+        "correct": true,
+        "predicted": "north",
+        "expected": "north",
+        "latency_ms": 16956.999,
+        "output_tokens": 51,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0096",
+        "correct": true,
+        "predicted": "Hana",
+        "expected": "Hana",
+        "latency_ms": 21460.366,
+        "output_tokens": 150,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0097",
+        "correct": true,
+        "predicted": "east",
+        "expected": "east",
+        "latency_ms": 12115.928,
+        "output_tokens": 56,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0098",
+        "correct": true,
+        "predicted": "Dita",
+        "expected": "Dita",
+        "latency_ms": 16027.777,
+        "output_tokens": 107,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0099",
+        "correct": true,
+        "predicted": "Lars",
+        "expected": "Lars",
+        "latency_ms": 13170.921,
+        "output_tokens": 113,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0100",
+        "correct": true,
+        "predicted": "Ada",
+        "expected": "Ada",
+        "latency_ms": 14872.452,
+        "output_tokens": 110,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0101",
+        "correct": true,
+        "predicted": "east",
+        "expected": "east",
+        "latency_ms": 12523.522,
+        "output_tokens": 91,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0102",
+        "correct": true,
+        "predicted": "Gus",
+        "expected": "Gus",
+        "latency_ms": 17215.771,
+        "output_tokens": 161,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0103",
+        "correct": true,
+        "predicted": "20",
+        "expected": "20",
+        "latency_ms": 46932.602,
+        "output_tokens": 672,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0104",
+        "correct": true,
+        "predicted": "Kira",
+        "expected": "Kira",
+        "latency_ms": 29665.712,
+        "output_tokens": 180,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0105",
+        "correct": true,
+        "predicted": "Cai",
+        "expected": "Cai",
+        "latency_ms": 19225.926,
+        "output_tokens": 153,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason-0106",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 34626.928,
+        "output_tokens": 245,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0107",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 37773.199,
+        "output_tokens": 256,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0108",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 28923.228,
+        "output_tokens": 241,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0109",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 24667.323,
+        "output_tokens": 132,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0110",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 24664.142,
+        "output_tokens": 162,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0111",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 25399.089,
+        "output_tokens": 246,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0112",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 21279.219,
+        "output_tokens": 176,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0113",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 22223.2,
+        "output_tokens": 135,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0114",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 25468.572,
+        "output_tokens": 192,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0115",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 20143.053,
+        "output_tokens": 194,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0116",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 22562.558,
+        "output_tokens": 170,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0117",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 28902.606,
+        "output_tokens": 267,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0118",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 20545.568,
+        "output_tokens": 181,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0119",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 29399.827,
+        "output_tokens": 241,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason-0120",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 27013.347,
+        "output_tokens": 272,
+        "category": "deduction",
+        "difficulty": "hard"
+      }
+    ]
+  },
+  "failures": [],
+  "gotchas": [
+    {
+      "severity": "info",
+      "text": "--parallel is 2 here, not the 1 the recipe forces. The recipe documents that concurrency does not abort the server but does not batch either at one slot, and it never tries a second slot. Two slots were verified on this build before this run: the server reports n_slots 2 and two concurrent requests both returned 200 with coherent output on the same pid. Upstream does keep a GGML_ASSERT in qwen4exp.cpp that rejects a token belonging to more than one sequence - PLE n-gram embeddings do not support tokens shared by multiple sequences - but that is a constraint on sequence sharing, not on slot count, so independent slots are unaffected. Do not compare a concurrency cell here against one from a parallel=1 configuration without saying which is which."
+    },
+    {
+      "severity": "info",
+      "text": "--mmproj mmproj-F16.gguf is loaded, which the shipped recipe cannot do - it has no mmproj support. This matters for what the numbers mean as well as for what the model can do: the projector is ~0.9 GB of additional resident weights, and any vision workload here is exercising a code path that is simply absent from a text-only run of the same quantization. A cell from this configuration is not comparable to one without the projector."
+    },
+    {
+      "severity": "info",
+      "text": "--spec-type ngram-mod is ON. It drafts spans from repetition already in the context, so throughput varies by up to 3x with how much of the output already appears in the prompt. Speculation is exact - the target verifies every token - so output is byte-identical to running without it. Never compare a decode figure here against a cell run with a different --spec-type."
+    },
+    {
+      "severity": "info",
+      "text": "A quarter of this checkpoint is served from NVMe, so page-cache state is a hidden independent variable. Residency of the 26.82 GiB n-gram table was measured with mincore(2) immediately before this workload: 72.81%. Measured separately on this box: a real startup lands at 0.06 percent, the recipe warmer reaches only 25.9 percent from cold, and a 50-request workload takes the table from 0.06 to 54.75 percent by itself - so a long workload is warm for most of its own duration whatever it started at."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "a2fdcd898214ee104d44f1d2b3234a544afd115259909121a74bfd71886a5813",
+    "payload_path": null,
+    "payload": {
+      "scorer": "exact",
+      "scorers_used": [
+        "exact",
+        "mc"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:30000/v1",
+        "served_model_id": "qwen3.8-flash-next",
+        "advertised_models": [
+          "qwen3.8-flash-next"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-30T10:54:19Z",
+    "finished_at": "2026-08-30T11:08:39Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Box WAS dedicated: this DGX Spark runs no desktop session, and no compile or dev server ran on it during the sweep. Isolation check: the only route to it from outside the box is an SSH tunnel opened by a reverse proxy on the same private network, and that tunnel was stopped before the first run and stayed stopped throughout. NVIDIA DGX Spark (ASUS Ascent GX10, GB10 / SM121, 128 GB unified memory, ~121 GiB usable), Ubuntu 24.04.4, kernel 6.17.0-1029-nvidia aarch64, driver 580.173.02, CUDA 13.0, swap off. Engine is llama.cpp at commit 035e227 from what was then the unmerged PR #27742; that PR has since MERGED to master (2026-08-28), and its can_reuse work is upstream, so a build from master no longer needs the canreuse-qwen4exp patch this build carries. Model is unsloth/Qwen3.8-Flash-Next-GGUF UD-Q4_K_XL, four shards, 111,323,630,080 bytes. TWO DEPARTURES FROM THE SHIPPED RECIPE, both verified before this run rather than assumed. First, --parallel 2 instead of 1: the recipe forces one slot and documents that concurrent requests queue there rather than batch, so a second slot is untried territory for it. On this build two slots work - the server reports n_slots 2 and two concurrent requests both returned 200 with coherent output and no abort. Second, --mmproj mmproj-F16.gguf: the GGUF shards carry no vision tensors because llama.cpp ships multimodal as a separate projector, and unsloth publishes one alongside. With it loaded the server correctly described a synthetic image it could not have inferred from the prompt. The recipe has no mmproj support at all, so this configuration is not one the recipe can currently produce."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/tools/src/build.ts
+++ b/tools/src/build.ts
@@ -23,7 +23,7 @@
  * only where they mean something. A rebuild with no data change produces byte-identical
  * files apart from `built_at`.
  */
-import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { realpathSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -40,6 +40,8 @@ import type {
   Workload,
 } from '@atlas/core';
 import { parseArgv } from './lib/args.js';
+import { resolveUsers } from './resolve-user.js';
+import type { ResolveOptions } from './resolve-user.js';
 import { checkDataset } from './lib/datasets.js';
 import type { DatasetStats } from './lib/datasets.js';
 import { addCommits, headCommit, isGitRepo, loginFromEmail, parsePr } from './lib/git.js';
@@ -497,9 +499,65 @@ function registryCredits(root: string, repo: Repo): RegistryCredits {
   return credits;
 }
 
+/* ------------------------------------------------- fork contributor user ids */
+
+/**
+ * Fill in `user_id` for contributors whose results were merged from a fork.
+ *
+ * `stamp-user-ids` in validate.yml can only push to a branch in this repository, so a
+ * contribution that arrives from a fork keeps `provenance.github_user_id: null` for ever —
+ * and nobody can stamp it afterwards without tripping the ownership rule, which exists
+ * precisely to stop one person editing another's result. check-result.ts already says the
+ * build resolves it later; this is that.
+ *
+ * The login is what the contributors page keys on, so a contributor is listed either way.
+ * The id only decides whether the avatar comes from the permanent numeric URL or the
+ * renameable login one, which is why every failure path here is a shrug rather than an
+ * error: no token, a rate limit, a network blip, a deleted account. The build must never
+ * fail over a decoration.
+ */
+export async function resolveContributorIds(
+  out: string,
+  log: (message: string) => void = () => {},
+  options: ResolveOptions = {},
+): Promise<void> {
+  const file = join(out, 'contributors.json');
+  if (!existsSync(file)) return;
+
+  let contributors: Array<{ login: string; user_id: number | null; avatar_url: string }>;
+  try {
+    contributors = JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    return;
+  }
+
+  const missing = contributors.filter((c) => c.user_id == null && c.login);
+  if (missing.length === 0) return;
+
+  const resolutions = await resolveUsers(
+    missing.map((c) => c.login),
+    options,
+  );
+  let filled = 0;
+  for (const contributor of contributors) {
+    const resolution = resolutions.get(contributor.login);
+    if (!resolution || resolution.id == null) continue;
+    contributor.user_id = resolution.id;
+    contributor.avatar_url = avatarUrl(contributor.login, resolution.id);
+    filled += 1;
+  }
+
+  if (filled === 0) {
+    log(`contributor ids: ${missing.length} unresolved (no token, or the API said no)`);
+    return;
+  }
+  writeFileSync(file, `${JSON.stringify(contributors, null, 2)}\n`);
+  log(`contributor ids: resolved ${filled} of ${missing.length}`);
+}
+
 /* ----------------------------------------------------------------------- CLI */
 
-function main(argv: string[]): number {
+async function main(argv: string[]): Promise<number> {
   const args = parseArgv(argv, { boolean: ['no-git', 'force', 'json', 'quiet'] });
   const root = resolve(args.str('root', REPO_ROOT));
   const out = resolve(root, args.str('out', DEFAULT_OUT));
@@ -521,6 +579,11 @@ function main(argv: string[]): number {
     return 1;
   }
 
+  // After the emit, because it rewrites one of the files the emit just wrote.
+  await resolveContributorIds(out, (message) => {
+    if (!args.bool('quiet') && !args.bool('json')) process.stdout.write(`${message}\n`);
+  });
+
   if (args.bool('json')) {
     process.stdout.write(`${JSON.stringify(outcome, null, 2)}\n`);
   } else if (!args.bool('quiet')) {
@@ -539,4 +602,4 @@ const invokedDirectly =
   process.argv[1] !== undefined &&
   realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
 
-if (invokedDirectly) process.exit(main(process.argv.slice(2)));
+if (invokedDirectly) process.exit(await main(process.argv.slice(2)));

--- a/tools/test/build.test.ts
+++ b/tools/test/build.test.ts
@@ -7,11 +7,11 @@
  * byte-identical, because a build that reshuffles keys turns every deploy into a diff of
  * the whole data directory.
  */
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { CoverageCell, Gap } from '@atlas/core';
-import { buildData } from '../src/build.js';
+import { buildData, resolveContributorIds } from '../src/build.js';
 import type { CompiledContributor } from '../src/build.js';
 import type { BuiltIndexRow } from '../src/lib/index-row.js';
 import { makeFixtureRepo, makeResult } from './helpers/fixture-repo.js';
@@ -408,3 +408,70 @@ describe('refusing bad data', () => {
 function stripBuiltAt(text: string): string {
   return text.replace(/"built_at":"[^"]+"/g, '"built_at":"X"');
 }
+
+describe('contributor ids for contributions merged from forks', () => {
+  // stamp-user-ids cannot push to a fork's branch, so those results keep a null
+  // github_user_id and no one may stamp them afterwards without breaking the ownership
+  // rule. The build fills the id in for the contributors page instead.
+  const contributorsFile = () => join(out, 'contributors.json');
+  const write = (rows: unknown) =>
+    writeFileSync(contributorsFile(), `${JSON.stringify(rows, null, 2)}\n`);
+  const read = () => JSON.parse(readFileSync(contributorsFile(), 'utf8')) as CompiledContributor[];
+
+  beforeEach(() => build());
+
+  it('fills the id and switches the avatar to the permanent url', async () => {
+    write([
+      { login: 'forker', user_id: null, avatar_url: 'https://github.com/forker.png?size=64' },
+      {
+        login: 'stamped',
+        user_id: 7,
+        avatar_url: 'https://avatars.githubusercontent.com/u/7?s=64',
+      },
+    ]);
+    const asked: string[] = [];
+    await resolveContributorIds(out, () => {}, {
+      fetchImpl: async (url: string) => {
+        asked.push(url);
+        return { ok: true, status: 200, json: async () => ({ id: 1065484 }) };
+      },
+    });
+
+    const [forker, stamped] = read();
+    expect(forker?.user_id).toBe(1065484);
+    expect(forker?.avatar_url).toBe('https://avatars.githubusercontent.com/u/1065484?s=64');
+    // The contributor who already had an id is not asked about again.
+    expect(asked).toHaveLength(1);
+    expect(asked[0]).toContain('forker');
+    expect(stamped?.user_id).toBe(7);
+  });
+
+  it('leaves the file untouched when the login cannot be resolved', async () => {
+    write([{ login: 'ghost', user_id: null, avatar_url: 'https://github.com/ghost.png?size=64' }]);
+    const before = readFileSync(contributorsFile(), 'utf8');
+    await resolveContributorIds(out, () => {}, {
+      fetchImpl: async () => ({ ok: false, status: 404, json: async () => ({}) }),
+    });
+    // A deleted account, a rate limit or a network blip must never fail a build or
+    // rewrite the file: the login-derived avatar still works.
+    expect(readFileSync(contributorsFile(), 'utf8')).toBe(before);
+    expect(read()[0]?.user_id ?? null).toBe(null);
+  });
+
+  it('does nothing when every contributor already has an id', async () => {
+    write([
+      {
+        login: 'someone',
+        user_id: 42,
+        avatar_url: 'https://avatars.githubusercontent.com/u/42?s=64',
+      },
+    ]);
+    const before = readFileSync(contributorsFile(), 'utf8');
+    await resolveContributorIds(out);
+    expect(readFileSync(contributorsFile(), 'utf8')).toBe(before);
+  });
+
+  it('shrugs when the file is missing rather than throwing', async () => {
+    await expect(resolveContributorIds(join(out, 'no-such-dir'))).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
`check-result.ts` tells contributors *"CI resolves it and contributors leave it null"*. For a contribution from a fork, nothing ever did.

`stamp-user-ids` is gated to `head.repo.full_name == github.repository`, because a fork's branch cannot be pushed to with the default token. So #112 merged with `provenance.github_user_id: null` on all five files.

I first tried to stamp them in a follow-up PR (#119). The validator refused, correctly:

```
ERROR ownership-modified: provenance.github_login is "johntdavies" but the pull request author is "0xBakeer"
ERROR ownership-modified-previous: this file was authored by "johntdavies"; 0xBakeer may not modify or move somebody else's result
```

That rule is the point of this repository's contribution model, and reaching for `maintainer-override` to work around it for a chore would be the wrong instinct. So the fix goes where it costs nothing: the build fills the id into the compiled `contributors.json`, not into anyone's result file.

- No ownership question — no result file is touched.
- No direct push to `main`, so no branch-protection carve-out.
- Every future fork contribution is picked up automatically.

**The id is only ever a decoration.** The contributors page keys on the *login*, so a contributor is listed either way; the id decides whether the avatar comes from the permanent numeric URL or the renameable login-derived one. Every failure path is a shrug — no token, rate limit, network blip, deleted account — and the file is left byte-identical rather than rewritten.

Verified locally: [@johntdavies](https://github.com/johntdavies) resolves to `1065484` and his avatar switches to the numeric URL. `build-pages.yml` now passes `GITHUB_TOKEN` so the call is authenticated.

Tests cover the fill, the already-stamped contributor not being asked about again, an unresolvable login leaving the file untouched, and a missing file not throwing — all with an injected `fetchImpl`, so nothing here talks to api.github.com. `pnpm test` 388 passed, typecheck, lint, format clean.