### PR TITLE
fix(coverage): fork builds are not stale, and multi-device cells belong on the grid

### DIFF
--- a/app/src/data/derive.test.ts
+++ b/app/src/data/derive.test.ts
@@ -1,10 +1,12 @@
 import { cellId, computeCoverage } from '@atlas/core';
 import { describe, expect, it } from 'vitest';
 import {
+  atlasCells,
   buildHeatMatrix,
   buildLookups,
   hardwarePlatforms,
   heatKey,
+  measuredCells,
   possibleCells,
 } from './derive.js';
 import { fixtureRegistry, fixtureRow } from './fixture.js';
@@ -69,6 +71,108 @@ describe('possibleCells', () => {
         memory_gb: 1,
       }),
     ).toEqual(['linux-cpu', 'windows-cpu']);
+  });
+});
+
+describe('measuredCells', () => {
+  const reg = fixtureRegistry();
+  const enumerated = possibleCells(reg);
+  const tpCellId = cellId({
+    model_id: 'Qwen/Qwen3-8B',
+    quant_id: 'fp8',
+    hardware_id: 'nvidia-rtx-4090',
+    hw_count: 2,
+    engine_id: 'vllm',
+    engine_minor: '0.27',
+  });
+  const tpIndex = normalizeIndex([
+    fixtureRow({
+      cell_id: tpCellId,
+      run_id: 'cfg0000000000002--serve-single-i256-o256-v1--abc125',
+      config_id: 'cfg0000000000002',
+      hardware: { id: 'nvidia-rtx-4090', count: 2 },
+      metrics: { output_tok_s: 200 },
+    }),
+  ]);
+  const tpCoverage = computeCoverage(
+    tpIndex,
+    { engineVersions: { vllm: ['0.26.1', '0.27.1'], 'mlx-lm': ['0.28.4'] } },
+    { site: reg.site },
+  );
+
+  it('adds a measured multi-device cell the cross product cannot enumerate', () => {
+    expect(enumerated.some((pc) => pc.cell_id === tpCellId)).toBe(false);
+    const extra = measuredCells(reg, tpCoverage, enumerated);
+    expect(extra).toHaveLength(1);
+    expect(extra[0]!.cell_id).toBe(tpCellId);
+    expect(extra[0]!.hw_count).toBe(2);
+    // pinned to the newest registered version of the cell's own minor, for the packet
+    expect(extra[0]!.engine_version).toBe('0.27.1');
+  });
+
+  it('adds nothing for a cell the cross product already has', () => {
+    const single = enumerated.find(
+      (c) => c.engine_id === 'vllm' && c.quant_id === 'fp8' && c.engine_minor === '0.27',
+    )!;
+    const cov = computeCoverage(
+      normalizeIndex([fixtureRow({ cell_id: single.cell_id })]),
+      { engineVersions: { vllm: ['0.26.1', '0.27.1'] } },
+      { site: reg.site },
+    );
+    expect(measuredCells(reg, cov, enumerated)).toHaveLength(0);
+  });
+
+  it('skips a cell naming hardware the registry does not have', () => {
+    const cov = {
+      deadbeef0000: {
+        cell_id: 'deadbeef0000',
+        model_id: 'Qwen/Qwen3-8B',
+        quant_id: 'fp8',
+        hardware_id: 'nvidia-rtx-9090',
+        hw_count: 2,
+        engine_id: 'vllm',
+        engine_minor: '0.27',
+        runs: 1,
+        logins: ['someone'],
+        workloads: [],
+        configs: [],
+        level: 'single' as const,
+        best: null,
+      },
+    };
+    expect(measuredCells(reg, cov, enumerated)).toHaveLength(0);
+  });
+
+  it('counts the multi-device square on the grid instead of dropping it', () => {
+    const before = buildHeatMatrix(
+      reg,
+      buildLookups(reg),
+      enumerated,
+      tpCoverage,
+      tpIndex,
+      'model',
+      'hardware',
+      {},
+      reg.site.coverage.key_metrics,
+    );
+    expect(before.cells.get(heatKey('Qwen/Qwen3-8B', 'nvidia-rtx-4090'))!.runs).toBe(0);
+
+    const after = buildHeatMatrix(
+      reg,
+      buildLookups(reg),
+      atlasCells(reg, tpCoverage),
+      tpCoverage,
+      tpIndex,
+      'model',
+      'hardware',
+      {},
+      reg.site.coverage.key_metrics,
+    );
+    const hc = after.cells.get(heatKey('Qwen/Qwen3-8B', 'nvidia-rtx-4090'))!;
+    expect(hc.runs).toBe(1);
+    expect(hc.covered).toBe(1);
+    expect(hc.possible).toBe(5);
+    expect(hc.cells.map((c) => c.cell_id)).toEqual([tpCellId]);
   });
 });
 

--- a/app/src/data/derive.ts
+++ b/app/src/data/derive.ts
@@ -88,6 +88,9 @@ export function engineMinors(engine: RegistryEngine): Array<{ minor: string; ver
 /**
  * Every cell that could exist given the registry: model x quant x hardware x engine-minor where
  * the quant lists the engine and the engine has a platform the device can run.
+ *
+ * `hw_count` is fixed at 1 — see `measuredCells` for the multi-device cells this cannot reach.
+ * Use `atlasCells` for the union, which is what the grid and the coverage ratio are built on.
  */
 export function possibleCells(reg: Registry): PossibleCell[] {
   const out: PossibleCell[] = [];
@@ -123,6 +126,61 @@ export function possibleCells(reg: Registry): PossibleCell[] {
     }
   }
   return out;
+}
+
+/**
+ * Cells somebody has measured that `possibleCells` does not enumerate.
+ *
+ * The cross product fixes `hw_count` at 1 because there is no bound on how many devices a
+ * contributor may gang together: enumerating 2, 4 and 8 of every device would be inventing a
+ * denominator nobody asked for. A configuration somebody has actually run, though,
+ * demonstrably exists — leaving it out does not make the map more honest, it hides evidence.
+ * A tensor-parallel run used to count in `coverage.json` and in `stats.cells_covered` and
+ * appear nowhere on the grid: the square's run count, its evidence level, its best number and
+ * the drawer's "Measured" list all silently excluded it.
+ *
+ * Only cells whose model, hardware and engine are all in the registry are returned, because a
+ * cell that names something the registry does not have cannot be placed on an axis or
+ * filtered by vendor.
+ */
+export function measuredCells(
+  reg: Registry,
+  coverage: CoverageMap,
+  enumerated: PossibleCell[],
+): PossibleCell[] {
+  const seen = new Set(enumerated.map((pc) => pc.cell_id));
+  const models = new Set(reg.models.map((m) => m.model.id));
+  const hardware = new Set(reg.hardware.map((h) => h.id));
+  const versionForMinor = new Map<string, string>();
+  for (const e of reg.engines)
+    for (const { minor, version } of engineMinors(e))
+      versionForMinor.set(`${e.meta.id} ${minor}`, version);
+
+  const out: PossibleCell[] = [];
+  for (const cell of Object.values(coverage)) {
+    if (!cell?.cell_id || seen.has(cell.cell_id)) continue;
+    if (!models.has(cell.model_id) || !hardware.has(cell.hardware_id)) continue;
+    const key = `${cell.engine_id} ${cell.engine_minor}`;
+    if (!versionForMinor.has(key)) continue;
+    seen.add(cell.cell_id);
+    out.push({
+      cell_id: cell.cell_id,
+      model_id: cell.model_id,
+      quant_id: cell.quant_id,
+      hardware_id: cell.hardware_id,
+      hw_count: cell.hw_count,
+      engine_id: cell.engine_id,
+      engine_version: versionForMinor.get(key)!,
+      engine_minor: cell.engine_minor,
+    });
+  }
+  return out;
+}
+
+/** The cross product plus the measured cells it does not reach — the app's whole universe. */
+export function atlasCells(reg: Registry, coverage: CoverageMap): PossibleCell[] {
+  const enumerated = possibleCells(reg);
+  return [...enumerated, ...measuredCells(reg, coverage, enumerated)];
 }
 
 /* --------------------------------------------------------------- heatmap aggregation */

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -6,7 +6,7 @@
 import { computeCoverage } from '@atlas/core';
 import type { EngineVersion, Gap, ResultRecord, SiteConfig } from '@atlas/core';
 import siteFallbackJson from '../../site/config.json';
-import { buildLookups, possibleCells, type Lookups, type PossibleCell } from './data/derive.js';
+import { atlasCells, buildLookups, type Lookups, type PossibleCell } from './data/derive.js';
 import {
   normalizeContributors,
   normalizeCoverage,
@@ -56,7 +56,8 @@ class Store {
   readonly contributors = signal<ContributorRow[] | null>(null);
 
   private lookupsCache: { reg: Registry; lookups: Lookups } | null = null;
-  private possibleCache: { reg: Registry; cells: PossibleCell[] } | null = null;
+  private possibleCache: { reg: Registry; coverage: CoverageMap; cells: PossibleCell[] } | null =
+    null;
   private engineVersionCache = new Map<string, Promise<EngineVersion | null>>();
   private runCache = new Map<string, Promise<ResultRecord | null>>();
   private gapsPromise: Promise<Gap[]> | null = null;
@@ -86,8 +87,13 @@ class Store {
   get possible(): PossibleCell[] {
     const reg = this.registry.value;
     if (!reg) return [];
-    if (!this.possibleCache || this.possibleCache.reg !== reg)
-      this.possibleCache = { reg, cells: possibleCells(reg) };
+    const coverage = this.coverage.value;
+    if (
+      !this.possibleCache ||
+      this.possibleCache.reg !== reg ||
+      this.possibleCache.coverage !== coverage
+    )
+      this.possibleCache = { reg, coverage, cells: atlasCells(reg, coverage) };
     return this.possibleCache.cells;
   }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -629,3 +629,32 @@ or where reality disagreed with it. Each one is binding until superseded here.
 
 21. **No seed results; measurements run on contributors' machines only.** The 8 hand-entered seed
     files were removed; `docs/reference-measurements.md` keeps the numbers as reference.
+
+22. **Staleness is only claimed on the release lineage (2026-08-30).** `minorsBehind` counts
+    only registered versions that can be placed on the engine's published release lineage —
+    a dotted numeric release (`0.27.1`) or a monotonic build number (`b7000`), the two shapes
+    `compareMinor` can actually order. Development and pre-release builds
+    (`0.1.dev20073+g8e685d198`, `0.0.0.dev0+qwen38.27b.g561c8f3`) and opaque build
+    identifiers (`960652b`, `b50-035e227`) are off the lineage: a cell measured on one is
+    never `stale`, and one of them in `versions_available` never makes anybody else's cell
+    stale. setuptools-scm reports `0.1.devN+g<sha>` for a checkout with no reachable tag,
+    which is what building an unmerged branch produces, so the leading `0.1` is a placeholder
+    and ordering it against 0.27 says nothing about age. Such a build is registered as its
+    own engine version precisely because its flags and its behaviour are those of no
+    published release (decision 7, and `engines/vllm/versions/0.1.dev20073+g8e685d198.json`);
+    calling it two minors old contradicts the reason it exists. This is a rule about version
+    strings, not about which engine version can load which model — the registry records no
+    per-version model support, so "is there a newer engine that can even run this" is not a
+    question the data can answer today.
+
+23. **The coverage denominator is the cross product plus what has been measured
+    (2026-08-30).** The registry cross product fixes `hw_count` at 1, because there is no
+    bound on how many devices a contributor may gang together and enumerating 2, 4 and 8 of
+    every device would invent a denominator. A cell somebody has run on several devices is
+    possible all the same, so `stats.cells_possible` and the app's atlas grid are the cross
+    product **union** the measured cells (`possibleCells(repo, cells)`,
+    `atlasCells(reg, coverage)`). Before this, a tensor-parallel run counted in
+    `coverage.json` and in `cells_covered` but appeared nowhere on the grid: the square's run
+    count, its evidence level, its best number and the cell drawer's "Measured" list all
+    silently excluded it, and the coverage ratio had a numerator its denominator did not
+    contain.

--- a/packages/core/src/coverage.test.ts
+++ b/packages/core/src/coverage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeCoverage, emptyCell, minorsBehind } from './coverage.js';
+import { computeCoverage, emptyCell, isReleaseVersion, minorsBehind } from './coverage.js';
 import { cellId } from './ids.js';
 import type { CompiledIndexRow, CoverageRegistry } from './index.js';
 
@@ -47,6 +47,40 @@ describe('minorsBehind', () => {
   });
   it('orders build numbers numerically, not lexicographically', () => {
     expect(minorsBehind('b9000', ['b7000', 'b9000', 'b10000'])).toBe(1);
+  });
+  it('accepts a full version as well as a bare minor', () => {
+    expect(minorsBehind('0.26.1', ['0.24.0', '0.25.1', '0.26.1', '0.27.1'])).toBe(1);
+  });
+  it('never calls a development build behind a release', () => {
+    // vLLM's Qwen3.8-Flash-Next branch build: setuptools-scm with no reachable tag reports
+    // 0.1.devN+g<sha>, so the leading 0.1 is a placeholder, not release 0.1.
+    expect(minorsBehind('0.1.dev20073+g8e685d198', ['0.1.dev20073+g8e685d198', '0.27.1'])).toBe(0);
+    expect(minorsBehind('0.0.0.dev0+qwen38.27b.g561c8f3', ['0.5.4'])).toBe(0);
+  });
+  it('never calls an opaque build identifier behind another one', () => {
+    expect(minorsBehind('b50-035e227', ['b50-035e227', 'b7000'])).toBe(0);
+    expect(minorsBehind('960652b', ['960652b'])).toBe(0);
+  });
+  it('does not let a development build make a release look behind', () => {
+    expect(minorsBehind('0.27', ['0.27.1', '0.28.0rc1', '99.0.dev1+gdeadbee'])).toBe(0);
+  });
+});
+
+describe('isReleaseVersion', () => {
+  it('accepts dotted releases and monotonic build numbers', () => {
+    for (const v of ['0.27.1', 'v1.2.3', '2026.08.1', '0.0.14', 'b7000', '7000'])
+      expect(isReleaseVersion(v), v).toBe(true);
+  });
+  it('rejects development, pre-release and opaque builds', () => {
+    for (const v of [
+      '0.1.dev20073+g8e685d198',
+      '0.0.0.dev0+qwen38.27b.g561c8f3',
+      '0.28.0rc1',
+      '1.0.0-beta.2',
+      'b50-035e227',
+      '960652b',
+    ])
+      expect(isReleaseVersion(v), v).toBe(false);
   });
 });
 
@@ -103,6 +137,29 @@ describe('coverage levels', () => {
     const cell = Object.values(cells)[0]!;
     expect(cell.level).toBe('stale');
     expect(cell.minors_behind).toBe(2);
+  });
+
+  it('does not call a development build stale', () => {
+    // The only build that runs the model is a fork of the engine, and it reports a
+    // placeholder version. There is no newer release that could supersede it.
+    const engine = { id: 'vllm', version: '0.1.dev20073+g8e685d198', minor: '0.1' };
+    const forkRegistry: CoverageRegistry = {
+      engineVersions: { vllm: ['0.1.dev20073+g8e685d198', '0.26.1', '0.27.1'] },
+    };
+    const cells = computeCoverage([row({ login: 'alice', engine })], forkRegistry);
+    const cell = Object.values(cells)[0]!;
+    expect(cell.level).toBe('single');
+    expect(cell.minors_behind).toBeUndefined();
+  });
+
+  it('still calls a real release stale when the engine has moved on', () => {
+    const engine = { id: 'vllm', version: '0.25.1', minor: '0.25' };
+    const forkRegistry: CoverageRegistry = {
+      engineVersions: { vllm: ['0.1.dev20073+g8e685d198', '0.25.1', '0.26.1', '0.27.1'] },
+    };
+    const cells = computeCoverage([row({ login: 'alice', engine })], forkRegistry);
+    expect(Object.values(cells)[0]?.level).toBe('stale');
+    expect(Object.values(cells)[0]?.minors_behind).toBe(2);
   });
 
   it('lets a dispute outrank staleness', () => {

--- a/packages/core/src/coverage.ts
+++ b/packages/core/src/coverage.ts
@@ -16,6 +16,10 @@ import type { CompiledIndexRow, CoverageCell, CoverageLevel, SiteConfig } from '
  * Precedence when several apply: disputed > stale > reproduced > single. Disputed wins
  * because a wrong number is worse than an old one; stale beats reproduced because a cell
  * that was reproduced on vLLM 0.19 tells you nothing about 0.27.
+ *
+ * `stale` is only claimed between two versions the registry can actually order — see
+ * `isReleaseVersion`. A development or fork build is never behind anything, because the
+ * release numbers it would be compared against do not describe the same software.
  */
 
 const DEFAULTS = {
@@ -69,14 +73,52 @@ function median(values: number[]): number {
   return (sorted[mid - 1]! + sorted[mid]!) / 2;
 }
 
+/** A dotted numeric version (`0.27.1`, `1.2.0`, `2026.08.1`), optionally `v`-prefixed. */
+const DOTTED_RELEASE = /^v?\d+(?:\.\d+)*$/;
+/** A build number in a monotonic sequence: llama.cpp's `b7000`, or a bare `7000`. */
+const BUILD_NUMBER = /^[a-z]*\d+$/;
+
 /**
- * How many registered minors of this engine are newer than `minor`.
+ * Can this version string be placed on its engine's published release lineage?
  *
- * Non-numeric version schemes (llama.cpp `b7000`) sort lexicographically after being
- * zero-padded, which is good enough because build numbers grow monotonically.
+ * "Behind" is a claim about two points on one lineage, and only two version shapes carry
+ * that information — the two `compareMinor` can order: a dotted numeric release and a
+ * monotonic build number. Everything else is off the lineage and is never compared:
+ *
+ *   - Development and pre-release builds, and anything carrying a local-version segment:
+ *     `0.1.dev20073+g8e685d198`, `0.0.0.dev0+qwen38.27b.g561c8f3`. setuptools-scm emits
+ *     `0.1.devN+g<sha>` for a checkout with no reachable tag, which is what building a fork
+ *     or an unmerged branch produces, so the leading `0.1` is a placeholder — it is not
+ *     vLLM 0.1, and ordering it against 0.27 says nothing about age. These builds are
+ *     registered as their own engine version precisely because their flags and their
+ *     behaviour are those of no published release; treating them as an old release
+ *     contradicts the reason they exist.
+ *   - Opaque build identifiers: a bare commit sha (`960652b`), or a build number carrying
+ *     one (`b50-035e227`). `compareMinor` falls back to string comparison for these, which
+ *     is a guess about ordering, not evidence of age.
+ *
+ * Both directions matter. A cell measured on such a build is never behind, and such a build
+ * in the registry never makes anybody else's cell look behind.
  */
-export function minorsBehind(minor: string, registered: string[]): number {
-  const known = new Set(registered.map(engineMinor));
+export function isReleaseVersion(version: string): boolean {
+  const v = version.trim().toLowerCase();
+  return DOTTED_RELEASE.test(v) || BUILD_NUMBER.test(v);
+}
+
+/**
+ * How many registered release minors of this engine are newer than `version`.
+ *
+ * `version` may be a full version (`0.27.1`) or the minor itself (`0.27`) — a minor is its
+ * own minor. A version that is not on the release lineage is never behind: it returns 0,
+ * and registered versions that are not on the lineage are not counted as newer.
+ *
+ * Build-number schemes (llama.cpp `b7000`) are ordered by their numeric part, which is good
+ * enough because build numbers grow monotonically.
+ */
+export function minorsBehind(version: string, registered: string[]): number {
+  if (!isReleaseVersion(version)) return 0;
+  const minor = engineMinor(version);
+  const known = new Set(registered.filter(isReleaseVersion).map(engineMinor));
   known.add(minor);
   const ordered = [...known].sort(compareMinor);
   const idx = ordered.indexOf(minor);
@@ -194,8 +236,13 @@ function buildCell(
     }
   }
 
+  // A cell is one engine minor, but its rows carry full versions, and only the full version
+  // says whether this is a release or a build off the lineage (`engineMinor` drops the
+  // `.dev20073+g8e685d198` that carries that information). If any row is a real release of
+  // the minor, the cell is on the lineage and ordinary staleness applies.
   const registered = registry.engineVersions[facts.engine_id] ?? [];
-  const behind = minorsBehind(facts.engine_minor, registered);
+  const versions = rows.map((r) => r.engine.version);
+  const behind = minorsBehind(versions.find(isReleaseVersion) ?? versions[0] ?? '', registered);
 
   let level: CoverageLevel;
   if (disputes.length > 0) level = 'disputed';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,7 +40,7 @@ export { resolveConditions, conditionsComparability } from './conditions.js';
 export type { ResolvedConditions, ConditionsSource, Comparability } from './conditions.js';
 export { computeScores } from './scoring.js';
 export type { ScoringInput, ScoringOutput, ScoredRun, RegistryCredits } from './scoring.js';
-export { computeCoverage, emptyCell, minorsBehind } from './coverage.js';
+export { computeCoverage, emptyCell, isReleaseVersion, minorsBehind } from './coverage.js';
 export type { CoverageRegistry, CoverageOptions } from './coverage.js';
 export { buildPacket, renderFlags, renderServeCommand, AGENT_RULES } from './packet.js';
 export type { PacketSpec, PacketRegistry, PacketEngineEntry, PacketModelEntry } from './packet.js';

--- a/tools/src/build.ts
+++ b/tools/src/build.ts
@@ -364,7 +364,7 @@ export function buildData(options: BuildOptions): BuildOutcome {
   const byKind: Record<string, number> = {};
   for (const row of rows) byKind[row.kind] = (byKind[row.kind] ?? 0) + 1;
 
-  const cellsPossible = possibleCells(repo);
+  const cellsPossible = possibleCells(repo, cells);
   const cellsCovered = Object.keys(cells).length;
   const times = rows
     .map((r) => r.provenance.submitted_at ?? r.provenance.started_at)

--- a/tools/src/lib/gaps.ts
+++ b/tools/src/lib/gaps.ts
@@ -306,9 +306,9 @@ export function computeGaps(input: GapsInput): GapsOutput {
   };
 }
 
-/** How many cells the registry says are possible — the denominator of the coverage figure. */
-export function possibleCells(repo: Repo): number {
-  let n = 0;
+/** Every cell the registry enumerates: `hw_count` 1, one per model × quant × hardware × minor. */
+function possibleCellIds(repo: Repo): Set<string> {
+  const ids = new Set<string>();
   for (const modelEntry of repo.models.values()) {
     for (const quant of modelEntry.quants.values()) {
       for (const engineId of quant.engines) {
@@ -319,10 +319,36 @@ export function possibleCells(repo: Repo): number {
         if (minors.size === 0) continue;
         for (const hardware of repo.hardware.values()) {
           if (!engineFitsHardware(engine.meta, hardware)) continue;
-          n += minors.size;
+          for (const minor of minors) {
+            ids.add(
+              cellId({
+                model_id: modelEntry.model.id,
+                quant_id: quant.id,
+                hardware_id: hardware.id,
+                hw_count: 1,
+                engine_id: engineId,
+                engine_minor: minor,
+              }),
+            );
+          }
         }
       }
     }
   }
-  return n;
+  return ids;
+}
+
+/**
+ * How many cells are possible — the denominator of the coverage figure.
+ *
+ * The enumeration fixes `hw_count` at 1: there is no bound on how many devices somebody may
+ * gang together, so multi-device cells cannot be crossed ahead of time. A cell somebody has
+ * measured on several devices is possible all the same, and it is already counted in
+ * `cells_covered`, so it is added here rather than making the ratio count a numerator the
+ * denominator does not contain.
+ */
+export function possibleCells(repo: Repo, measured: Record<string, CoverageCell> = {}): number {
+  const ids = possibleCellIds(repo);
+  for (const id of Object.keys(measured)) ids.add(id);
+  return ids.size;
 }

--- a/tools/test/build.test.ts
+++ b/tools/test/build.test.ts
@@ -10,6 +10,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cellId, engineMinor } from '@atlas/core';
 import type { CoverageCell, Gap } from '@atlas/core';
 import { buildData, resolveContributorIds } from '../src/build.js';
 import type { CompiledContributor } from '../src/build.js';
@@ -201,6 +202,31 @@ describe('output shape', () => {
     expect(stats.coverage_pct).toBeGreaterThan(0);
     expect(stats.last_updated).toBe('2026-08-02T10:00:00Z');
     expect((stats.levels as Record<string, number>).reproduced).toBe(1);
+  });
+
+  it('counts a measured multi-device cell in the denominator as well as the numerator', () => {
+    const base = build();
+    expect(base.ok).toBe(true);
+    const before = read<Record<string, number>>('stats.json');
+
+    // The cross product enumerates hw_count 1 only, so a tensor-parallel run lands in a cell
+    // it cannot reach. It still has to be possible: it has been measured.
+    const tp = makeResult(repo, { login: 'alice', startedAt: '2026-08-05T10:00:00Z' });
+    tp.hardware.count = 2;
+    tp.cell_id = cellId({
+      model_id: tp.model.id,
+      quant_id: tp.model.quant_id,
+      hardware_id: tp.hardware.id,
+      hw_count: 2,
+      engine_id: tp.engine.id,
+      engine_minor: engineMinor(tp.engine.version),
+    });
+    repo.writeResult(tp);
+    build();
+
+    const after = read<Record<string, number>>('stats.json');
+    expect(after.cells_covered).toBe(before.cells_covered! + 1);
+    expect(after.cells_possible).toBe(before.cells_possible! + 1);
   });
 
   it('reports dataset metadata and counts without compiling the rows', () => {


### PR DESCRIPTION
The Qwen3.8-Flash-Next × DGX Spark square on the atlas grid showed **69** runs in the `stale` colour. Both halves of that were wrong, for unrelated reasons.

## 1. The number: 69 instead of 75

Four coverage cells sit behind that square:

| cell_id | engine | minor | hw_count | runs | login |
|---|---|---|---|---|---|
| `146e5bfec676` | vllm | 0.1 | 1 | 42 | 0xBakeer |
| `1ab063de12eb` | llamacpp | b50-035e227 | 1 | 27 | 0xBakeer |
| `d8bc7ae8de81` | vllm | 0.1 | **2** | 5 | johntdavies |
| `4f657ccdfb62` | vllm | 0.1 | **3** | 1 | bumasoft |

42 + 27 = 69. The two multi-device cells were not being counted.

`possibleCells()` in `app/src/data/derive.ts` enumerates the registry cross product with `hw_count` hard-coded to 1, and `buildHeatMatrix` folds a coverage cell into a square only when the cross product produced that `cell_id`. `cell_id` hashes `hw_count`, so a tensor-parallel run lands in a cell the cross product can never reach and is dropped from the square's run count, its evidence level, its best number and the cell drawer's "Measured" list. It was still counted in `coverage.json` and in `stats.cells_covered`, so `cells_covered` (9) contained two cells that `cells_possible` (4717) did not.

Fixed by making the grid's universe the cross product **union** the measured cells (`atlasCells()`), and by adding the same measured cells to `stats.cells_possible` on the build side. `hw_count` stays un-enumerated — there is no bound on how many devices someone may gang together, so crossing 2, 4 and 8 of every device would invent a denominator — but a configuration somebody has run demonstrably exists. That square now reads 75 runs over 4 of 10 cells.

## 2. The colour: `stale` on the only build that can run the model

`engineMinor("0.1.dev20073+g8e685d198")` is `"0.1"`. `minorsBehind` put that in the same ordering as the registered vLLM minors 0.26 and 0.27, found two above it, and `stale_minors_behind` is 2.

`0.1.devN+g<sha>` is what setuptools-scm reports for a checkout with no reachable tag, which is what building an unmerged branch produces. This is the build of vLLM's Qwen3.8-Flash-Next branch (upstream support is still open in vllm-project/vllm#53896), and it is the only build that loads the model at all. The registry already says so — `engines/vllm/versions/0.1.dev20073+g8e685d198.json` records it as its own engine version "because its flags and its behaviour are not those of any published version". Ordering that placeholder `0.1` against 0.27 and calling the result age contradicts the reason the file exists, and "only on old engine minors" is the opposite of true: there is no newer engine minor that can run this model.

`minorsBehind` now counts only versions on the engine's published release lineage — a dotted numeric release (`0.27.1`, `2026.08.1`) or a monotonic build number (`b7000`), which are exactly the two shapes `compareMinor` can order. Everything else is off the lineage in both directions: a cell measured on such a build is never behind, and such a version in `versions_available` never makes anybody else's cell look behind. That covers three registered builds, all of them the same case:

- `vllm 0.1.dev20073+g8e685d198` — was `stale`, `minors_behind: 2`
- `sglang 0.0.0.dev0+qwen38.27b.g561c8f3` — was `minors_behind: 1`
- `llamacpp b50-035e227` (unmerged PR #27742 build, self-reports `0.3.0-dev` and build number 50, so `b50-035e227 < b7000` lexicographically) — was `minors_behind: 1`

After this the repository has no `stale` cells: `{"single": 9, "stale": 0}` where it had `{"single": 6, "stale": 3}`, and `minors_behind` disappears from every cell. That is the correct reading of the current data — nothing in the atlas is currently measured on a superseded release.

**Rejected alternative:** counting only newer minors that support the model in question. That is the sharper rule, but nothing in the registry expresses it. A quant declares `engines: ["vllm"]`, not a version range, and adding one would ask every contributor to assert a support boundary they cannot verify. The lineage rule resolves this case from data the registry already carries.

**Rejected alternative:** using `released: null` as the "not a release" marker. It does not discriminate — `llamacpp b7000` and `lmstudio 0.4.21` are ordinary releases with `released: null`, so the field currently means "nobody filled it in".

## Changes

- `packages/core/src/coverage.ts` — new `isReleaseVersion()`; `minorsBehind()` takes a full version (a bare minor is still accepted, unchanged behaviour) and filters both sides to the release lineage; `buildCell` passes the row's full version, since `engineMinor` is what discards the `.dev…+g…` that carries the distinction. The header comment on the levels and the `stale` semantics is updated.
- `app/src/data/derive.ts` — `measuredCells()` and `atlasCells()`; `app/src/store.ts` memoises on coverage as well as registry.
- `tools/src/lib/gaps.ts`, `tools/src/build.ts` — `possibleCells(repo, cells)` unions the measured cells into the denominator.
- `docs/SPEC.md` — decisions 22 and 23.
- Tests: `packages/core/src/coverage.test.ts` (release-lineage cases, and that a real release still goes stale), `app/src/data/derive.test.ts` (multi-device cell reaches the grid; unknown hardware is skipped), `tools/test/build.test.ts` (a measured multi-device cell moves both `cells_covered` and `cells_possible`).

## What this does not fix

- The wanted queue still enumerates one gap per registered engine minor, fork builds included, so it will keep proposing runs of unrelated models on `vllm 0.1.dev20073+g8e685d198`. That needs the per-version model support the registry does not record.
- `newestMinors()` in `tools/src/lib/gaps.ts` still picks the newest minor without the lineage filter. Harmless on today's data (`0.27` for vLLM either way), but a fork build with a high placeholder version would skew the `newest_engine_minor` gap weight.
- `compareMinor` is still duplicated between `packages/core/src/coverage.ts` and `tools/src/lib/gaps.ts`.
- No result file was touched.
