### PR TITLE
Harness: carry engine.build, and warn before a fork run instead of after it

### DIFF
--- a/bench/atlas_bench/registry.py
+++ b/bench/atlas_bench/registry.py
@@ -167,6 +167,7 @@ class Registry:
         args: dict[str, Any],
         quant_id: str,
         dtype: str | None,
+        build: str | None = None,
     ) -> ResolvedConfig:
         """Build the :class:`CanonicalInput` for a run from the registries.
 
@@ -182,6 +183,10 @@ class Registry:
         version = self.engine_version(engine_id, engine_version)
         if version is None:
             warnings.append(f"unknown-engine-version:{engine_id}@{engine_version}")
+        elif version.get("distribution") == "fork" and not (build or "").strip():
+            # The validator refuses this on review; failing here means the contributor finds
+            # out before the run rather than after it.
+            warnings.append(f"fork-build-unnamed:{engine_id}@{engine_version}")
 
         params: tuple[ParamSpec, ...] | None = None
         if version is not None:
@@ -209,6 +214,7 @@ class Registry:
                 param_aliases={
                     str(k): str(v) for k, v in (meta.get("param_aliases") or {}).items()
                 },
+                build=build,
             ),
             warnings=warnings,
         )

--- a/bench/atlas_bench/result.py
+++ b/bench/atlas_bench/result.py
@@ -267,6 +267,7 @@ def build_result(inputs: ResultInputs) -> dict[str, Any]:
         args=spec.args,
         quant_id=spec.model.quant_id,
         dtype=spec.model.dtype,
+        build=spec.engine.build,
     )
     inputs.warnings.extend(resolved.warnings)
     args_canonical = canonicalize(resolved.canonical_input)
@@ -320,6 +321,7 @@ def build_result(inputs: ResultInputs) -> dict[str, Any]:
             "id": spec.engine.id,
             "version": spec.engine.version,
             "commit": spec.engine.commit,
+            "build": spec.engine.build,
             "container": inputs.container or spec.engine.container,
             "install_method": _install_method(inputs.install_method or spec.engine.install_method),
         },

--- a/bench/atlas_bench/spec.py
+++ b/bench/atlas_bench/spec.py
@@ -51,6 +51,11 @@ class EngineRef(_Base):
     id: str
     version: str
     commit: str | None = None
+    #: Identity of the BUILD when the version string does not pin it: a container digest, or
+    #: ``<fork repo>@<fork ref>``. Required for engine versions registered as forks, because
+    #: a fork's ``<release>+g<sha>`` names the upstream commit it branched from rather than
+    #: its own patches (SPEC §3, decision 24). Enters the fingerprint as ``@build``.
+    build: str | None = None
     install: InstallSpec | None = None
     container: str | None = None
     base_url: str | None = None

--- a/bench/atlas_bench/validate.py
+++ b/bench/atlas_bench/validate.py
@@ -104,6 +104,7 @@ def _id_issues(record: dict[str, Any], registry: Registry, file_path: Path | Non
         args=record.get("args") or {},
         quant_id=str(model.get("quant_id")),
         dtype=model.get("dtype"),
+        build=engine.get("build"),
     )
     for warning in resolved.warnings:
         issues.append(Issue("warning", warning.split(":", 1)[0], warning, path))

--- a/bench/tests/test_result.py
+++ b/bench/tests/test_result.py
@@ -243,3 +243,21 @@ def test_conditions_absent_stays_null(atlas_repo: Path) -> None:
     """No conditions given: the field is null, never invented."""
     record = build_result(inputs(atlas_repo, WorkloadOutcome(kind="serving")))
     assert record["conditions"] is None
+
+
+def test_engine_build_reaches_the_fingerprint_and_the_record() -> None:
+    """A fork build must change config_id and be recorded, or the fork rule is unenforceable.
+
+    A fork's version string names the upstream commit it branched from, so two builds share
+    it; ``engine.build`` is what separates them (SPEC §3, decision 24).
+    """
+    from atlas_bench.canonical import CanonicalInput, canonicalize
+
+    base = dict(engine_id="vllm", engine_version="0.1.dev20073+g8e685d198", args={}, quant_id="nvfp4")
+    before = canonicalize(CanonicalInput(**base, build="github.com/example/fork@82ed48d"))
+    after = canonicalize(CanonicalInput(**base, build="github.com/example/fork@8347e7c"))
+    assert before != after, "two builds of one version must not share a canonical string"
+
+    # And a run that declares nothing hashes exactly as it did before the field existed.
+    assert canonicalize(CanonicalInput(**base)) == canonicalize(CanonicalInput(**base, build=None))
+    assert canonicalize(CanonicalInput(**base)) == "@dtype=auto;@quant=nvfp4"


### PR DESCRIPTION
#131 made `engine.build` part of the fingerprint and required it for fork engine versions. Nothing could produce it: the packet had no such field, so the first run against a fork version was refused **after** the measurement instead of before it.

Found the honest way — the first two Qwen3.6-35B-A3B cells produced under the new rule failed validation with `fork-build-unnamed` and had nothing to put in that field.

- `EngineRef` gains `build`
- `resolve_config()` threads it into `CanonicalInput`, so it reaches `config_id`
- the result records `engine.build`
- `resolve_config()` also emits a `fork-build-unnamed` **warning** when the version file says `fork` and the packet named no build, so this surfaces during setup rather than after an hour of GPU time

`pytest` 462 passed, including a new test asserting that two builds of one version string produce different canonical strings and that omitting the field reproduces `@dtype=auto;@quant=nvfp4` exactly.