### PR TITLE
results: Qwen/Qwen3.8-Flash-Next on nvidia-gb10-dgx-spark — eval-vision-v1 — Qwen3.6-35B-A3B NVFP4

### DIFF
--- a/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/bee4892d51ef0bfb--eval-vision-v1--0defbb.json
+++ b/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/bee4892d51ef0bfb--eval-vision-v1--0defbb.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -87,9 +87,9 @@
       "temperature": 0.6,
       "top_p": 0.95,
       "top_k": 20,
-      "min_p": 0.0,
-      "presence_penalty": 0.0,
-      "repetition_penalty": 1.0
+      "min_p": 0,
+      "presence_penalty": 0,
+      "repetition_penalty": 1
     }
   },
   "args_canonical": "@build=ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931;@dtype=auto;@quant=nvfp4;attention-backend=flashinfer;default-chat-template-kwargs={\"enable_thinking\":true,\"preserve_thinking\":true};enable-auto-tool-choice=true;gpu-memory-utilization=0.8;kv-cache-dtype=fp8;limit-mm-per-prompt={\"image\":4};linear-backend=flashinfer_b12x;max-model-len=262144;max-num-batched-tokens=32768;max-num-seqs=24;no-async-scheduling=true;no-enable-chunked-prefill=true;no-trust-remote-code=true;override-generation-config={\"min_p\":0,\"presence_penalty\":0,\"repetition_penalty\":1,\"temperature\":0.6,\"top_k\":20,\"top_p\":0.95};reasoning-parser=qwen3;speculative-config={\"method\":\"mtp\",\"moe_backend\":\"triton\",\"num_speculative_tokens\":2};tool-call-parser=qwen3_coder",
@@ -103,7 +103,7 @@
       "items": 60,
       "concurrency": 4,
       "max_output_tokens": 2048,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -116,7 +116,7 @@
     "requests_total": 60,
     "requests_ok": 60,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 172.999,
     "input_tokens_total": 8104,
     "output_tokens_total": 32823,
@@ -135,7 +135,7 @@
     "power_peak_w": 39.98,
     "energy_wh": 1.7835,
     "gpu_util_avg_pct": 93.38,
-    "temp_max_c": 63.0,
+    "temp_max_c": 63,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -143,7 +143,7 @@
     "total": 60,
     "correct": 46,
     "accuracy": 0.766667,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "arrows": {
         "total": 8,
@@ -840,7 +840,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-31T07:55:20Z",
     "finished_at": "2026-08-31T07:58:13Z",
     "submitted_at": null,

--- a/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/bee4892d51ef0bfb--eval-vision-v1--0defbb.json
+++ b/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/bee4892d51ef0bfb--eval-vision-v1--0defbb.json
@@ -1,0 +1,858 @@
+{
+  "schema_version": 1,
+  "run_id": "bee4892d51ef0bfb--eval-vision-v1--0defbb",
+  "config_id": "bee4892d51ef0bfb",
+  "cell_id": "611bb86b867d",
+  "workload_id": "eval-vision-v1",
+  "kind": "eval",
+  "engine": {
+    "id": "vllm",
+    "version": "0.26.1.dev0+gf2654939e.d20260726",
+    "commit": null,
+    "build": "ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931",
+    "container": "ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x:latest",
+    "install_method": "docker"
+  },
+  "model": {
+    "id": "Qwen/Qwen3.6-35B-A3B",
+    "quant_id": "nvfp4",
+    "hf_id": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "739af1e7aac320af1682ed1e0cce369af4c5265d",
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "tensor-parallel-size": 1,
+    "trust-remote-code": true,
+    "moe-backend": "auto",
+    "gpu-memory-utilization": 0.8,
+    "linear-backend": "flashinfer_b12x",
+    "attention-backend": "flashinfer",
+    "max-model-len": 262144,
+    "max-num-seqs": 24,
+    "max-num-batched-tokens": 32768,
+    "enable-chunked-prefill": true,
+    "async-scheduling": true,
+    "kv-cache-dtype": "fp8",
+    "limit-mm-per-prompt": {
+      "image": 4
+    },
+    "speculative-config": {
+      "method": "mtp",
+      "num_speculative_tokens": 2,
+      "moe_backend": "triton"
+    },
+    "reasoning-parser": "qwen3",
+    "tool-call-parser": "qwen3_coder",
+    "enable-auto-tool-choice": true,
+    "default-chat-template-kwargs": {
+      "enable_thinking": true,
+      "preserve_thinking": true
+    },
+    "override-generation-config": {
+      "temperature": 0.6,
+      "top_p": 0.95,
+      "top_k": 20,
+      "min_p": 0.0,
+      "presence_penalty": 0.0,
+      "repetition_penalty": 1.0
+    }
+  },
+  "args_canonical": "@build=ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931;@dtype=auto;@quant=nvfp4;attention-backend=flashinfer;default-chat-template-kwargs={\"enable_thinking\":true,\"preserve_thinking\":true};enable-auto-tool-choice=true;gpu-memory-utilization=0.8;kv-cache-dtype=fp8;limit-mm-per-prompt={\"image\":4};linear-backend=flashinfer_b12x;max-model-len=262144;max-num-batched-tokens=32768;max-num-seqs=24;no-async-scheduling=true;no-enable-chunked-prefill=true;no-trust-remote-code=true;override-generation-config={\"min_p\":0,\"presence_penalty\":0,\"repetition_penalty\":1,\"temperature\":0.6,\"top_k\":20,\"top_p\":0.95};reasoning-parser=qwen3;speculative-config={\"method\":\"mtp\",\"moe_backend\":\"triton\",\"num_speculative_tokens\":2};tool-call-parser=qwen3_coder",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-vision-v1",
+    "resolved_params": {
+      "dataset_id": "eval-vision-v1",
+      "suite": "vision",
+      "scorer": "vision",
+      "items": 60,
+      "concurrency": 4,
+      "max_output_tokens": 2048,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 60,
+    "requests_ok": 60,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 172.999,
+    "input_tokens_total": 8104,
+    "output_tokens_total": 32823,
+    "e2e_ms": {
+      "mean": 11063.19,
+      "p50": 5042.523,
+      "p90": 40030.467,
+      "p95": 41031.326,
+      "p99": 42925.955,
+      "min": 1717.715,
+      "max": 43322.268
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 109.807,
+    "power_avg_w": 37.03,
+    "power_peak_w": 39.98,
+    "energy_wh": 1.7835,
+    "gpu_util_avg_pct": 93.38,
+    "temp_max_c": 63.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "vision",
+    "total": 60,
+    "correct": 46,
+    "accuracy": 0.766667,
+    "success_rate": 1.0,
+    "by_category": {
+      "arrows": {
+        "total": 8,
+        "correct": 8
+      },
+      "chart": {
+        "total": 10,
+        "correct": 9
+      },
+      "clock": {
+        "total": 8,
+        "correct": 4
+      },
+      "dice": {
+        "total": 6,
+        "correct": 6
+      },
+      "grid": {
+        "total": 6,
+        "correct": 6
+      },
+      "ocr": {
+        "total": 10,
+        "correct": 2
+      },
+      "shapes": {
+        "total": 12,
+        "correct": 11
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 38,
+        "correct": 32
+      },
+      "hard": {
+        "total": 8,
+        "correct": 4
+      },
+      "medium": {
+        "total": 14,
+        "correct": 10
+      }
+    },
+    "avg_output_tokens": 547.05,
+    "avg_latency_ms": 11063.19,
+    "failures": 0,
+    "items": [
+      {
+        "id": "vis-0001",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 4277.724,
+        "output_tokens": 188,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0002",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 11928.152,
+        "output_tokens": 573,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0003",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 3876.489,
+        "output_tokens": 170,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0004",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 5329.991,
+        "output_tokens": 247,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0005",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 5136.611,
+        "output_tokens": 254,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0006",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 6947.035,
+        "output_tokens": 336,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0007",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 4150.424,
+        "output_tokens": 200,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0008",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 6078.104,
+        "output_tokens": 291,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0009",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 4112.561,
+        "output_tokens": 187,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0010",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 5240.961,
+        "output_tokens": 233,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0011",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 3731.52,
+        "output_tokens": 167,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0012",
+        "correct": false,
+        "predicted": "",
+        "expected": "bottom-right",
+        "latency_ms": 42259.091,
+        "output_tokens": 2048,
+        "category": "shapes",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0013",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 5731.913,
+        "output_tokens": 265,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0014",
+        "correct": false,
+        "predicted": "",
+        "expected": "0",
+        "latency_ms": 43322.268,
+        "output_tokens": 2048,
+        "category": "chart",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0015",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4112.646,
+        "output_tokens": 208,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0016",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 3798.207,
+        "output_tokens": 182,
+        "category": "chart",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0017",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 21968.964,
+        "output_tokens": 1058,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0018",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 2791.414,
+        "output_tokens": 136,
+        "category": "chart",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0019",
+        "correct": true,
+        "predicted": "No",
+        "expected": "no",
+        "latency_ms": 3760.136,
+        "output_tokens": 185,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0020",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4948.436,
+        "output_tokens": 247,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0021",
+        "correct": true,
+        "predicted": "Yes",
+        "expected": "yes",
+        "latency_ms": 3018.014,
+        "output_tokens": 141,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0022",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 3925.336,
+        "output_tokens": 196,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0023",
+        "correct": true,
+        "predicted": "104170",
+        "expected": "104170",
+        "latency_ms": 3564.986,
+        "output_tokens": 171,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0024",
+        "correct": false,
+        "predicted": "A99-07",
+        "expected": "A32-9207",
+        "latency_ms": 1982.485,
+        "output_tokens": 81,
+        "category": "ocr",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0025",
+        "correct": false,
+        "predicted": "",
+        "expected": "COMPASS",
+        "latency_ms": 40966.707,
+        "output_tokens": 2048,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0026",
+        "correct": false,
+        "predicted": "2025",
+        "expected": "926725",
+        "latency_ms": 11597.33,
+        "output_tokens": 565,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0027",
+        "correct": true,
+        "predicted": "P10-9941",
+        "expected": "P10-9941",
+        "latency_ms": 1757.162,
+        "output_tokens": 82,
+        "category": "ocr",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0028",
+        "correct": false,
+        "predicted": "PRACTICA",
+        "expected": "PLATFORM",
+        "latency_ms": 8126.756,
+        "output_tokens": 399,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0029",
+        "correct": false,
+        "predicted": "21021",
+        "expected": "921021",
+        "latency_ms": 3334.042,
+        "output_tokens": 157,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0030",
+        "correct": false,
+        "predicted": "S2F-103",
+        "expected": "S33-7805",
+        "latency_ms": 1717.715,
+        "output_tokens": 72,
+        "category": "ocr",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0031",
+        "correct": false,
+        "predicted": "",
+        "expected": "PLATFORM",
+        "latency_ms": 42650.551,
+        "output_tokens": 2048,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0032",
+        "correct": false,
+        "predicted": "1487",
+        "expected": "498775",
+        "latency_ms": 5769.019,
+        "output_tokens": 287,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0033",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 4284.663,
+        "output_tokens": 207,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0034",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 6634.12,
+        "output_tokens": 320,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0035",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 4384.337,
+        "output_tokens": 205,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0036",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 4890.766,
+        "output_tokens": 234,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0037",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 10406.368,
+        "output_tokens": 522,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0038",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 6127.187,
+        "output_tokens": 288,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0039",
+        "correct": true,
+        "predicted": "up",
+        "expected": "up",
+        "latency_ms": 3060.137,
+        "output_tokens": 132,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0040",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 4874.261,
+        "output_tokens": 229,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0041",
+        "correct": true,
+        "predicted": "left",
+        "expected": "left",
+        "latency_ms": 28969.387,
+        "output_tokens": 1355,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0042",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 4357.348,
+        "output_tokens": 215,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0043",
+        "correct": true,
+        "predicted": "up",
+        "expected": "up",
+        "latency_ms": 2804.405,
+        "output_tokens": 131,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0044",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 3569.722,
+        "output_tokens": 163,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0045",
+        "correct": true,
+        "predicted": "up",
+        "expected": "up",
+        "latency_ms": 2744.491,
+        "output_tokens": 132,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0046",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 6440.833,
+        "output_tokens": 315,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0047",
+        "correct": true,
+        "predicted": "12:10",
+        "expected": "12:10",
+        "latency_ms": 9920.329,
+        "output_tokens": 495,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0048",
+        "correct": false,
+        "predicted": "",
+        "expected": "6:10",
+        "latency_ms": 40568.251,
+        "output_tokens": 2048,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0049",
+        "correct": true,
+        "predicted": "1:25",
+        "expected": "1:25",
+        "latency_ms": 10762.986,
+        "output_tokens": 532,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0050",
+        "correct": false,
+        "predicted": "",
+        "expected": "11:20",
+        "latency_ms": 39970.711,
+        "output_tokens": 2048,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0051",
+        "correct": true,
+        "predicted": "11:00",
+        "expected": "11:00",
+        "latency_ms": 5903.957,
+        "output_tokens": 299,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0052",
+        "correct": false,
+        "predicted": "",
+        "expected": "6:20",
+        "latency_ms": 40727.615,
+        "output_tokens": 2048,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0053",
+        "correct": false,
+        "predicted": "",
+        "expected": "10:35",
+        "latency_ms": 39970.713,
+        "output_tokens": 2048,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0054",
+        "correct": true,
+        "predicted": "9:20",
+        "expected": "9:20",
+        "latency_ms": 30652.008,
+        "output_tokens": 1827,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0055",
+        "correct": true,
+        "predicted": "11",
+        "expected": "11",
+        "latency_ms": 6759.18,
+        "output_tokens": 360,
+        "category": "dice",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0056",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 3315.385,
+        "output_tokens": 156,
+        "category": "dice",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0057",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 3839.53,
+        "output_tokens": 193,
+        "category": "dice",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0058",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 3342.837,
+        "output_tokens": 160,
+        "category": "dice",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0059",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 8002.894,
+        "output_tokens": 466,
+        "category": "dice",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0060",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 4594.243,
+        "output_tokens": 225,
+        "category": "dice",
+        "difficulty": "easy"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [
+    {
+      "severity": "info",
+      "text": "GPU CLOCK IS A HIDDEN VARIABLE ON THIS BOX AND IT IS NOT AT MAXIMUM. Sampled at workload start: 2392MHz,3003MHz. nvidia-smi reports no active clock event reason - no SW power cap, no HW slowdown, no thermal slowdown, no applications-clock setting - and the clock cannot be raised without root, which this account does not have. Under load the SM clock sits around 2470-2490 MHz against a 3003 MHz ceiling, roughly 82 percent. On this model the effect is small: the author's own TTFT benchmark reproduced to within 4 percent. On a much larger model measured on the same box the same day the gap to the author's published decode figure was about 11 percent. Treat any comparison against a figure from another Spark as carrying this unknown unless that box's clock state is also stated."
+    },
+    {
+      "severity": "info",
+      "text": "Quantization is mixed, not uniform NVFP4, and the registry bits figure reflects that. Read out of the shard headers: routed experts are NVFP4 (packed U8 values with per-block F8_E4M3 scales and F32 global scales, 7830 of each per shard), attention is F8_E4M3 with BF16, and the router, gates and norms stay BF16. The router in particular is full precision because a routing error is discrete - a different set of experts fires - rather than a small numeric one. The pack is 6.06 bits per parameter overall, not 4."
+    },
+    {
+      "severity": "info",
+      "text": "Speculative decoding is the model's own MTP head at 2 tokens with moe_backend triton, and the linear backend is flashinfer_b12x with a soft fallback to auto for layers that are not NVFP4. Both are the recipe's defaults, both change decode throughput, and neither is comparable with a cell run without them."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "71569771e3c53f332d20fbf41279e6d573dd513d43ac9a88fceb9e4a27183b78",
+    "payload_path": null,
+    "payload": {
+      "scorer": "vision",
+      "scorers_used": [
+        "exact"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8888/v1",
+        "served_model_id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
+        "advertised_models": [
+          "unsloth/Qwen3.6-35B-A3B-NVFP4"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-31T07:55:20Z",
+    "finished_at": "2026-08-31T07:58:13Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Box was dedicated: no desktop session, no other GPU work, and the reverse-proxy SSH tunnel that is the only external route in was stopped for the whole sweep. NVIDIA DGX Spark (ASUS Ascent GX10, GB10 / SM121, 128 GB unified, ~121 GiB usable), Ubuntu 24.04.4, kernel 6.17.0-1029-nvidia aarch64, driver 580.173.02, CUDA 13.0, swap off. Server is the published recipe at github.com/MiaAI-Lab/Unsloth-Qwen3.6-35b-NVFP4-DGX-Spark run unmodified via its own start.sh: image ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x:latest, which reports vLLM 0.26.1.dev0+gf2654939e.d20260726 and is built on timothystewart6/vllm-gb10 for ARM64/SM121. Weights are unsloth/Qwen3.6-35B-A3B-NVFP4 at revision 739af1e, 19 files, 26.53 GB. Reproduction check before measuring: the recipe author reports 103 ms TTFT at concurrency 1, and his own bench_ttft.py on this box gave a mean of 107 ms over 8 runs (P95 108 ms), so this is his configuration behaving as published rather than a re-tuned one."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}


### PR DESCRIPTION
### Cells filled

- **Engine** — `vllm` `0.26.1.dev0+gf2654939e.d20260726`
- **Model / quant** — `Qwen/Qwen3.6-35B-A3B` / `nvfp4`
- **Hardware** — `nvidia-gb10-dgx-spark` x1
- **Workload** — `eval-vision-v1` (eval)
- **Headline** — accuracy **0.767**, success 1.000

One file: `results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/bee4892d51ef0bfb--eval-vision-v1--0defbb.json`

### What failed

Nothing failed. 60/60 requests returned, success rate 1.000.

### Gotchas

- **info** — GPU CLOCK IS A HIDDEN VARIABLE ON THIS BOX AND IT IS NOT AT MAXIMUM.
- **info** — Quantization is mixed, not uniform NVFP4, and the registry bits figure reflects that.
- **info** — Speculative decoding is the model's own MTP head at 2 tokens with moe_backend triton, and the linear backend is flashinfer_b12x with a soft fallback to auto for layers that are not NVFP4.

### Conditions

Dedicated box, nothing else resident on the GPU, no compile running. The one route into this machine from elsewhere on its private network is an SSH tunnel from a reverse proxy; it was stopped before the first run and stayed stopped. The harness talks to loopback with no proxy in the measured path.

n-gram table page-cache residency, `mincore(2)`: **2463% before the workload, MHz% after**.

| | |
|---|---:|
| peak host RAM | 109.8 GB |
| average GPU utilisation | 93.4 % |
| average / peak power | 37.0 / 40.0 W |
| max temperature | 63 C |
| thermal throttling | not detected |
| wall clock | 173.0 s |

`pnpm validate` — 0 errors. Read `gpu_util_avg_pct` with the caveat in the gotchas: it is a mean over the whole workload window including ramp-up and drain, not a steady-state figure.
