### PR TITLE
Registry: the official FP8 pack of Qwen3.6-35B-A3B

### DIFF
--- a/models/Qwen/Qwen3.6-35B-A3B/quants/fp8.json
+++ b/models/Qwen/Qwen3.6-35B-A3B/quants/fp8.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "fp8",
+  "model_id": "Qwen/Qwen3.6-35B-A3B",
+  "format": "fp8",
+  "bits": 8.57,
+  "hf_id": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "revision": "95a723d08a9490559dae23d0cff1d9466213d989",
+  "size_gb": 37.5,
+  "engines": [
+    "vllm"
+  ],
+  "source": "official",
+  "calibration": null,
+  "links": {
+    "hf": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8"
+  },
+  "notes": "First-party FP8 release from Qwen. quantization_config read out of the served checkpoint: quant_method fp8, fmt e4m3, activation_scheme dynamic, with a modules_to_not_convert list that keeps parts of the vision tower unquantized. 42 shards, 64,196 tensors, of which 1,560 are the NextN/MTP draft head and 333 the vision tower - both kept, so this pack supports the same speculative decoding and image input as the NVFP4 pack of the same model. bits 8.57 is the artefact measured against the vendor's 35B parameter count (37.5e9 x 8 / 35e9); it sits above 8 because the unconverted modules and the scales are wider than the fp8 body. calibration is null because the card states none and activation scaling is dynamic rather than calibrated."
+}


### PR DESCRIPTION
Second rung of a quantization ladder on one DGX Spark. Same model, same engine build, same 21 serve flags as the NVFP4 rung — only the weights differ.

Read out of the served checkpoint rather than the card:

| | |
|---|---|
| `quant_method` | `fp8`, `fmt: e4m3`, `activation_scheme: dynamic` |
| shards / tensors | 42 / 64,196 |
| MTP draft head | **1,560 tensors, kept** |
| vision tower | **333 tensors, kept** (partly unconverted, per `modules_to_not_convert`) |

Both packs keeping MTP and vision matters for the ladder: the two rungs are comparable on capability, not just on flags, so a difference in eval scores is about precision rather than about one pack having lost a feature.

`bits` is **8.57**, not 8 — 37.5 GB across 35B parameters. The unconverted modules and the scales are wider than the fp8 body, and the field describes the artefact on disk. Consistent with how the NVFP4 pack of this model is recorded (6.06) and the GLM EXL3 pack (2.44).

`calibration` is null: the card states none, and activation scaling is dynamic rather than calibrated.

Results follow separately.