### PR TITLE
bench: restamp a result that never named its build

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -122,6 +122,7 @@ without an adapter falls back to attach mode.
 | `submit --dir DIR [--draft]`                                    | branch `result/<engine>-<model>-<hardware>-<short>`, commits **only** result files, `gh pr create --label results`                                                                                                       |
 | `packet --cell ...`                                             | prints the agent task packet (SPEC §7) for a cell                                                                                                                                                                        |
 | `wrap raw.json --spec task.json`                                | wraps `vllm bench serve` / SGLang `bench_serving` JSON into a result file                                                                                                                                                |
+| `restamp FILE... --build REF`                                   | names the build behind an already-written result, recomputes `config_id`/`run_id` and moves the file (the cell is unchanged); for results written before `engine.build` existed                                          |
 
 Useful `run` flags: `--gotcha "text"` (repeatable), `--notes "ambient 22C, box idle"`,
 `--no-telemetry`, `--tokenizer <hf-id>`, `--login <github-login>`.

--- a/bench/atlas_bench/cli.py
+++ b/bench/atlas_bench/cli.py
@@ -9,6 +9,7 @@ Commands
 ``submit``   branch + commit + ``gh pr create`` for new result files only
 ``packet``   print the agent packet for a cell
 ``wrap``     turn an engine-native benchmark JSON into an Atlas result file
+``restamp``  name the build behind an already-written result and recompute its ids
 """
 
 from __future__ import annotations
@@ -27,6 +28,8 @@ from . import __version__
 from . import hwinfo as hwinfo_module
 from .client import utc_now
 from .engines.base import get_adapter
+from .canonical import canonicalize
+from .ids import config_id_from_canonical, run_id
 from .packet import build_packet, find_cell, parse_cell, write_packet
 from .registry import Registry
 from .repo import find_repo_root, write_json
@@ -548,6 +551,110 @@ def wrap(
     path = output_path(record, out)
     write_json(path, record)
     console.print(f"wrote {path}")
+
+
+# --------------------------------------------------------------------- restamp
+
+
+@app.command()
+def restamp(
+    files: list[Path] = typer.Argument(..., help="Result files (or directories) to restamp."),
+    build: str = typer.Option(
+        ..., "--build", help="What was actually run: an image digest, a wheel, a commit+patch."
+    ),
+    registry_dir: Path | None = typer.Option(None, "--registry-dir", "--repo"),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite a build that is already recorded and different."
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print the plan, change nothing."),
+) -> None:
+    """Name the build behind an already-written result and recompute its ids.
+
+    Two forks of an engine can report the same version string, so a result from one and a
+    result from the other used to collide on ``config_id`` and be read as repeats of a single
+    configuration. ``engine.build`` separates them (SPEC decision 24). A result written before
+    the field existed — or by a harness that left it null — needs the field added and the
+    fingerprint recomputed, which also moves the file, because the filename is the run id.
+
+    The cell id does not change: a build is a property of the configuration, not of the
+    model/quant/hardware/engine-minor cell the configuration sits in.
+    """
+    registry = _registry(registry_dir)
+    targets: list[Path] = []
+    for entry in files:
+        targets.extend(sorted(entry.rglob("*.json")) if entry.is_dir() else [entry])
+    if not targets:
+        error_console.print("[bold red]no result files given[/]")
+        raise typer.Exit(code=2)
+
+    changed = 0
+    for target in targets:
+        record = json.loads(target.read_text())
+        engine = record.get("engine") or {}
+        existing = (engine.get("build") or "").strip()
+        if existing == build.strip():
+            console.print(f"[dim]unchanged[/] {target} — already names this build")
+            continue
+        if existing and not force:
+            error_console.print(
+                f"[bold red]{target}[/] already names a different build "
+                f"({existing}); pass --force to replace it"
+            )
+            raise typer.Exit(code=1)
+
+        model = record.get("model") or {}
+        resolved = registry.resolve_config(
+            engine_id=engine.get("id", ""),
+            engine_version=engine.get("version", ""),
+            args=record.get("args") or {},
+            quant_id=model.get("quant_id", ""),
+            dtype=model.get("dtype"),
+            build=build,
+        )
+        for warning in resolved.warnings:
+            console.print(f"  [yellow]warning[/] {warning}")
+
+        args_canonical = canonicalize(resolved.canonical_input)
+        cfg_id = config_id_from_canonical(args_canonical)
+        provenance = record.get("provenance") or {}
+        rid = run_id(
+            cfg_id=cfg_id,
+            workload_id=str((record.get("workload") or {}).get("id")),
+            github_login=provenance.get("github_login") or "",
+            started_at=provenance.get("started_at") or "",
+        )
+
+        engine["build"] = build
+        record["engine"] = engine
+        record["args_canonical"] = args_canonical
+        record["config_id"] = cfg_id
+        record["run_id"] = rid
+
+        # The filename is the run id, so a recomputed fingerprint always relocates the file.
+        # output_path wants the repo root or its results/ directory; walk up to the results/
+        # the file already sits under, because a model id may be one path segment or two.
+        results_root = next(
+            (parent for parent in target.parents if parent.name == "results"), None
+        )
+        if results_root is None:
+            error_console.print(f"[bold red]{target} is not under a results/ directory[/]")
+            raise typer.Exit(code=2)
+        destination = output_path(record, results_root)
+
+        console.print(f"[bold]{target}[/]")
+        console.print(f"  config_id {record.get('config_id')} ← recomputed with the build")
+        console.print(f"  cell_id   {record.get('cell_id')} (unchanged — a build is not a cell)")
+        console.print(f"  → {destination}")
+        if dry_run:
+            continue
+        write_json(destination, record)
+        if destination.resolve() != target.resolve():
+            target.unlink()
+        changed += 1
+
+    console.print(f"\n{len(targets)} file(s), {changed} restamped")
+    if changed and not dry_run:
+        console.print("[dim]re-run `atlas-bench validate` before submitting.[/]")
 
 
 def main() -> None:

--- a/bench/tests/test_cli.py
+++ b/bench/tests/test_cli.py
@@ -219,3 +219,104 @@ def test_wrap_writes_a_result(atlas_repo: Path, tmp_path: Path, monkeypatch) -> 
     assert record["raw"]["payload"]["source"] == "vllm-bench-serve"
     assert record["provenance"]["started_at"] == "2026-08-16T14:15:16Z"
     assert any("not by atlas-bench" in g["text"] for g in record["gotchas"])
+
+
+# ------------------------------------------------------------------- restamp
+
+
+def _result_for_restamp(atlas_repo: Path) -> Path:
+    """One written result whose engine.build is missing, at its correct path."""
+    record = {
+        "schema_version": 1,
+        "config_id": "0000000000000000",
+        "cell_id": "000000000000",
+        "run_id": "0000000000000000--workload-test-v1--aaaaaa",
+        "engine": {"id": "vllm", "version": "0.27.1", "build": None},
+        "model": {"id": "acme/test-model-1b", "quant_id": "fp8", "dtype": "auto"},
+        "hardware": {"id": "test-gpu-24gb", "count": 1},
+        "args": {"max-model-len": 4096},
+        "args_canonical": "max-model-len=4096",
+        "workload": {"id": "workload-test-v1"},
+        "provenance": {"github_login": "someone", "started_at": "2026-01-01T00:00:00Z"},
+    }
+    path = (
+        atlas_repo
+        / "results"
+        / "vllm"
+        / "acme"
+        / "test-model-1b"
+        / "test-gpu-24gb"
+        / f"{record['run_id']}.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def test_restamp_names_the_build_and_moves_the_file(atlas_repo: Path) -> None:
+    """Adding the build changes the config fingerprint, so the result relocates with it."""
+    path = _result_for_restamp(atlas_repo)
+    build = "ghcr.io/example/vllm@sha256:" + "a" * 64
+
+    result = runner.invoke(
+        app, ["restamp", str(path), "--build", build, "--registry-dir", str(atlas_repo)]
+    )
+    assert result.exit_code == 0, result.stdout
+    assert not path.exists(), "the old filename still carries the old fingerprint"
+
+    written = sorted(p for p in path.parent.glob("*.json"))
+    assert len(written) == 1
+    record = json.loads(written[0].read_text())
+    assert record["engine"]["build"] == build
+    assert record["config_id"] != "0000000000000000"
+    assert written[0].name == f"{record['run_id']}.json"
+    assert record["run_id"].startswith(record["config_id"])
+    # A build is a property of the configuration, not of the cell it sits in.
+    assert record["cell_id"] == "000000000000"
+
+
+def test_restamp_is_idempotent(atlas_repo: Path) -> None:
+    """Restamping the same build twice is a no-op, not a second relocation."""
+    path = _result_for_restamp(atlas_repo)
+    build = "ghcr.io/example/vllm@sha256:" + "b" * 64
+    args = ["restamp", "--build", build, "--registry-dir", str(atlas_repo)]
+
+    first = runner.invoke(app, ["restamp", str(path), *args[1:]])
+    assert first.exit_code == 0, first.stdout
+    moved = next(iter(path.parent.glob("*.json")))
+    before = moved.read_text()
+
+    second = runner.invoke(app, ["restamp", str(moved), *args[1:]])
+    assert second.exit_code == 0, second.stdout
+    assert "unchanged" in second.stdout
+    assert moved.read_text() == before
+
+
+def test_restamp_refuses_to_replace_a_different_build(atlas_repo: Path) -> None:
+    """Silently overwriting a recorded build would rewrite somebody's measurement."""
+    path = _result_for_restamp(atlas_repo)
+    args = ["--registry-dir", str(atlas_repo)]
+    first = runner.invoke(app, ["restamp", str(path), "--build", "image-a", *args])
+    assert first.exit_code == 0, first.stdout
+    moved = next(iter(path.parent.glob("*.json")))
+
+    refused = runner.invoke(app, ["restamp", str(moved), "--build", "image-b", *args])
+    assert refused.exit_code == 1
+    assert json.loads(moved.read_text())["engine"]["build"] == "image-a"
+
+    forced = runner.invoke(app, ["restamp", str(moved), "--build", "image-b", "--force", *args])
+    assert forced.exit_code == 0, forced.stdout
+    replaced = next(iter(path.parent.glob("*.json")))
+    assert json.loads(replaced.read_text())["engine"]["build"] == "image-b"
+
+
+def test_restamp_dry_run_changes_nothing(atlas_repo: Path) -> None:
+    """The plan is printable without touching the file."""
+    path = _result_for_restamp(atlas_repo)
+    before = path.read_text()
+    result = runner.invoke(
+        app,
+        ["restamp", str(path), "--build", "image-x", "--dry-run", "--registry-dir", str(atlas_repo)],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert path.exists() and path.read_text() == before

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -686,7 +686,7 @@ or where reality disagreed with it. Each one is binding until superseded here.
     gap.
 
     A result already on disk without the field is repaired by `atlas-bench restamp FILE
-    --build <ref>`, which recomputes the fingerprint and moves the file, because the
+--build <ref>`, which recomputes the fingerprint and moves the file, because the
     filename is the run id. Restamping is idempotent, refuses to replace a build already
     recorded unless forced, and never touches `cell_id`: a build is a property of the
     configuration, not of the cell the configuration sits in.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -684,3 +684,9 @@ or where reality disagreed with it. Each one is binding until superseded here.
     known — `sglang 0.0.0.dev0+qwen38.27b.g561c8f3` — `source_repo` is recorded as
     `unknown` rather than guessed; an invented repository would be worse than an admitted
     gap.
+
+    A result already on disk without the field is repaired by `atlas-bench restamp FILE
+    --build <ref>`, which recomputes the fingerprint and moves the file, because the
+    filename is the run id. Restamping is idempotent, refuses to replace a build already
+    recorded unless forced, and never touches `cell_id`: a build is a property of the
+    configuration, not of the cell the configuration sits in.


### PR DESCRIPTION
Decision 24 requires a result on a forked engine to set `engine.build`, and the validator refuses one that does not. That rule is answerable for a run that has not started — `resolve_config` warns before the box is busy — but not for a result already written. The fingerprint has to be recomputed, and because the filename is the run id and the run id derives from the config id, the file has to move with it.

Doing that by hand is three hashes and a rename — exactly the kind of edit `AGENTS.md` tells contributors never to make by hand.

```
atlas-bench restamp results/vllm/.../<run>.json --build ghcr.io/you/vllm@sha256:...
```

re-resolves the config against the registry with the build present, recomputes `args_canonical` / `config_id` / `run_id`, writes the record at its new path and removes the old one. Resolve warnings (unknown engine, unknown version) are printed, not swallowed.

Three refusals, because the command rewrites a measurement someone made:

- idempotent when the build already matches — prints `unchanged`, rewrites nothing
- exit 1 when a *different* build is already recorded, unless `--force`
- `--dry-run` prints the plan and touches nothing

`cell_id` is deliberately untouched. A build is a property of the configuration, not of the model/quant/hardware/engine-minor cell it sits in — so restamping splits one cell's configurations apart without moving the cell. There is a test asserting exactly that, so a later refactor cannot quietly change it.

466 bench tests pass; `pnpm validate` is clean.
