### PR TITLE
results: Qwen/Qwen3.8-Flash-Next on nvidia-gb10-dgx-spark — eval-instruction-v1 at parallel 2 with vision

### DIFF
--- a/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-instruction-v1--16b560.json
+++ b/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-instruction-v1--16b560.json
@@ -1,0 +1,1283 @@
+{
+  "schema_version": 1,
+  "run_id": "0cad79844e7b427c--eval-instruction-v1--16b560",
+  "config_id": "0cad79844e7b427c",
+  "cell_id": "1ab063de12eb",
+  "workload_id": "eval-instruction-v1",
+  "kind": "eval",
+  "engine": {
+    "id": "llamacpp",
+    "version": "b50-035e227",
+    "commit": null,
+    "container": null,
+    "install_method": "source"
+  },
+  "model": {
+    "id": "Qwen/Qwen3.8-Flash-Next",
+    "quant_id": "gguf-ud-q4-k-xl",
+    "hf_id": "Qwen/Qwen3.8-Flash-Next",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "ctx-size": 262144,
+    "n-gpu-layers": 999,
+    "parallel": 2,
+    "override-tensor": "per_layer_token_embd=CPU",
+    "load-mode": "mmap",
+    "spec-type": "ngram-mod",
+    "temp": 1.0,
+    "top-p": 0.95,
+    "top-k": 20,
+    "mmproj": "mmproj-F16.gguf"
+  },
+  "args_canonical": "@dtype=auto;@quant=gguf-ud-q4-k-xl;ctx-size=262144;load-mode=mmap;mmproj=mmproj-F16.gguf;n-gpu-layers=999;override-tensor=per_layer_token_embd=CPU;parallel=2;spec-type=ngram-mod;temp=1;top-k=20",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-instruction-v1",
+    "resolved_params": {
+      "dataset_id": "eval-instruction-v1",
+      "suite": "instruction",
+      "scorer": "instruction",
+      "items": 104,
+      "concurrency": 4,
+      "max_output_tokens": 2048,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 104,
+    "requests_ok": 104,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 749.781,
+    "input_tokens_total": 8450,
+    "output_tokens_total": 24990,
+    "e2e_ms": {
+      "mean": 28413.152,
+      "p50": 24808.217,
+      "p90": 45587.115,
+      "p95": 59917.641,
+      "p99": 79367.662,
+      "min": 8025.173,
+      "max": 81847.678
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 100.942,
+    "power_avg_w": 38.7,
+    "power_peak_w": 56.37,
+    "energy_wh": 8.0643,
+    "gpu_util_avg_pct": 84.33,
+    "temp_max_c": 70.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "instruction",
+    "total": 104,
+    "correct": 103,
+    "accuracy": 0.990385,
+    "success_rate": 1.0,
+    "by_category": {
+      "casing": {
+        "total": 11,
+        "correct": 11
+      },
+      "exclusion": {
+        "total": 8,
+        "correct": 8
+      },
+      "format": {
+        "total": 10,
+        "correct": 10
+      },
+      "framing": {
+        "total": 13,
+        "correct": 13
+      },
+      "inclusion": {
+        "total": 11,
+        "correct": 11
+      },
+      "json": {
+        "total": 4,
+        "correct": 3
+      },
+      "language": {
+        "total": 5,
+        "correct": 5
+      },
+      "length": {
+        "total": 17,
+        "correct": 17
+      },
+      "structure": {
+        "total": 25,
+        "correct": 25
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 23,
+        "correct": 23
+      },
+      "hard": {
+        "total": 20,
+        "correct": 19
+      },
+      "medium": {
+        "total": 61,
+        "correct": 61
+      }
+    },
+    "avg_output_tokens": 240.29,
+    "avg_latency_ms": 28413.15,
+    "failures": 0,
+    "items": [
+      {
+        "id": "inst-0001",
+        "correct": true,
+        "predicted": "Writing a plan down before starting clarifies goals, organizes steps, and reduces mistakes, making success more likely.",
+        "expected": "1 rules",
+        "latency_ms": 22263.21,
+        "output_tokens": 353,
+        "category": "length",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0002",
+        "correct": true,
+        "predicted": "Explaining forces you to organize ideas, retrieve them actively, and connect them to examples. This deeper processing creates stronger memory traces, making the information easier to recall later.",
+        "expected": "1 rules",
+        "latency_ms": 20347.368,
+        "output_tokens": 404,
+        "category": "length",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0003",
+        "correct": true,
+        "predicted": "First, check the power supply: ensure the wall outlet works, the charger cable is firmly connected, and the adapter is plugged into the laptop. If battery-powered, try charging briefly, then press and hold the power button to see if it responds.",
+        "expected": "1 rules",
+        "latency_ms": 52606.384,
+        "output_tokens": 537,
+        "category": "length",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0004",
+        "correct": true,
+        "predicted": "People underestimate task duration because they imagine best-case scenarios, ignore past delays, overlook interruptions, and confuse motivation with time. Optimism and narrow focus make future work seem simpler than it actually is.",
+        "expected": "1 rules",
+        "latency_ms": 39256.812,
+        "output_tokens": 308,
+        "category": "length",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0005",
+        "correct": true,
+        "predicted": "Clear steps, simple language, logical order, and specific details help readers know what to do. Visual cues, numbered actions, warnings, and examples reduce confusion. Good instructions anticipate mistakes, define terms, and let users check progress confidently.",
+        "expected": "1 rules",
+        "latency_ms": 34832.155,
+        "output_tokens": 278,
+        "category": "length",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0006",
+        "correct": true,
+        "predicted": "Reading the last page first reveals troubleshooting, safety notes, support contacts, and expected outcomes. This gives you a practical map, helping you navigate the manual faster, avoid common mistakes, and focus on the sections that matter most.",
+        "expected": "1 rules",
+        "latency_ms": 54883.237,
+        "output_tokens": 409,
+        "category": "length",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0007",
+        "correct": true,
+        "predicted": "A dress rehearsal lets performers practice the full show exactly as planned, revealing technical, timing, and coordination problems before the audience arrives.",
+        "expected": "1 rules",
+        "latency_ms": 28402.98,
+        "output_tokens": 212,
+        "category": "length",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0008",
+        "correct": true,
+        "predicted": "Shared calendars fail because they assume everyone will update them promptly, honestly, and consistently. People forget, avoid conflicts, use private reminders, or distrust visibility. Without clear rules, ownership, and simple habits, calendars become noisy, outdated, or politically loaded, so users stop trusting them and revert to messages, calls, or guesswork.",
+        "expected": "1 rules",
+        "latency_ms": 34211.653,
+        "output_tokens": 361,
+        "category": "length",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0009",
+        "correct": true,
+        "predicted": "Grey rain slicks harbour dawn",
+        "expected": "1 rules",
+        "latency_ms": 29677.577,
+        "output_tokens": 135,
+        "category": "length",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0010",
+        "correct": true,
+        "predicted": "Squeezing lever pulls cable forcing pads against wheel rim creating friction that slows down bicycle safely",
+        "expected": "1 rules",
+        "latency_ms": 52213.848,
+        "output_tokens": 610,
+        "category": "length",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0011",
+        "correct": true,
+        "predicted": "It relaxes gluten, redistributes gases.",
+        "expected": "1 rules",
+        "latency_ms": 29820.569,
+        "output_tokens": 360,
+        "category": "length",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0012",
+        "correct": true,
+        "predicted": "Sunlight spills on unfamiliar streets, footsteps echo, coffee warms, strangers smile, curiosity blooms, home begins forming.",
+        "expected": "1 rules",
+        "latency_ms": 45279.998,
+        "output_tokens": 399,
+        "category": "length",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0013",
+        "correct": true,
+        "predicted": "Clean as you go wash dishes wipe counters store food",
+        "expected": "1 rules",
+        "latency_ms": 60806.065,
+        "output_tokens": 493,
+        "category": "length",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0014",
+        "correct": true,
+        "predicted": "Adults learn swimming by trusting water slowly",
+        "expected": "1 rules",
+        "latency_ms": 65093.167,
+        "output_tokens": 730,
+        "category": "length",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0015",
+        "correct": true,
+        "predicted": "The library opens late, always welcoming night owls with quiet shelves and warm lamps.",
+        "expected": "1 rules",
+        "latency_ms": 44878.108,
+        "output_tokens": 312,
+        "category": "length",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0016",
+        "correct": true,
+        "predicted": "Tokyo",
+        "expected": "2 rules",
+        "latency_ms": 37702.462,
+        "output_tokens": 46,
+        "category": "format",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0017",
+        "correct": true,
+        "predicted": "180",
+        "expected": "1 rules",
+        "latency_ms": 23068.223,
+        "output_tokens": 41,
+        "category": "format",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0018",
+        "correct": true,
+        "predicted": "366",
+        "expected": "2 rules",
+        "latency_ms": 9927.157,
+        "output_tokens": 54,
+        "category": "format",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0019",
+        "correct": true,
+        "predicted": "Pacific Ocean",
+        "expected": "1 rules",
+        "latency_ms": 8025.173,
+        "output_tokens": 50,
+        "category": "format",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0020",
+        "correct": true,
+        "predicted": "On my first day in the new city, I wandered along the harbour and watched the boats sway gently. A small lantern hung from a rope near the dock, glowing softly as evening arrived.",
+        "expected": "2 rules",
+        "latency_ms": 10590.697,
+        "output_tokens": 98,
+        "category": "inclusion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0021",
+        "correct": true,
+        "predicted": "After using the kettle, wipe the counter and put it away so the shared kitchen stays tidy. If rain splashes through the window, dry the sill promptly to prevent mess.",
+        "expected": "2 rules",
+        "latency_ms": 12342.678,
+        "output_tokens": 138,
+        "category": "inclusion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0022",
+        "correct": true,
+        "predicted": "As an adult learning to swim, I recorded every pool visit in a ledger. I stamped the final page and tucked it into a drawer beside my goggles.",
+        "expected": "2 rules",
+        "latency_ms": 18107.06,
+        "output_tokens": 183,
+        "category": "inclusion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0023",
+        "correct": true,
+        "predicted": "The library opens late, like a harbor chart guiding night readers through the tide of quiet shelves. Its desk lamp points like a compass toward stories waiting after dark.",
+        "expected": "2 rules",
+        "latency_ms": 17743.845,
+        "output_tokens": 145,
+        "category": "inclusion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0024",
+        "correct": true,
+        "predicted": "The workshop smelled of fresh paint clinging to the ladder. A faint metallic scent rose from the hinge, mixing with the dust in the air.",
+        "expected": "2 rules",
+        "latency_ms": 17432.54,
+        "output_tokens": 91,
+        "category": "inclusion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0025",
+        "correct": true,
+        "predicted": "Before heading to the platform, I packed a thermos of tea and snacks for the long train journey. I also tucked the timetable into my bag so I could check each stop along the way.",
+        "expected": "2 rules",
+        "latency_ms": 18462.134,
+        "output_tokens": 150,
+        "category": "inclusion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0026",
+        "correct": true,
+        "predicted": "First, check that the power adapter is securely connected to both the laptop and a working outlet, and confirm the battery is charged or seated properly; if possible, try a different outlet or cable to rule out a power supply issue.",
+        "expected": "2 rules",
+        "latency_ms": 21286.642,
+        "output_tokens": 257,
+        "category": "exclusion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0027",
+        "correct": true,
+        "predicted": "People often underestimate task duration because they imagine a smooth, uninterrupted version of the work, focusing on the steps they control while overlooking delays, distractions, and hidden complications. This optimistic view is reinforced by the planning fallacy, where past overruns are treated as exceptions rather than useful evidence, and by the desire to feel capable or please others with quick promises. As a result, the mind anchors to a hopeful timeline instead of a realistic one.",
+        "expected": "2 rules",
+        "latency_ms": 28024.698,
+        "output_tokens": 369,
+        "category": "exclusion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0028",
+        "correct": true,
+        "predicted": "A good set of instructions is easy to follow when it states the goal clearly, breaks the process into ordered steps, uses plain language, defines any required terms, and anticipates common mistakes. Each step should contain one action, include necessary details without clutter, and offer a way to check progress. Visual cues, examples, and consistent formatting can further reduce confusion, while a brief summary or troubleshooting section helps readers recover if they go astray.",
+        "expected": "2 rules",
+        "latency_ms": 31660.526,
+        "output_tokens": 320,
+        "category": "exclusion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0029",
+        "correct": true,
+        "predicted": "Reading the last page of a manual first can reveal the intended result, common warnings, or troubleshooting steps, giving you a clear destination before you begin. That preview helps you understand why each instruction matters, spot missing parts early, and decide whether the task is feasible, so the detailed steps that follow become easier to follow and less likely to cause confusion.",
+        "expected": "2 rules",
+        "latency_ms": 35963.743,
+        "output_tokens": 319,
+        "category": "exclusion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0030",
+        "correct": true,
+        "predicted": "A dress rehearsal is a full practice run of a performance using the actual costumes, lighting, sound, props, and stage setup. Its purpose is to reveal problems before the audience arrives, allowing performers and crew to adjust timing, transitions, cues, and technical details. It also helps everyone become comfortable with the real conditions of the show, building confidence and reducing the chance of mistakes during the final performance.",
+        "expected": "2 rules",
+        "latency_ms": 28828.82,
+        "output_tokens": 199,
+        "category": "exclusion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0031",
+        "correct": true,
+        "predicted": "Shared calendars often fail because they assume everyone will update them consistently, but real work is messy, priorities shift, and people forget or avoid adding events that feel uncertain. They can also create confusion when permissions, time zones, reminders, and personal preferences are not aligned, so some users ignore the calendar while others rely on it too heavily. Without clear ownership, simple rules, and a habit of checking it before scheduling, the calendar becomes another noisy inb",
+        "expected": "2 rules",
+        "latency_ms": 30162.721,
+        "output_tokens": 213,
+        "category": "exclusion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0032",
+        "correct": true,
+        "predicted": "A checklist reduces panic by giving clear steps.  \nIt prevents forgetting critical actions under stress.  \nIt speeds response and improves safety.",
+        "expected": "2 rules",
+        "latency_ms": 26457.464,
+        "output_tokens": 231,
+        "category": "exclusion",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0033",
+        "correct": true,
+        "predicted": "Regular backups protect important data from loss caused by hardware failure theft malware or human error and help restore normal operations quickly.",
+        "expected": "2 rules",
+        "latency_ms": 24047.053,
+        "output_tokens": 177,
+        "category": "exclusion",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0034",
+        "correct": true,
+        "predicted": "EXPLAINING FORCES YOU TO ORGANIZE, RETRIEVE, AND SIMPLIFY INFORMATION, STRENGTHENING MEMORY PATHS AND MAKING THE IDEA MORE MEANINGFUL.",
+        "expected": "2 rules",
+        "latency_ms": 28296.828,
+        "output_tokens": 244,
+        "category": "casing",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0035",
+        "correct": true,
+        "predicted": "CHECK THE POWER CABLE, BATTERY, AND POWER BUTTON FIRST",
+        "expected": "2 rules",
+        "latency_ms": 22318.58,
+        "output_tokens": 165,
+        "category": "casing",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0036",
+        "correct": true,
+        "predicted": "PEOPLE FOCUS ON BEST CASES, IGNORE PAST DELAYS, AND OVERLOOK INTERRUPTIONS, SO THEY BELIEVE TASKS WILL GO FASTER THAN THEY USUALLY DO.",
+        "expected": "2 rules",
+        "latency_ms": 28073.152,
+        "output_tokens": 240,
+        "category": "casing",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0037",
+        "correct": true,
+        "predicted": "CLEAR STEPS, SIMPLE WORDS, LOGICAL ORDER, SPECIFIC ACTIONS, AND USEFUL EXAMPLES HELP PEOPLE UNDERSTAND AND COMPLETE TASKS SUCCESSFULLY.",
+        "expected": "2 rules",
+        "latency_ms": 23855.069,
+        "output_tokens": 199,
+        "category": "casing",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0038",
+        "correct": true,
+        "predicted": "THE LAST PAGE OFTEN HAS TROUBLESHOOTING, SUPPORT, AND SAFETY INFO, SO YOU KNOW WHAT TO DO IF THINGS GO WRONG.",
+        "expected": "2 rules",
+        "latency_ms": 35808.207,
+        "output_tokens": 365,
+        "category": "casing",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0039",
+        "correct": true,
+        "predicted": "TO TEST EVERYTHING FULLY BEFORE THE REAL PERFORMANCE, FINDING PROBLEMS AND BUILDING CONFIDENCE.",
+        "expected": "2 rules",
+        "latency_ms": 22612.366,
+        "output_tokens": 178,
+        "category": "casing",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0040",
+        "correct": true,
+        "predicted": "the library opens late and stays open until midnight.",
+        "expected": "2 rules",
+        "latency_ms": 20118.513,
+        "output_tokens": 146,
+        "category": "casing",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0041",
+        "correct": true,
+        "predicted": "the air hangs thick with sawdust, hot metal, and oil.",
+        "expected": "2 rules",
+        "latency_ms": 24747.767,
+        "output_tokens": 90,
+        "category": "casing",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0042",
+        "correct": true,
+        "predicted": "pack clothes, snacks, water, a book, and a blanket for comfort.",
+        "expected": "2 rules",
+        "latency_ms": 17648.129,
+        "output_tokens": 107,
+        "category": "casing",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0043",
+        "correct": true,
+        "predicted": "lists beat memory because they turn fragile thoughts into visible, reusable records.",
+        "expected": "2 rules",
+        "latency_ms": 14521.226,
+        "output_tokens": 118,
+        "category": "casing",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0044",
+        "correct": true,
+        "predicted": "soft green shoots rise through damp soil as pale blossoms tremble in cool morning light.",
+        "expected": "2 rules",
+        "latency_ms": 16654.854,
+        "output_tokens": 146,
+        "category": "casing",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0045",
+        "correct": true,
+        "predicted": "- Check tire pressure and tread depth.\n- Inspect engine oil, coolant, and washer fluid levels.\n- Test brakes, headlights, and turn signals.\n- Ensure the battery and wipers are in good condition.\n- Pack an emergency kit with water, snacks, and a first-aid kit.",
+        "expected": "2 rules",
+        "latency_ms": 18090.693,
+        "output_tokens": 151,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0046",
+        "correct": true,
+        "predicted": "- Check all rooms and storage areas for personal belongings.\n- Ensure utilities are turned off or transferred as required.\n- Clean the flat and remove all rubbish.\n- Take meter readings and document the property condition.",
+        "expected": "2 rules",
+        "latency_ms": 20648.057,
+        "output_tokens": 172,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0047",
+        "correct": true,
+        "predicted": "- Confirm the start time, location, and reporting instructions.\n- Prepare required documents, such as ID, tax forms, and contracts.\n- Plan your commute and allow extra time for unexpected delays.\n- Choose appropriate work attire and ensure it is clean and ready.\n- Review the job description and any onboarding materials provided.",
+        "expected": "2 rules",
+        "latency_ms": 19948.875,
+        "output_tokens": 145,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0048",
+        "correct": true,
+        "predicted": "- Check the weather forecast and pack clothing for temperature changes.\n- Inspect your tent, stakes, poles, and rainfly for damage or missing parts.\n- Confirm your campsite reservation, permits, and local camping rules.\n- Pack enough food, water, and wildlife-safe storage containers.\n- Test your flashlight, batteries, first aid kit, and emergency supplies.\n- Review campfire regulations and bring firewood if allowed.",
+        "expected": "2 rules",
+        "latency_ms": 27220.149,
+        "output_tokens": 253,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0049",
+        "correct": true,
+        "predicted": "- Verify all data, figures, and calculations are accurate.\n- Ensure the report fully addresses the requested scope and objectives.\n- Check for spelling, grammar, punctuation, and formatting consistency.\n- Confirm all sources, references, and citations are properly included.\n- Review conclusions and recommendations for clarity and logical support.\n- Make sure required approvals, signatures, or sign-offs are obtained.",
+        "expected": "2 rules",
+        "latency_ms": 23897.463,
+        "output_tokens": 238,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0050",
+        "correct": true,
+        "predicted": "- Check your passport, visa, and any required travel documents for validity.\n- Confirm your flight details, including departure time, gate, and layover information.\n- Verify baggage allowances and pack accordingly to avoid extra fees.\n- Ensure your phone, laptop, and chargers are packed and accessible.\n- Review health precautions, medications, and any needed travel insurance.\n- Check weather and airport conditions that could affect your trip.",
+        "expected": "2 rules",
+        "latency_ms": 25521.522,
+        "output_tokens": 162,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0051",
+        "correct": true,
+        "predicted": "- Confirm guest count and dietary restrictions\n- Check menu ingredients and cooking equipment\n- Clean dining area and set tableware\n- Plan timing for serving and cleanup",
+        "expected": "2 rules",
+        "latency_ms": 23458.639,
+        "output_tokens": 141,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0052",
+        "correct": true,
+        "predicted": "1. Allows gluten to relax so the loaf keeps its shape.\n2. Lets steam redistribute and the crust set for better texture.\n3. Makes slicing easier and prevents a gummy crumb.",
+        "expected": "2 rules",
+        "latency_ms": 21101.959,
+        "output_tokens": 173,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0053",
+        "correct": true,
+        "predicted": "1. Arrive and settle into your accommodation.\n2. Explore the immediate neighborhood on foot.\n3. Find a local café or market for food.\n4. Use public transit to visit one landmark.\n5. Plan tomorrow’s route and rest.",
+        "expected": "2 rules",
+        "latency_ms": 19520.617,
+        "output_tokens": 183,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0054",
+        "correct": true,
+        "predicted": "1. Wash or load dishes immediately after use.\n2. Wipe down counters and appliances after cooking.\n3. Store food properly and remove trash when full.",
+        "expected": "2 rules",
+        "latency_ms": 18538.867,
+        "output_tokens": 93,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0055",
+        "correct": true,
+        "predicted": "1. Get comfortable in the water by practicing breathing and floating.\n2. Learn basic strokes such as freestyle and backstroke with proper form.\n3. Practice kicking and arm movements separately before combining them.\n4. Swim short distances regularly to build confidence and endurance.",
+        "expected": "2 rules",
+        "latency_ms": 18987.708,
+        "output_tokens": 122,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0056",
+        "correct": true,
+        "predicted": "1. Check the library's late opening hours online or by phone.\n2. Arrive after the scheduled opening time with your library card.\n3. Enter through the self-service desk or staffed late entrance.",
+        "expected": "2 rules",
+        "latency_ms": 20111.082,
+        "output_tokens": 206,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0057",
+        "correct": true,
+        "predicted": "1. Sawdust and cut timber fill the air.\n2. Machine oil and hot metal linger nearby.\n3. Paint, varnish, or solvent notes drift past.\n4. Dust settles with a faint, dry warmth.",
+        "expected": "2 rules",
+        "latency_ms": 27792.6,
+        "output_tokens": 274,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0058",
+        "correct": true,
+        "predicted": "1. Pack essential documents, tickets, and money in an easily accessible pouch.\n2. Include comfortable clothing, toiletries, and any required medications.\n3. Bring snacks, water, and entertainment for the journey.",
+        "expected": "2 rules",
+        "latency_ms": 20429.664,
+        "output_tokens": 107,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0059",
+        "correct": true,
+        "predicted": "Lists beat memory because they externalize information into a reliable, reviewable format that reduces cognitive load and prevents important details from fading.\n\nUnlike memory, which is fragile and biased, lists provide a concrete record that can be shared, updated, and trusted.",
+        "expected": "2 rules",
+        "latency_ms": 30967.717,
+        "output_tokens": 218,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0060",
+        "correct": true,
+        "predicted": "The garden stirs beneath a pale morning sun, where crocuses push through damp soil like tiny promises.\n\nA thin mist clings to the bare branches of the apple tree, softening the edges of the quiet beds.\n\nBees test the cool air near the first pale blossoms, while sparrows hop along the mossy path.\n\nBy afternoon, the earth smells of rain and new leaves, and the garden feels ready to begin again.",
+        "expected": "2 rules",
+        "latency_ms": 22851.591,
+        "output_tokens": 225,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0061",
+        "correct": true,
+        "predicted": "The bus schedule promised arrival at noon, but the shelter clock ticked past it without a sign of headlights.\n\nA woman checked her phone again, her thumb hovering over the transit app as if refreshing might summon the vehicle.\n\nRain began to bead on the bench, darkening the wood and making the wait feel heavier.\n\nFinally, a distant rumble turned into the familiar hiss of air brakes, and the crowd exhaled together.",
+        "expected": "2 rules",
+        "latency_ms": 32853.248,
+        "output_tokens": 310,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0062",
+        "correct": true,
+        "predicted": "The old radio sat on the shelf, its wooden case worn smooth by decades of hands.\n\nWhen I turned the dial, a warm hum rose from its tubes and filled the quiet room.\n\nStatic crackled for a moment before a clear voice drifted through the speaker.\n\nIt still worked, carrying the past into the present with a gentle, steady sound.",
+        "expected": "2 rules",
+        "latency_ms": 28215.724,
+        "output_tokens": 260,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0063",
+        "correct": true,
+        "predicted": "The last hour of the night shift moved slowly, like a clock holding its breath.\n\nFluorescent lights hummed over tired faces while coffee cooled in forgotten mugs.\n\nBy the time the alarm sounded, relief felt both sudden and earned.",
+        "expected": "2 rules",
+        "latency_ms": 30046.783,
+        "output_tokens": 229,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0064",
+        "correct": true,
+        "predicted": "The market lay quiet under canvas awnings, waiting for the first footsteps to disturb the stacked crates and folded tables.\n\nA faint chill moved between the empty stalls, carrying the scent of damp wood, ripe fruit, and yesterday's spices.\n\nVendors arrived in small groups, unlocking shutters and arranging produce with careful hands while the streetlamps still glowed.\n\nBefore the gates opened, the whole place seemed to hold its breath, bright with promise and untouched by the day's crowds.",
+        "expected": "2 rules",
+        "latency_ms": 38570.986,
+        "output_tokens": 347,
+        "category": "structure",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0065",
+        "correct": true,
+        "predicted": "Clean as you go.\nWipe counters after use.\nLabel your leftovers clearly.\nTake turns cleaning fridge.",
+        "expected": "3 rules",
+        "latency_ms": 26835.625,
+        "output_tokens": 198,
+        "category": "structure",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0066",
+        "correct": true,
+        "predicted": "Adults can learn swimming.\nStart in shallow water.\nBreathe slowly, trust water.\nPractice floating first.\nTake lessons, be patient.\nCelebrate small progress.",
+        "expected": "3 rules",
+        "latency_ms": 44919.354,
+        "output_tokens": 395,
+        "category": "structure",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0067",
+        "correct": true,
+        "predicted": "Night shelves glow\nBooks wait quietly\nStreetlamp lights doors\nLate readers enter\nWhispers fill aisles\nMoon checks out",
+        "expected": "3 rules",
+        "latency_ms": 23666.652,
+        "output_tokens": 179,
+        "category": "structure",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0068",
+        "correct": true,
+        "predicted": "Sawdust hangs in air.\nOil gleams on steel.\nHot metal breathes.\nCoffee stains old plans.\nRubber warms under lights.\nDust settles on tools.",
+        "expected": "3 rules",
+        "latency_ms": 26358.077,
+        "output_tokens": 226,
+        "category": "structure",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0069",
+        "correct": true,
+        "predicted": "Pack snacks\nBring water\nPack clothes",
+        "expected": "3 rules",
+        "latency_ms": 29258.942,
+        "output_tokens": 119,
+        "category": "structure",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0070",
+        "correct": true,
+        "predicted": "In short: Writing a plan down before starting helps clarify your goals, organize your steps, and reduce uncertainty, making it easier to stay focused and follow through.",
+        "expected": "2 rules",
+        "latency_ms": 19608.884,
+        "output_tokens": 90,
+        "category": "framing",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0071",
+        "correct": true,
+        "predicted": "Here is the summary: explaining something to someone else makes it easier to remember because it forces you to actively process the information. You have to organize your thoughts, choose clear words, connect ideas, and notice gaps in your understanding. This deeper processing creates stronger memory traces than simply reading or hearing the material. It also works like retrieval practice: pulling the information out of memory strengthens it, and the social context can make the experience more e",
+        "expected": "2 rules",
+        "latency_ms": 19517.439,
+        "output_tokens": 178,
+        "category": "framing",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0072",
+        "correct": true,
+        "predicted": "Final note: Check the power source first—make sure the charger is plugged in securely, the outlet works, and the battery is connected or charged.",
+        "expected": "2 rules",
+        "latency_ms": 13328.964,
+        "output_tokens": 109,
+        "category": "framing",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0073",
+        "correct": true,
+        "predicted": "To begin with: people often underestimate how long a task will take because they focus on the best-case scenario and ignore likely interruptions, delays, and complications. They may also rely on optimistic memories of past tasks, overlook hidden steps, or confuse how long the work feels with how long it actually requires. In addition, planning fallacy plays a role: when estimating, people tend to think about the task in abstract terms rather than accounting for the concrete conditions under whic",
+        "expected": "2 rules",
+        "latency_ms": 18126.21,
+        "output_tokens": 162,
+        "category": "framing",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0074",
+        "correct": true,
+        "predicted": "Short answer: A good set of instructions is easy to follow when it is clear, concise, and organized in a logical order. It uses simple language, defines any necessary terms, breaks tasks into manageable steps, and anticipates common mistakes or questions. Visual cues, consistent formatting, and examples can also help the reader understand what to do and how to know they have done it correctly.",
+        "expected": "2 rules",
+        "latency_ms": 19119.21,
+        "output_tokens": 135,
+        "category": "framing",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0075",
+        "correct": true,
+        "predicted": "One thing first: reading the last page of a manual can give you the destination before you start the journey. It often contains the summary, troubleshooting tips, safety warnings, final steps, or expected results, so you know what success looks like and what mistakes to avoid. This helps you read the rest of the manual with context, focus on the important parts, and understand why each step matters.",
+        "expected": "2 rules",
+        "latency_ms": 21194.02,
+        "output_tokens": 172,
+        "category": "framing",
+        "difficulty": "easy"
+      },
+      {
+        "id": "inst-0076",
+        "correct": true,
+        "predicted": "Learning to swim as an adult means trusting water slowly. You practice breathing, floating, and gentle kicks, replacing fear with patience. Each small victory builds confidence, turning awkward movements into calm rhythm. Thank you for reading.",
+        "expected": "2 rules",
+        "latency_ms": 35615.764,
+        "output_tokens": 457,
+        "category": "framing",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0077",
+        "correct": true,
+        "predicted": "The library opens late, glowing like a lantern after midnight. Quiet shelves welcome night owls, students, and dreamers, offering warm light, soft chairs, and stories that wait until the city finally sleeps. End of answer.",
+        "expected": "2 rules",
+        "latency_ms": 33316.365,
+        "output_tokens": 348,
+        "category": "framing",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0078",
+        "correct": true,
+        "predicted": "Sawdust and warm metal hang in the air, mixed with oil, rubber, and faint varnish. A sharp tang of solder lingers beneath the dusty sweetness of old wood, while coffee and sweat add a human warmth. That is all.",
+        "expected": "2 rules",
+        "latency_ms": 45718.736,
+        "output_tokens": 320,
+        "category": "framing",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0079",
+        "correct": true,
+        "predicted": "Pack light: clothes, toiletries, snacks, water, charger, book, and a small blanket. Keep tickets, ID, and valuables accessible. Dress in layers, choose comfortable shoes, and carry a reusable bag. Stay hydrated, rest often, and enjoy the scenery. Nothing further.",
+        "expected": "2 rules",
+        "latency_ms": 45139.087,
+        "output_tokens": 414,
+        "category": "framing",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0080",
+        "correct": true,
+        "predicted": "In short: people focus on best case plans and ignore interruptions and hidden steps and past delays so they imagine a smooth path and finish sooner than reality proves done",
+        "expected": "4 rules",
+        "latency_ms": 36253.007,
+        "output_tokens": 278,
+        "category": "framing",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0081",
+        "correct": true,
+        "predicted": "Here is the summary: clear steps and simple words and logical order and helpful examples and warnings about common mistakes make instructions easy to follow done",
+        "expected": "4 rules",
+        "latency_ms": 39897.479,
+        "output_tokens": 275,
+        "category": "framing",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0082",
+        "correct": true,
+        "predicted": "Final note: reading the last page first reveals the expected result and gives a clear target so every step feels purposeful and you can judge progress while learning the system until the task is done",
+        "expected": "4 rules",
+        "latency_ms": 37514.397,
+        "output_tokens": 325,
+        "category": "framing",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0083",
+        "correct": true,
+        "predicted": "{\"city\":\"Paris\",\"country\":\"France\"}",
+        "expected": "3 rules",
+        "latency_ms": 21794.765,
+        "output_tokens": 75,
+        "category": "json",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0084",
+        "correct": true,
+        "predicted": "[1,2,3]",
+        "expected": "2 rules",
+        "latency_ms": 16389.314,
+        "output_tokens": 57,
+        "category": "json",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0085",
+        "correct": true,
+        "predicted": "{\"ok\": true, \"count\": 7}",
+        "expected": "3 rules",
+        "latency_ms": 13962.908,
+        "output_tokens": 69,
+        "category": "json",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0086",
+        "correct": false,
+        "predicted": "{\n  \"steps\": [\n    \"Boil water.\",\n    \"Pour hot water over a tea bag or leaves.\",\n    \"Steep, then remove the tea and serve.\"\n  ]\n}",
+        "expected": "3 rules",
+        "latency_ms": 16873.258,
+        "output_tokens": 134,
+        "category": "json",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0087",
+        "correct": true,
+        "predicted": "MAXIMUM_SIZE=4096",
+        "expected": "1 rules",
+        "latency_ms": 12167.998,
+        "output_tokens": 117,
+        "category": "format",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0088",
+        "correct": true,
+        "predicted": "2026-08-23",
+        "expected": "1 rules",
+        "latency_ms": 14455.953,
+        "output_tokens": 85,
+        "category": "format",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0089",
+        "correct": true,
+        "predicted": "alpha,beta,gamma",
+        "expected": "1 rules",
+        "latency_ms": 12005.132,
+        "output_tokens": 59,
+        "category": "format",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0090",
+        "correct": true,
+        "predicted": "RESULT: 12",
+        "expected": "1 rules",
+        "latency_ms": 9064.579,
+        "output_tokens": 53,
+        "category": "format",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0091",
+        "correct": true,
+        "predicted": "Der Bahnhof ist ein belebter Ort, an dem Züge ankommen und abfahren. Reisende warten auf den Bahnsteigen, während die Gleise in verschiedene Richtungen führen.",
+        "expected": "3 rules",
+        "latency_ms": 13826.263,
+        "output_tokens": 140,
+        "category": "language",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0092",
+        "correct": true,
+        "predicted": "La gare est animée par les voyageurs qui attendent leur train. Les quais s'étendent sous une grande verrière lumineuse.",
+        "expected": "3 rules",
+        "latency_ms": 12460.658,
+        "output_tokens": 122,
+        "category": "language",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0093",
+        "correct": true,
+        "predicted": "La estacion tiene andenes largos y un reloj antiguo. Los trenes llegan y salen entre anuncios y pasos de viajeros.",
+        "expected": "3 rules",
+        "latency_ms": 24868.667,
+        "output_tokens": 247,
+        "category": "language",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0094",
+        "correct": true,
+        "predicted": "La stazione è un luogo affollato di viaggiatori. I treni partono e arrivano ogni giorno.",
+        "expected": "3 rules",
+        "latency_ms": 14501.191,
+        "output_tokens": 97,
+        "category": "language",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0095",
+        "correct": true,
+        "predicted": "A estacao é grande e movimentada. Os trens chegam e partem todos os dias.",
+        "expected": "3 rules",
+        "latency_ms": 31711.336,
+        "output_tokens": 376,
+        "category": "language",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0096",
+        "correct": true,
+        "predicted": "The workshop smelled of oil, sawdust, and warm metal, while an atlas lay open on the bench. The atlas pages curled near the heater, atlas maps absorbed the scent of varnish, and every atlas corner gathered dust. The atlas after atlas left a dry, papery sweetness beneath the grease.",
+        "expected": "2 rules",
+        "latency_ms": 79570.922,
+        "output_tokens": 1250,
+        "category": "inclusion",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0097",
+        "correct": true,
+        "predicted": "Packing for a long train journey means bringing a signal of comfort: a signal from home, like a favorite scarf, and a signal of readiness, such as a charged phone. A signal from the conductor may guide you, while a signal from your own body reminds you to rest, hydrate, and enjoy the passing scenery.",
+        "expected": "2 rules",
+        "latency_ms": 46895.882,
+        "output_tokens": 427,
+        "category": "inclusion",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0098",
+        "correct": true,
+        "predicted": "Lists beat memory because they harbour details, harbour priorities, harbour reminders, and harbour peace. When you write tasks down, your mind can stop storing fragile notes and start creating ideas. A simple list keeps intentions safe, so nothing important sinks beneath distraction.",
+        "expected": "2 rules",
+        "latency_ms": 81847.678,
+        "output_tokens": 745,
+        "category": "inclusion",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0099",
+        "correct": true,
+        "predicted": "In the early spring garden, I keep a ledger of crocus shoots, a ledger of thawing soil, and a ledger of returning bees. Each morning I add a line beside the daffodils, while the ledger of raindrops on the bench records the season’s quiet, patient arithmetic.",
+        "expected": "2 rules",
+        "latency_ms": 72795.579,
+        "output_tokens": 371,
+        "category": "inclusion",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0100",
+        "correct": true,
+        "predicted": "I waited on the platform, checking the platform sign, while the delayed bus remained invisible. The platform bench was cold, and the platform announcement only repeated the same apology. Passengers paced the platform, hoping the next arrival would finally appear.",
+        "expected": "2 rules",
+        "latency_ms": 66357.205,
+        "output_tokens": 409,
+        "category": "inclusion",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0101",
+        "correct": true,
+        "predicted": "green",
+        "expected": "2 rules",
+        "latency_ms": 26017.67,
+        "output_tokens": 58,
+        "category": "format",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0102",
+        "correct": true,
+        "predicted": "I CAN DO THIS NOW",
+        "expected": "3 rules",
+        "latency_ms": 15881.494,
+        "output_tokens": 87,
+        "category": "format",
+        "difficulty": "hard"
+      },
+      {
+        "id": "inst-0103",
+        "correct": true,
+        "predicted": "A list to ensure key steps aren't missed.",
+        "expected": "1 rules",
+        "latency_ms": 33239.69,
+        "output_tokens": 441,
+        "category": "length",
+        "difficulty": "medium"
+      },
+      {
+        "id": "inst-0104",
+        "correct": true,
+        "predicted": "The quick brown fox ran past the old stone wall at dusk.",
+        "expected": "3 rules",
+        "latency_ms": 25056.039,
+        "output_tokens": 202,
+        "category": "length",
+        "difficulty": "hard"
+      }
+    ]
+  },
+  "failures": [],
+  "gotchas": [
+    {
+      "severity": "info",
+      "text": "--parallel is 2 here, not the 1 the recipe forces. The recipe documents that concurrency does not abort the server but does not batch either at one slot, and it never tries a second slot. Two slots were verified on this build before this run: the server reports n_slots 2 and two concurrent requests both returned 200 with coherent output on the same pid. Upstream does keep a GGML_ASSERT in qwen4exp.cpp that rejects a token belonging to more than one sequence - PLE n-gram embeddings do not support tokens shared by multiple sequences - but that is a constraint on sequence sharing, not on slot count, so independent slots are unaffected. Do not compare a concurrency cell here against one from a parallel=1 configuration without saying which is which."
+    },
+    {
+      "severity": "info",
+      "text": "--mmproj mmproj-F16.gguf is loaded, which the shipped recipe cannot do - it has no mmproj support. This matters for what the numbers mean as well as for what the model can do: the projector is ~0.9 GB of additional resident weights, and any vision workload here is exercising a code path that is simply absent from a text-only run of the same quantization. A cell from this configuration is not comparable to one without the projector."
+    },
+    {
+      "severity": "info",
+      "text": "--spec-type ngram-mod is ON. It drafts spans from repetition already in the context, so throughput varies by up to 3x with how much of the output already appears in the prompt. Speculation is exact - the target verifies every token - so output is byte-identical to running without it. Never compare a decode figure here against a cell run with a different --spec-type."
+    },
+    {
+      "severity": "info",
+      "text": "A quarter of this checkpoint is served from NVMe, so page-cache state is a hidden independent variable. Residency of the 26.82 GiB n-gram table was measured with mincore(2) immediately before this workload: 74.28%. Measured separately on this box: a real startup lands at 0.06 percent, the recipe warmer reaches only 25.9 percent from cold, and a 50-request workload takes the table from 0.06 to 54.75 percent by itself - so a long workload is warm for most of its own duration whatever it started at."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "2ba9dc4cf9a5703cb356848df5d52d6fe14fa477774dbde2e6e9043abf288a95",
+    "payload_path": null,
+    "payload": {
+      "scorer": "instruction",
+      "scorers_used": [
+        "instruction"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:30000/v1",
+        "served_model_id": "qwen3.8-flash-next",
+        "advertised_models": [
+          "qwen3.8-flash-next"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-30T11:11:58Z",
+    "finished_at": "2026-08-30T11:24:28Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Box WAS dedicated: this DGX Spark runs no desktop session, and no compile or dev server ran on it during the sweep. Isolation check: the only route to it from outside the box is an SSH tunnel opened by a reverse proxy on the same private network, and that tunnel was stopped before the first run and stayed stopped throughout. NVIDIA DGX Spark (ASUS Ascent GX10, GB10 / SM121, 128 GB unified memory, ~121 GiB usable), Ubuntu 24.04.4, kernel 6.17.0-1029-nvidia aarch64, driver 580.173.02, CUDA 13.0, swap off. Engine is llama.cpp at commit 035e227 from what was then the unmerged PR #27742; that PR has since MERGED to master (2026-08-28), and its can_reuse work is upstream, so a build from master no longer needs the canreuse-qwen4exp patch this build carries. Model is unsloth/Qwen3.8-Flash-Next-GGUF UD-Q4_K_XL, four shards, 111,323,630,080 bytes. TWO DEPARTURES FROM THE SHIPPED RECIPE, both verified before this run rather than assumed. First, --parallel 2 instead of 1: the recipe forces one slot and documents that concurrent requests queue there rather than batch, so a second slot is untried territory for it. On this build two slots work - the server reports n_slots 2 and two concurrent requests both returned 200 with coherent output and no abort. Second, --mmproj mmproj-F16.gguf: the GGUF shards carry no vision tensors because llama.cpp ships multimodal as a separate projector, and unsloth publishes one alongside. With it loaded the server correctly described a synthetic image it could not have inferred from the prompt. The recipe has no mmproj support at all, so this configuration is not one the recipe can currently produce."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-instruction-v1--16b560.json
+++ b/results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-instruction-v1--16b560.json
@@ -41,7 +41,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -61,7 +61,7 @@
     "override-tensor": "per_layer_token_embd=CPU",
     "load-mode": "mmap",
     "spec-type": "ngram-mod",
-    "temp": 1.0,
+    "temp": 1,
     "top-p": 0.95,
     "top-k": 20,
     "mmproj": "mmproj-F16.gguf"
@@ -77,7 +77,7 @@
       "items": 104,
       "concurrency": 4,
       "max_output_tokens": 2048,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -90,7 +90,7 @@
     "requests_total": 104,
     "requests_ok": 104,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 749.781,
     "input_tokens_total": 8450,
     "output_tokens_total": 24990,
@@ -109,7 +109,7 @@
     "power_peak_w": 56.37,
     "energy_wh": 8.0643,
     "gpu_util_avg_pct": 84.33,
-    "temp_max_c": 70.0,
+    "temp_max_c": 70,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -117,7 +117,7 @@
     "total": 104,
     "correct": 103,
     "accuracy": 0.990385,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "casing": {
         "total": 11,
@@ -1265,7 +1265,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-30T11:11:58Z",
     "finished_at": "2026-08-30T11:24:28Z",
     "submitted_at": null,


### PR DESCRIPTION
### Cells filled

- **Engine** — `llamacpp` `b50-035e227`
- **Model / quant** — `Qwen/Qwen3.8-Flash-Next` / `gguf-ud-q4-k-xl`
- **Hardware** — `nvidia-gb10-dgx-spark` x1
- **Workload** — `eval-instruction-v1` (eval)
- **Headline** — accuracy **0.990**, success 1.000

One file: `results/llamacpp/Qwen/Qwen3.8-Flash-Next/nvidia-gb10-dgx-spark/0cad79844e7b427c--eval-instruction-v1--16b560.json`

### What failed

Nothing failed. 104/104 requests returned, success rate 1.000.

### Gotchas

- **info** — --parallel is 2 here, not the 1 the recipe forces.
- **info** — --mmproj mmproj-F16.gguf is loaded, which the shipped recipe cannot do - it has no mmproj support.
- **info** — --spec-type ngram-mod is ON.
- **info** — A quarter of this checkpoint is served from NVMe, so page-cache state is a hidden independent variable.

### Conditions

Dedicated box, nothing else resident on the GPU, no compile running. The one route into this machine from elsewhere on its private network is an SSH tunnel from a reverse proxy; it was stopped before the first run and stayed stopped. The harness talks to loopback with no proxy in the measured path.

n-gram table page-cache residency, `mincore(2)`: **74.28% before the workload, 76.98% after**.

| | |
|---|---:|
| peak host RAM | 100.9 GB |
| average GPU utilisation | 84.3 % |
| average / peak power | 38.7 / 56.4 W |
| max temperature | 70 C |
| thermal throttling | not detected |
| wall clock | 749.8 s |

`pnpm validate` — 0 errors. Read `gpu_util_avg_pct` with the caveat in the gotchas: it is a mean over the whole workload window including ramp-up and drain, not a steady-state figure.
