### PR TITLE
results: Qwen/Qwen3.6-35B-A3B FP8 on nvidia-gb10-dgx-spark — eval-json-v1

### DIFF
--- a/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--eval-json-v1--2911f0.json
+++ b/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--eval-json-v1--2911f0.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -86,9 +86,9 @@
       "temperature": 0.6,
       "top_p": 0.95,
       "top_k": 20,
-      "min_p": 0.0,
-      "presence_penalty": 0.0,
-      "repetition_penalty": 1.0
+      "min_p": 0,
+      "presence_penalty": 0,
+      "repetition_penalty": 1
     }
   },
   "args_canonical": "@build=ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931;@dtype=auto;@quant=fp8;attention-backend=flashinfer;default-chat-template-kwargs={\"enable_thinking\":true,\"preserve_thinking\":true};enable-auto-tool-choice=true;gpu-memory-utilization=0.8;kv-cache-dtype=fp8;limit-mm-per-prompt={\"image\":4};max-model-len=262144;max-num-batched-tokens=32768;max-num-seqs=24;no-async-scheduling=true;no-enable-chunked-prefill=true;no-trust-remote-code=true;override-generation-config={\"min_p\":0,\"presence_penalty\":0,\"repetition_penalty\":1,\"temperature\":0.6,\"top_k\":20,\"top_p\":0.95};reasoning-parser=qwen3;speculative-config={\"method\":\"mtp\",\"moe_backend\":\"triton\",\"num_speculative_tokens\":2};tool-call-parser=qwen3_coder",
@@ -102,7 +102,7 @@
       "items": 110,
       "concurrency": 4,
       "max_output_tokens": 2048,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -115,7 +115,7 @@
     "requests_total": 110,
     "requests_ok": 110,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 806.582,
     "input_tokens_total": 10224,
     "output_tokens_total": 102760,
@@ -134,7 +134,7 @@
     "power_peak_w": 39.43,
     "energy_wh": 8.5476,
     "gpu_util_avg_pct": 95.39,
-    "temp_max_c": 67.0,
+    "temp_max_c": 67,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -142,7 +142,7 @@
     "total": 110,
     "correct": 101,
     "accuracy": 0.918182,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "aggregation": {
         "total": 10,
@@ -1166,7 +1166,7 @@
         "correct": true,
         "predicted": "{\"date\":\"2025-03-15\",\"weekday_known\":false}",
         "expected": "{\"date\":\"2025-03-15\",\"weekday_known\":false}",
-        "latency_ms": 9503.0,
+        "latency_ms": 9503,
         "output_tokens": 296,
         "category": "normalisation",
         "difficulty": "medium"
@@ -1339,7 +1339,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-31T09:15:43Z",
     "finished_at": "2026-08-31T09:29:10Z",
     "submitted_at": null,

--- a/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--eval-json-v1--2911f0.json
+++ b/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--eval-json-v1--2911f0.json
@@ -1,0 +1,1357 @@
+{
+  "schema_version": 1,
+  "run_id": "8cd52c733b36ecb7--eval-json-v1--2911f0",
+  "config_id": "8cd52c733b36ecb7",
+  "cell_id": "803dc89250a5",
+  "workload_id": "eval-json-v1",
+  "kind": "eval",
+  "engine": {
+    "id": "vllm",
+    "version": "0.26.1.dev0+gf2654939e.d20260726",
+    "commit": null,
+    "build": "ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931",
+    "container": "ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x:latest",
+    "install_method": "docker"
+  },
+  "model": {
+    "id": "Qwen/Qwen3.6-35B-A3B",
+    "quant_id": "fp8",
+    "hf_id": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "95a723d08a94",
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "tensor-parallel-size": 1,
+    "trust-remote-code": true,
+    "moe-backend": "auto",
+    "gpu-memory-utilization": 0.8,
+    "attention-backend": "flashinfer",
+    "max-model-len": 262144,
+    "max-num-seqs": 24,
+    "max-num-batched-tokens": 32768,
+    "enable-chunked-prefill": true,
+    "async-scheduling": true,
+    "kv-cache-dtype": "fp8",
+    "limit-mm-per-prompt": {
+      "image": 4
+    },
+    "speculative-config": {
+      "method": "mtp",
+      "num_speculative_tokens": 2,
+      "moe_backend": "triton"
+    },
+    "reasoning-parser": "qwen3",
+    "tool-call-parser": "qwen3_coder",
+    "enable-auto-tool-choice": true,
+    "default-chat-template-kwargs": {
+      "enable_thinking": true,
+      "preserve_thinking": true
+    },
+    "override-generation-config": {
+      "temperature": 0.6,
+      "top_p": 0.95,
+      "top_k": 20,
+      "min_p": 0.0,
+      "presence_penalty": 0.0,
+      "repetition_penalty": 1.0
+    }
+  },
+  "args_canonical": "@build=ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931;@dtype=auto;@quant=fp8;attention-backend=flashinfer;default-chat-template-kwargs={\"enable_thinking\":true,\"preserve_thinking\":true};enable-auto-tool-choice=true;gpu-memory-utilization=0.8;kv-cache-dtype=fp8;limit-mm-per-prompt={\"image\":4};max-model-len=262144;max-num-batched-tokens=32768;max-num-seqs=24;no-async-scheduling=true;no-enable-chunked-prefill=true;no-trust-remote-code=true;override-generation-config={\"min_p\":0,\"presence_penalty\":0,\"repetition_penalty\":1,\"temperature\":0.6,\"top_k\":20,\"top_p\":0.95};reasoning-parser=qwen3;speculative-config={\"method\":\"mtp\",\"moe_backend\":\"triton\",\"num_speculative_tokens\":2};tool-call-parser=qwen3_coder",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-json-v1",
+    "resolved_params": {
+      "dataset_id": "eval-json-v1",
+      "suite": "json",
+      "scorer": "json",
+      "items": 110,
+      "concurrency": 4,
+      "max_output_tokens": 2048,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 110,
+    "requests_ok": 110,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 806.582,
+    "input_tokens_total": 10224,
+    "output_tokens_total": 102760,
+    "e2e_ms": {
+      "mean": 29030.939,
+      "p50": 30245.601,
+      "p90": 41151.491,
+      "p95": 46545.536,
+      "p99": 51584.959,
+      "min": 8337.069,
+      "max": 56904.832
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 107.556,
+    "power_avg_w": 38.15,
+    "power_peak_w": 39.43,
+    "energy_wh": 8.5476,
+    "gpu_util_avg_pct": 95.39,
+    "temp_max_c": 67.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "json",
+    "total": 110,
+    "correct": 101,
+    "accuracy": 0.918182,
+    "success_rate": 1.0,
+    "by_category": {
+      "aggregation": {
+        "total": 10,
+        "correct": 10
+      },
+      "arrays": {
+        "total": 18,
+        "correct": 18
+      },
+      "classification": {
+        "total": 22,
+        "correct": 13
+      },
+      "extraction": {
+        "total": 40,
+        "correct": 40
+      },
+      "nested": {
+        "total": 10,
+        "correct": 10
+      },
+      "normalisation": {
+        "total": 6,
+        "correct": 6
+      },
+      "transformation": {
+        "total": 4,
+        "correct": 4
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 32,
+        "correct": 23
+      },
+      "hard": {
+        "total": 12,
+        "correct": 12
+      },
+      "medium": {
+        "total": 66,
+        "correct": 66
+      }
+    },
+    "avg_output_tokens": 934.18,
+    "avg_latency_ms": 29030.94,
+    "failures": 0,
+    "items": [
+      {
+        "id": "json-0001",
+        "correct": true,
+        "predicted": "{\"age\":64,\"city\":\"Aberholt\",\"email\":\"priya.ellery@example.org\",\"name\":\"Priya Ellery\"}",
+        "expected": "{\"age\":64,\"city\":\"Aberholt\",\"email\":\"priya.ellery@example.org\",\"name\":\"Priya Ellery\"}",
+        "latency_ms": 29844.62,
+        "output_tokens": 978,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0002",
+        "correct": true,
+        "predicted": "{\"age\":25,\"city\":\"Kesswater\",\"email\":\"dana.fairbank@example.org\",\"name\":\"Dana Fairbank\"}",
+        "expected": "{\"age\":25,\"city\":\"Kesswater\",\"email\":\"dana.fairbank@example.org\",\"name\":\"Dana Fairbank\"}",
+        "latency_ms": 28992.611,
+        "output_tokens": 962,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0003",
+        "correct": true,
+        "predicted": "{\"age\":27,\"city\":\"Valcrest\",\"email\":\"mira.ellery@example.org\",\"name\":\"Mira Ellery\"}",
+        "expected": "{\"age\":27,\"city\":\"Valcrest\",\"email\":\"mira.ellery@example.org\",\"name\":\"Mira Ellery\"}",
+        "latency_ms": 12985.986,
+        "output_tokens": 432,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0004",
+        "correct": true,
+        "predicted": "{\"age\":62,\"city\":\"Aberholt\",\"email\":\"priya.dunmore@example.org\",\"name\":\"Priya Dunmore\"}",
+        "expected": "{\"age\":62,\"city\":\"Aberholt\",\"email\":\"priya.dunmore@example.org\",\"name\":\"Priya Dunmore\"}",
+        "latency_ms": 34576.431,
+        "output_tokens": 1160,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0005",
+        "correct": true,
+        "predicted": "{\"age\":62,\"city\":\"Marren Bay\",\"email\":\"gus.dunmore@example.org\",\"name\":\"Gus Dunmore\"}",
+        "expected": "{\"age\":62,\"city\":\"Marren Bay\",\"email\":\"gus.dunmore@example.org\",\"name\":\"Gus Dunmore\"}",
+        "latency_ms": 24576.356,
+        "output_tokens": 790,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0006",
+        "correct": true,
+        "predicted": "{\"age\":40,\"city\":\"Dunhallow\",\"email\":\"ines.dunmore@example.org\",\"name\":\"Ines Dunmore\"}",
+        "expected": "{\"age\":40,\"city\":\"Dunhallow\",\"email\":\"ines.dunmore@example.org\",\"name\":\"Ines Dunmore\"}",
+        "latency_ms": 14386.096,
+        "output_tokens": 463,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0007",
+        "correct": true,
+        "predicted": "{\"age\":71,\"city\":\"Kesswater\",\"email\":\"mira.braith@example.org\",\"name\":\"Mira Braith\"}",
+        "expected": "{\"age\":71,\"city\":\"Kesswater\",\"email\":\"mira.braith@example.org\",\"name\":\"Mira Braith\"}",
+        "latency_ms": 25010.411,
+        "output_tokens": 801,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0008",
+        "correct": true,
+        "predicted": "{\"age\":26,\"city\":\"Threeford\",\"email\":\"fenna.keswick@example.org\",\"name\":\"Fenna Keswick\"}",
+        "expected": "{\"age\":26,\"city\":\"Threeford\",\"email\":\"fenna.keswick@example.org\",\"name\":\"Fenna Keswick\"}",
+        "latency_ms": 32767.949,
+        "output_tokens": 1060,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0009",
+        "correct": true,
+        "predicted": "{\"age\":21,\"city\":\"Marren Bay\",\"email\":\"priya.alder@example.org\",\"name\":\"Priya Alder\"}",
+        "expected": "{\"age\":21,\"city\":\"Marren Bay\",\"email\":\"priya.alder@example.org\",\"name\":\"Priya Alder\"}",
+        "latency_ms": 13872.502,
+        "output_tokens": 442,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0010",
+        "correct": true,
+        "predicted": "{\"age\":65,\"city\":\"Aberholt\",\"email\":\"dana.gale@example.org\",\"name\":\"Dana Gale\"}",
+        "expected": "{\"age\":65,\"city\":\"Aberholt\",\"email\":\"dana.gale@example.org\",\"name\":\"Dana Gale\"}",
+        "latency_ms": 25303.131,
+        "output_tokens": 817,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0011",
+        "correct": true,
+        "predicted": "{\"age\":56,\"city\":\"Valcrest\",\"email\":\"ines.ivers@example.org\",\"name\":\"Ines Ivers\"}",
+        "expected": "{\"age\":56,\"city\":\"Valcrest\",\"email\":\"ines.ivers@example.org\",\"name\":\"Ines Ivers\"}",
+        "latency_ms": 32579.281,
+        "output_tokens": 1059,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0012",
+        "correct": true,
+        "predicted": "{\"age\":54,\"city\":\"Kesswater\",\"email\":\"tomas.ellery@example.org\",\"name\":\"Tomas Ellery\"}",
+        "expected": "{\"age\":54,\"city\":\"Kesswater\",\"email\":\"tomas.ellery@example.org\",\"name\":\"Tomas Ellery\"}",
+        "latency_ms": 13330.79,
+        "output_tokens": 436,
+        "category": "extraction",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0013",
+        "correct": true,
+        "predicted": "{\"amount_cents\":17746,\"currency\":\"EUR\",\"due_days\":14,\"invoice_id\":\"INV-77315\"}",
+        "expected": "{\"amount_cents\":17746,\"currency\":\"EUR\",\"due_days\":14,\"invoice_id\":\"INV-77315\"}",
+        "latency_ms": 34933.499,
+        "output_tokens": 1139,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0014",
+        "correct": true,
+        "predicted": "{\"amount_cents\":203187,\"currency\":\"GBP\",\"due_days\":30,\"invoice_id\":\"INV-82382\"}",
+        "expected": "{\"amount_cents\":203187,\"currency\":\"GBP\",\"due_days\":30,\"invoice_id\":\"INV-82382\"}",
+        "latency_ms": 40853.485,
+        "output_tokens": 1302,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0015",
+        "correct": true,
+        "predicted": "{\"amount_cents\":104564,\"currency\":\"EUR\",\"due_days\":14,\"invoice_id\":\"INV-77092\"}",
+        "expected": "{\"amount_cents\":104564,\"currency\":\"EUR\",\"due_days\":14,\"invoice_id\":\"INV-77092\"}",
+        "latency_ms": 27406.98,
+        "output_tokens": 900,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0016",
+        "correct": true,
+        "predicted": "{\"amount_cents\":169877,\"currency\":\"USD\",\"due_days\":30,\"invoice_id\":\"INV-44042\"}",
+        "expected": "{\"amount_cents\":169877,\"currency\":\"USD\",\"due_days\":30,\"invoice_id\":\"INV-44042\"}",
+        "latency_ms": 27076.808,
+        "output_tokens": 863,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0017",
+        "correct": true,
+        "predicted": "{\"amount_cents\":126104,\"currency\":\"CHF\",\"due_days\":60,\"invoice_id\":\"INV-31069\"}",
+        "expected": "{\"amount_cents\":126104,\"currency\":\"CHF\",\"due_days\":60,\"invoice_id\":\"INV-31069\"}",
+        "latency_ms": 31267.783,
+        "output_tokens": 1003,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0018",
+        "correct": true,
+        "predicted": "{\"amount_cents\":7610,\"currency\":\"EUR\",\"due_days\":7,\"invoice_id\":\"INV-60017\"}",
+        "expected": "{\"amount_cents\":7610,\"currency\":\"EUR\",\"due_days\":7,\"invoice_id\":\"INV-60017\"}",
+        "latency_ms": 36590.27,
+        "output_tokens": 1188,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0019",
+        "correct": true,
+        "predicted": "{\"amount_cents\":248441,\"currency\":\"CHF\",\"due_days\":60,\"invoice_id\":\"INV-86413\"}",
+        "expected": "{\"amount_cents\":248441,\"currency\":\"CHF\",\"due_days\":60,\"invoice_id\":\"INV-86413\"}",
+        "latency_ms": 38832.588,
+        "output_tokens": 1264,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0020",
+        "correct": true,
+        "predicted": "{\"amount_cents\":175564,\"currency\":\"CHF\",\"due_days\":60,\"invoice_id\":\"INV-82818\"}",
+        "expected": "{\"amount_cents\":175564,\"currency\":\"CHF\",\"due_days\":60,\"invoice_id\":\"INV-82818\"}",
+        "latency_ms": 33713.089,
+        "output_tokens": 1080,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0021",
+        "correct": true,
+        "predicted": "{\"amount_cents\":236148,\"currency\":\"GBP\",\"due_days\":60,\"invoice_id\":\"INV-94680\"}",
+        "expected": "{\"amount_cents\":236148,\"currency\":\"GBP\",\"due_days\":60,\"invoice_id\":\"INV-94680\"}",
+        "latency_ms": 33256.916,
+        "output_tokens": 1073,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0022",
+        "correct": true,
+        "predicted": "{\"amount_cents\":167374,\"currency\":\"CHF\",\"due_days\":7,\"invoice_id\":\"INV-50802\"}",
+        "expected": "{\"amount_cents\":167374,\"currency\":\"CHF\",\"due_days\":7,\"invoice_id\":\"INV-50802\"}",
+        "latency_ms": 38822.832,
+        "output_tokens": 1255,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0023",
+        "correct": true,
+        "predicted": "{\"amount_cents\":219295,\"currency\":\"USD\",\"due_days\":14,\"invoice_id\":\"INV-28572\"}",
+        "expected": "{\"amount_cents\":219295,\"currency\":\"USD\",\"due_days\":14,\"invoice_id\":\"INV-28572\"}",
+        "latency_ms": 38341.584,
+        "output_tokens": 1222,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0024",
+        "correct": true,
+        "predicted": "{\"amount_cents\":14140,\"currency\":\"EUR\",\"due_days\":7,\"invoice_id\":\"INV-24541\"}",
+        "expected": "{\"amount_cents\":14140,\"currency\":\"EUR\",\"due_days\":7,\"invoice_id\":\"INV-24541\"}",
+        "latency_ms": 40428.806,
+        "output_tokens": 1270,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0025",
+        "correct": true,
+        "predicted": "{\"latency_ms\":8944,\"level\":\"INFO\",\"service\":\"payments\",\"status\":200,\"tenant\":\"t-5887\"}",
+        "expected": "{\"latency_ms\":8944,\"level\":\"INFO\",\"service\":\"payments\",\"status\":200,\"tenant\":\"t-5887\"}",
+        "latency_ms": 31633.668,
+        "output_tokens": 1002,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0026",
+        "correct": true,
+        "predicted": "{\"latency_ms\":1508,\"level\":\"ERROR\",\"service\":\"search\",\"status\":429,\"tenant\":\"t-5649\"}",
+        "expected": "{\"latency_ms\":1508,\"level\":\"ERROR\",\"service\":\"search\",\"status\":429,\"tenant\":\"t-5649\"}",
+        "latency_ms": 49394.817,
+        "output_tokens": 1581,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0027",
+        "correct": true,
+        "predicted": "{\"latency_ms\":8337,\"level\":\"DEBUG\",\"service\":\"identity\",\"status\":500,\"tenant\":\"t-5422\"}",
+        "expected": "{\"latency_ms\":8337,\"level\":\"DEBUG\",\"service\":\"identity\",\"status\":500,\"tenant\":\"t-5422\"}",
+        "latency_ms": 29527.409,
+        "output_tokens": 953,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0028",
+        "correct": true,
+        "predicted": "{\"latency_ms\":3642,\"level\":\"INFO\",\"service\":\"identity\",\"status\":200,\"tenant\":\"t-3827\"}",
+        "expected": "{\"latency_ms\":3642,\"level\":\"INFO\",\"service\":\"identity\",\"status\":200,\"tenant\":\"t-3827\"}",
+        "latency_ms": 38786.435,
+        "output_tokens": 1265,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0029",
+        "correct": true,
+        "predicted": "{\"latency_ms\":1571,\"level\":\"ERROR\",\"service\":\"media\",\"status\":404,\"tenant\":\"t-1804\"}",
+        "expected": "{\"latency_ms\":1571,\"level\":\"ERROR\",\"service\":\"media\",\"status\":404,\"tenant\":\"t-1804\"}",
+        "latency_ms": 40013.685,
+        "output_tokens": 1309,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0030",
+        "correct": true,
+        "predicted": "{\"latency_ms\":8597,\"level\":\"ERROR\",\"service\":\"billing\",\"status\":400,\"tenant\":\"t-7618\"}",
+        "expected": "{\"latency_ms\":8597,\"level\":\"ERROR\",\"service\":\"billing\",\"status\":400,\"tenant\":\"t-7618\"}",
+        "latency_ms": 30112.243,
+        "output_tokens": 970,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0031",
+        "correct": true,
+        "predicted": "{\"latency_ms\":1804,\"level\":\"WARN\",\"service\":\"payments\",\"status\":500,\"tenant\":\"t-9922\"}",
+        "expected": "{\"latency_ms\":1804,\"level\":\"WARN\",\"service\":\"payments\",\"status\":500,\"tenant\":\"t-9922\"}",
+        "latency_ms": 34578.147,
+        "output_tokens": 1144,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0032",
+        "correct": true,
+        "predicted": "{\"latency_ms\":7083,\"level\":\"WARN\",\"service\":\"notify\",\"status\":500,\"tenant\":\"t-8774\"}",
+        "expected": "{\"latency_ms\":7083,\"level\":\"WARN\",\"service\":\"notify\",\"status\":500,\"tenant\":\"t-8774\"}",
+        "latency_ms": 35520.362,
+        "output_tokens": 1187,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0033",
+        "correct": true,
+        "predicted": "{\"latency_ms\":4504,\"level\":\"INFO\",\"service\":\"search\",\"status\":429,\"tenant\":\"t-2998\"}",
+        "expected": "{\"latency_ms\":4504,\"level\":\"INFO\",\"service\":\"search\",\"status\":429,\"tenant\":\"t-2998\"}",
+        "latency_ms": 31889.815,
+        "output_tokens": 1036,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0034",
+        "correct": true,
+        "predicted": "{\"latency_ms\":2395,\"level\":\"WARN\",\"service\":\"billing\",\"status\":401,\"tenant\":\"t-9000\"}",
+        "expected": "{\"latency_ms\":2395,\"level\":\"WARN\",\"service\":\"billing\",\"status\":401,\"tenant\":\"t-9000\"}",
+        "latency_ms": 36407.797,
+        "output_tokens": 1183,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0035",
+        "correct": true,
+        "predicted": "{\"latency_ms\":6641,\"level\":\"DEBUG\",\"service\":\"payments\",\"status\":429,\"tenant\":\"t-9435\"}",
+        "expected": "{\"latency_ms\":6641,\"level\":\"DEBUG\",\"service\":\"payments\",\"status\":429,\"tenant\":\"t-9435\"}",
+        "latency_ms": 46079.44,
+        "output_tokens": 1492,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0036",
+        "correct": true,
+        "predicted": "{\"latency_ms\":3628,\"level\":\"ERROR\",\"service\":\"notify\",\"status\":400,\"tenant\":\"t-7170\"}",
+        "expected": "{\"latency_ms\":3628,\"level\":\"ERROR\",\"service\":\"notify\",\"status\":400,\"tenant\":\"t-7170\"}",
+        "latency_ms": 36696.043,
+        "output_tokens": 1199,
+        "category": "extraction",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0037",
+        "correct": false,
+        "predicted": "{\"depth\":266,\"level\":\"high\",\"service\":\"search service\"}",
+        "expected": "{\"depth\":266,\"level\":\"high\",\"service\":\"search\"}",
+        "latency_ms": 29073.28,
+        "output_tokens": 933,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0038",
+        "correct": true,
+        "predicted": "{\"depth\":302,\"level\":\"high\",\"service\":\"notify\"}",
+        "expected": "{\"depth\":302,\"level\":\"high\",\"service\":\"notify\"}",
+        "latency_ms": 33281.859,
+        "output_tokens": 1046,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0039",
+        "correct": false,
+        "predicted": "{\"depth\":320,\"level\":\"high\",\"service\":\"payments service\"}",
+        "expected": "{\"depth\":320,\"level\":\"high\",\"service\":\"payments\"}",
+        "latency_ms": 39333.763,
+        "output_tokens": 1261,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0040",
+        "correct": false,
+        "predicted": "{\"depth\":355,\"level\":\"high\",\"service\":\"media service\"}",
+        "expected": "{\"depth\":355,\"level\":\"high\",\"service\":\"media\"}",
+        "latency_ms": 29050.385,
+        "output_tokens": 934,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0041",
+        "correct": false,
+        "predicted": "{\"depth\":30,\"level\":\"high\",\"service\":\"notify\"}",
+        "expected": "{\"depth\":30,\"level\":\"low\",\"service\":\"notify\"}",
+        "latency_ms": 46822.513,
+        "output_tokens": 1455,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0042",
+        "correct": false,
+        "predicted": "{\"depth\":171,\"level\":\"low\",\"service\":\"media service\"}",
+        "expected": "{\"depth\":171,\"level\":\"low\",\"service\":\"media\"}",
+        "latency_ms": 35794.513,
+        "output_tokens": 1158,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0043",
+        "correct": false,
+        "predicted": "{\"depth\":257,\"level\":\"high\",\"service\":\"payments service\"}",
+        "expected": "{\"depth\":257,\"level\":\"high\",\"service\":\"payments\"}",
+        "latency_ms": 23150.684,
+        "output_tokens": 764,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0044",
+        "correct": false,
+        "predicted": "{\"depth\":63,\"level\":\"low\",\"service\":\"notify service\"}",
+        "expected": "{\"depth\":63,\"level\":\"low\",\"service\":\"notify\"}",
+        "latency_ms": 37010.225,
+        "output_tokens": 1166,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0045",
+        "correct": false,
+        "predicted": "{\"depth\":60,\"level\":\"low\",\"service\":\"search service\"}",
+        "expected": "{\"depth\":60,\"level\":\"low\",\"service\":\"search\"}",
+        "latency_ms": 22065.701,
+        "output_tokens": 698,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0046",
+        "correct": false,
+        "predicted": "{\"depth\":20,\"level\":\"low\",\"service\":\"billing service\"}",
+        "expected": "{\"depth\":20,\"level\":\"low\",\"service\":\"billing\"}",
+        "latency_ms": 20709.007,
+        "output_tokens": 647,
+        "category": "classification",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0047",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"cancel\"}",
+        "expected": "{\"confident\":true,\"intent\":\"cancel\"}",
+        "latency_ms": 8337.069,
+        "output_tokens": 256,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0048",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"track\"}",
+        "expected": "{\"confident\":true,\"intent\":\"track\"}",
+        "latency_ms": 10147.247,
+        "output_tokens": 294,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0049",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"billing\"}",
+        "expected": "{\"confident\":true,\"intent\":\"billing\"}",
+        "latency_ms": 16383.554,
+        "output_tokens": 495,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0050",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"reschedule\"}",
+        "expected": "{\"confident\":true,\"intent\":\"reschedule\"}",
+        "latency_ms": 10869.327,
+        "output_tokens": 331,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0051",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"close_account\"}",
+        "expected": "{\"confident\":true,\"intent\":\"close_account\"}",
+        "latency_ms": 11012.277,
+        "output_tokens": 343,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0052",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"return\"}",
+        "expected": "{\"confident\":true,\"intent\":\"return\"}",
+        "latency_ms": 10094.829,
+        "output_tokens": 295,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0053",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"cancel\"}",
+        "expected": "{\"confident\":true,\"intent\":\"cancel\"}",
+        "latency_ms": 14178.946,
+        "output_tokens": 429,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0054",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"track\"}",
+        "expected": "{\"confident\":true,\"intent\":\"track\"}",
+        "latency_ms": 10064.235,
+        "output_tokens": 310,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0055",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"billing\"}",
+        "expected": "{\"confident\":true,\"intent\":\"billing\"}",
+        "latency_ms": 10737.98,
+        "output_tokens": 315,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0056",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"reschedule\"}",
+        "expected": "{\"confident\":true,\"intent\":\"reschedule\"}",
+        "latency_ms": 11310.135,
+        "output_tokens": 341,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0057",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"close_account\"}",
+        "expected": "{\"confident\":true,\"intent\":\"close_account\"}",
+        "latency_ms": 19273.597,
+        "output_tokens": 581,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0058",
+        "correct": true,
+        "predicted": "{\"confident\":true,\"intent\":\"return\"}",
+        "expected": "{\"confident\":true,\"intent\":\"return\"}",
+        "latency_ms": 23354.466,
+        "output_tokens": 716,
+        "category": "classification",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0059",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-730\",\"item_count\":9,\"ship_to\":\"Valcrest\"},\"user\":{\"id\":8899,\"name\":\"Priya Alder\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-730\",\"item_count\":9,\"ship_to\":\"Valcrest\"},\"user\":{\"id\":8899,\"name\":\"Priya Alder\"}}",
+        "latency_ms": 34213.87,
+        "output_tokens": 1104,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0060",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-830\",\"item_count\":9,\"ship_to\":\"Threeford\"},\"user\":{\"id\":3305,\"name\":\"Fenna Fairbank\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-830\",\"item_count\":9,\"ship_to\":\"Threeford\"},\"user\":{\"id\":3305,\"name\":\"Fenna Fairbank\"}}",
+        "latency_ms": 34160.757,
+        "output_tokens": 1100,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0061",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-990\",\"item_count\":2,\"ship_to\":\"Threeford\"},\"user\":{\"id\":1173,\"name\":\"Bo Ellery\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-990\",\"item_count\":2,\"ship_to\":\"Threeford\"},\"user\":{\"id\":1173,\"name\":\"Bo Ellery\"}}",
+        "latency_ms": 39474.412,
+        "output_tokens": 1251,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0062",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-833\",\"item_count\":8,\"ship_to\":\"Threeford\"},\"user\":{\"id\":7315,\"name\":\"Emre Ivers\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-833\",\"item_count\":8,\"ship_to\":\"Threeford\"},\"user\":{\"id\":7315,\"name\":\"Emre Ivers\"}}",
+        "latency_ms": 35243.389,
+        "output_tokens": 1142,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0063",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-574\",\"item_count\":3,\"ship_to\":\"Threeford\"},\"user\":{\"id\":1379,\"name\":\"Mira Keswick\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-574\",\"item_count\":3,\"ship_to\":\"Threeford\"},\"user\":{\"id\":1379,\"name\":\"Mira Keswick\"}}",
+        "latency_ms": 46672.612,
+        "output_tokens": 1513,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0064",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-462\",\"item_count\":2,\"ship_to\":\"Kesswater\"},\"user\":{\"id\":1731,\"name\":\"Bo Corvin\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-462\",\"item_count\":2,\"ship_to\":\"Kesswater\"},\"user\":{\"id\":1731,\"name\":\"Bo Corvin\"}}",
+        "latency_ms": 44332.949,
+        "output_tokens": 1424,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0065",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-220\",\"item_count\":9,\"ship_to\":\"Valcrest\"},\"user\":{\"id\":7418,\"name\":\"Bo Ellery\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-220\",\"item_count\":9,\"ship_to\":\"Valcrest\"},\"user\":{\"id\":7418,\"name\":\"Bo Ellery\"}}",
+        "latency_ms": 51801.566,
+        "output_tokens": 1675,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0066",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-855\",\"item_count\":2,\"ship_to\":\"Threeford\"},\"user\":{\"id\":3038,\"name\":\"Bo Gale\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-855\",\"item_count\":2,\"ship_to\":\"Threeford\"},\"user\":{\"id\":3038,\"name\":\"Bo Gale\"}}",
+        "latency_ms": 28774.931,
+        "output_tokens": 918,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0067",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-357\",\"item_count\":8,\"ship_to\":\"Dunhallow\"},\"user\":{\"id\":1558,\"name\":\"Hana Lund\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-357\",\"item_count\":8,\"ship_to\":\"Dunhallow\"},\"user\":{\"id\":1558,\"name\":\"Hana Lund\"}}",
+        "latency_ms": 47401.888,
+        "output_tokens": 1508,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0068",
+        "correct": true,
+        "predicted": "{\"order\":{\"id\":\"ORD-743\",\"item_count\":7,\"ship_to\":\"Kesswater\"},\"user\":{\"id\":4894,\"name\":\"Lars Ellery\"}}",
+        "expected": "{\"order\":{\"id\":\"ORD-743\",\"item_count\":7,\"ship_to\":\"Kesswater\"},\"user\":{\"id\":4894,\"name\":\"Lars Ellery\"}}",
+        "latency_ms": 39511.085,
+        "output_tokens": 1269,
+        "category": "nested",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0069",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-3547\",\"t-4456\",\"t-7824\",\"t-8174\",\"t-4279\",\"t-7816\"]}",
+        "expected": "{\"tenants\":[\"t-3547\",\"t-4456\",\"t-7824\",\"t-8174\",\"t-4279\",\"t-7816\"]}",
+        "latency_ms": 30378.96,
+        "output_tokens": 990,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0070",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-7567\",\"t-7968\",\"t-8928\",\"t-7983\"]}",
+        "expected": "{\"tenants\":[\"t-7567\",\"t-7968\",\"t-8928\",\"t-7983\"]}",
+        "latency_ms": 14584.121,
+        "output_tokens": 461,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0071",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-1022\",\"t-6879\",\"t-2365\",\"t-6799\"]}",
+        "expected": "{\"tenants\":[\"t-1022\",\"t-6879\",\"t-2365\",\"t-6799\"]}",
+        "latency_ms": 13316.158,
+        "output_tokens": 424,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0072",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-2838\",\"t-4070\",\"t-8165\",\"t-3012\"]}",
+        "expected": "{\"tenants\":[\"t-2838\",\"t-4070\",\"t-8165\",\"t-3012\"]}",
+        "latency_ms": 13426.186,
+        "output_tokens": 425,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0073",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-3759\",\"t-4899\",\"t-1657\",\"t-2263\"]}",
+        "expected": "{\"tenants\":[\"t-3759\",\"t-4899\",\"t-1657\",\"t-2263\"]}",
+        "latency_ms": 26514.263,
+        "output_tokens": 864,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0074",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-6700\",\"t-3630\",\"t-3979\"]}",
+        "expected": "{\"tenants\":[\"t-6700\",\"t-3630\",\"t-3979\"]}",
+        "latency_ms": 12434.826,
+        "output_tokens": 399,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0075",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-8440\",\"t-4890\",\"t-3932\",\"t-5058\",\"t-9497\",\"t-6146\"]}",
+        "expected": "{\"tenants\":[\"t-8440\",\"t-4890\",\"t-3932\",\"t-5058\",\"t-9497\",\"t-6146\"]}",
+        "latency_ms": 34614.833,
+        "output_tokens": 1123,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0076",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-8659\",\"t-6014\",\"t-6867\",\"t-8175\",\"t-9729\"]}",
+        "expected": "{\"tenants\":[\"t-8659\",\"t-6014\",\"t-6867\",\"t-8175\",\"t-9729\"]}",
+        "latency_ms": 14222.353,
+        "output_tokens": 464,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0077",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-7083\",\"t-6458\",\"t-6179\"]}",
+        "expected": "{\"tenants\":[\"t-7083\",\"t-6458\",\"t-6179\"]}",
+        "latency_ms": 21506.194,
+        "output_tokens": 682,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0078",
+        "correct": true,
+        "predicted": "{\"tenants\":[\"t-7886\",\"t-2715\",\"t-8504\",\"t-4462\",\"t-1039\"]}",
+        "expected": "{\"tenants\":[\"t-7886\",\"t-2715\",\"t-8504\",\"t-4462\",\"t-1039\"]}",
+        "latency_ms": 24895.237,
+        "output_tokens": 786,
+        "category": "arrays",
+        "difficulty": "easy"
+      },
+      {
+        "id": "json-0079",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":26,\"name\":\"Nadia Ivers\"},{\"age\":56,\"name\":\"Lars Corvin\"},{\"age\":34,\"name\":\"Juno Keswick\"}]}",
+        "expected": "{\"people\":[{\"age\":26,\"name\":\"Nadia Ivers\"},{\"age\":56,\"name\":\"Lars Corvin\"},{\"age\":34,\"name\":\"Juno Keswick\"}]}",
+        "latency_ms": 33968.568,
+        "output_tokens": 1085,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0080",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":53,\"name\":\"Tomas Lund\"},{\"age\":51,\"name\":\"Lars Ivers\"},{\"age\":27,\"name\":\"Cai Braith\"}]}",
+        "expected": "{\"people\":[{\"age\":53,\"name\":\"Tomas Lund\"},{\"age\":51,\"name\":\"Lars Ivers\"},{\"age\":27,\"name\":\"Cai Braith\"}]}",
+        "latency_ms": 29156.868,
+        "output_tokens": 943,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0081",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":28,\"name\":\"Bo Jarrow\"},{\"age\":21,\"name\":\"Cai Braith\"},{\"age\":41,\"name\":\"Rafael Dunmore\"}]}",
+        "expected": "{\"people\":[{\"age\":28,\"name\":\"Bo Jarrow\"},{\"age\":21,\"name\":\"Cai Braith\"},{\"age\":41,\"name\":\"Rafael Dunmore\"}]}",
+        "latency_ms": 39505.806,
+        "output_tokens": 1256,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0082",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":52,\"name\":\"Mira Holt\"},{\"age\":51,\"name\":\"Cai Corvin\"},{\"age\":49,\"name\":\"Dana Keswick\"}]}",
+        "expected": "{\"people\":[{\"age\":52,\"name\":\"Mira Holt\"},{\"age\":51,\"name\":\"Cai Corvin\"},{\"age\":49,\"name\":\"Dana Keswick\"}]}",
+        "latency_ms": 35679.073,
+        "output_tokens": 1156,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0083",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":33,\"name\":\"Ines Corvin\"},{\"age\":29,\"name\":\"Hana Corvin\"},{\"age\":43,\"name\":\"Mira Corvin\"}]}",
+        "expected": "{\"people\":[{\"age\":33,\"name\":\"Ines Corvin\"},{\"age\":29,\"name\":\"Hana Corvin\"},{\"age\":43,\"name\":\"Mira Corvin\"}]}",
+        "latency_ms": 44346.104,
+        "output_tokens": 1439,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0084",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":31,\"name\":\"Ines Ivers\"},{\"age\":32,\"name\":\"Nadia Ellery\"},{\"age\":63,\"name\":\"Fenna Fairbank\"}]}",
+        "expected": "{\"people\":[{\"age\":31,\"name\":\"Ines Ivers\"},{\"age\":32,\"name\":\"Nadia Ellery\"},{\"age\":63,\"name\":\"Fenna Fairbank\"}]}",
+        "latency_ms": 37839.475,
+        "output_tokens": 1213,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0085",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":51,\"name\":\"Tomas Braith\"},{\"age\":22,\"name\":\"Bo Jarrow\"},{\"age\":46,\"name\":\"Fenna Fairbank\"}]}",
+        "expected": "{\"people\":[{\"age\":51,\"name\":\"Tomas Braith\"},{\"age\":22,\"name\":\"Bo Jarrow\"},{\"age\":46,\"name\":\"Fenna Fairbank\"}]}",
+        "latency_ms": 32101.043,
+        "output_tokens": 1025,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0086",
+        "correct": true,
+        "predicted": "{\"people\":[{\"age\":55,\"name\":\"Cai Lund\"},{\"age\":63,\"name\":\"Emre Holt\"},{\"age\":39,\"name\":\"Mira Fairbank\"}]}",
+        "expected": "{\"people\":[{\"age\":55,\"name\":\"Cai Lund\"},{\"age\":63,\"name\":\"Emre Holt\"},{\"age\":39,\"name\":\"Mira Fairbank\"}]}",
+        "latency_ms": 38190.543,
+        "output_tokens": 1224,
+        "category": "arrays",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0087",
+        "correct": true,
+        "predicted": "{\"count\":4,\"max\":304,\"min\":58,\"total\":723}",
+        "expected": "{\"count\":4,\"max\":304,\"min\":58,\"total\":723}",
+        "latency_ms": 46390.221,
+        "output_tokens": 1492,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0088",
+        "correct": true,
+        "predicted": "{\"count\":3,\"max\":298,\"min\":86,\"total\":651}",
+        "expected": "{\"count\":3,\"max\":298,\"min\":86,\"total\":651}",
+        "latency_ms": 43833.544,
+        "output_tokens": 1400,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0089",
+        "correct": true,
+        "predicted": "{\"count\":6,\"max\":327,\"min\":89,\"total\":1519}",
+        "expected": "{\"count\":6,\"max\":327,\"min\":89,\"total\":1519}",
+        "latency_ms": 40024.649,
+        "output_tokens": 1313,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0090",
+        "correct": true,
+        "predicted": "{\"count\":5,\"max\":211,\"min\":29,\"total\":560}",
+        "expected": "{\"count\":5,\"max\":211,\"min\":29,\"total\":560}",
+        "latency_ms": 31722.887,
+        "output_tokens": 1023,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0091",
+        "correct": true,
+        "predicted": "{\"count\":4,\"max\":374,\"min\":63,\"total\":907}",
+        "expected": "{\"count\":4,\"max\":374,\"min\":63,\"total\":907}",
+        "latency_ms": 29915.101,
+        "output_tokens": 957,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0092",
+        "correct": true,
+        "predicted": "{\"count\":5,\"max\":331,\"min\":22,\"total\":756}",
+        "expected": "{\"count\":5,\"max\":331,\"min\":22,\"total\":756}",
+        "latency_ms": 35867.736,
+        "output_tokens": 1159,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0093",
+        "correct": true,
+        "predicted": "{\"count\":3,\"max\":397,\"min\":354,\"total\":1135}",
+        "expected": "{\"count\":3,\"max\":397,\"min\":354,\"total\":1135}",
+        "latency_ms": 39399.364,
+        "output_tokens": 1259,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0094",
+        "correct": true,
+        "predicted": "{\"count\":4,\"max\":334,\"min\":63,\"total\":741}",
+        "expected": "{\"count\":4,\"max\":334,\"min\":63,\"total\":741}",
+        "latency_ms": 56904.832,
+        "output_tokens": 1834,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0095",
+        "correct": true,
+        "predicted": "{\"count\":6,\"max\":380,\"min\":130,\"total\":1638}",
+        "expected": "{\"count\":6,\"max\":380,\"min\":130,\"total\":1638}",
+        "latency_ms": 32322.011,
+        "output_tokens": 1038,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0096",
+        "correct": true,
+        "predicted": "{\"count\":5,\"max\":359,\"min\":30,\"total\":1122}",
+        "expected": "{\"count\":5,\"max\":359,\"min\":30,\"total\":1122}",
+        "latency_ms": 38198.865,
+        "output_tokens": 1248,
+        "category": "aggregation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0097",
+        "correct": true,
+        "predicted": "{\"date\":\"2019-05-13\",\"weekday_known\":false}",
+        "expected": "{\"date\":\"2019-05-13\",\"weekday_known\":false}",
+        "latency_ms": 26174.205,
+        "output_tokens": 842,
+        "category": "normalisation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0098",
+        "correct": true,
+        "predicted": "{\"date\":\"2025-03-15\",\"weekday_known\":false}",
+        "expected": "{\"date\":\"2025-03-15\",\"weekday_known\":false}",
+        "latency_ms": 9503.0,
+        "output_tokens": 296,
+        "category": "normalisation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0099",
+        "correct": true,
+        "predicted": "{\"date\":\"2019-06-10\",\"weekday_known\":false}",
+        "expected": "{\"date\":\"2019-06-10\",\"weekday_known\":false}",
+        "latency_ms": 9682.18,
+        "output_tokens": 301,
+        "category": "normalisation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0100",
+        "correct": true,
+        "predicted": "{\"date\":\"2023-11-15\",\"weekday_known\":false}",
+        "expected": "{\"date\":\"2023-11-15\",\"weekday_known\":false}",
+        "latency_ms": 26796.742,
+        "output_tokens": 856,
+        "category": "normalisation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0101",
+        "correct": true,
+        "predicted": "{\"date\":\"2030-04-05\",\"weekday_known\":false}",
+        "expected": "{\"date\":\"2030-04-05\",\"weekday_known\":false}",
+        "latency_ms": 20031.531,
+        "output_tokens": 650,
+        "category": "normalisation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0102",
+        "correct": true,
+        "predicted": "{\"date\":\"2029-04-04\",\"weekday_known\":false}",
+        "expected": "{\"date\":\"2029-04-04\",\"weekday_known\":false}",
+        "latency_ms": 22832.847,
+        "output_tokens": 744,
+        "category": "normalisation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0103",
+        "correct": true,
+        "predicted": "{\"enabled\":true,\"region\":\"eu-west\",\"retries\":1}",
+        "expected": "{\"enabled\":true,\"region\":\"eu-west\",\"retries\":1}",
+        "latency_ms": 29619.285,
+        "output_tokens": 948,
+        "category": "transformation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0104",
+        "correct": true,
+        "predicted": "{\"enabled\":true,\"region\":\"eu-central\",\"retries\":5}",
+        "expected": "{\"enabled\":true,\"region\":\"eu-central\",\"retries\":5}",
+        "latency_ms": 27200.252,
+        "output_tokens": 846,
+        "category": "transformation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0105",
+        "correct": true,
+        "predicted": "{\"enabled\":true,\"region\":\"eu-west\",\"retries\":0}",
+        "expected": "{\"enabled\":true,\"region\":\"eu-west\",\"retries\":0}",
+        "latency_ms": 29418.276,
+        "output_tokens": 932,
+        "category": "transformation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0106",
+        "correct": true,
+        "predicted": "{\"enabled\":false,\"region\":\"eu-central\",\"retries\":1}",
+        "expected": "{\"enabled\":false,\"region\":\"eu-central\",\"retries\":1}",
+        "latency_ms": 29599.644,
+        "output_tokens": 931,
+        "category": "transformation",
+        "difficulty": "medium"
+      },
+      {
+        "id": "json-0107",
+        "correct": true,
+        "predicted": "{\"name\":\"Cai Holt\",\"phone\":null}",
+        "expected": "{\"name\":\"Cai Holt\",\"phone\":null}",
+        "latency_ms": 11254.524,
+        "output_tokens": 347,
+        "category": "extraction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0108",
+        "correct": true,
+        "predicted": "{\"name\":\"Tomas Jarrow\",\"phone\":null}",
+        "expected": "{\"name\":\"Tomas Jarrow\",\"phone\":null}",
+        "latency_ms": 11537.755,
+        "output_tokens": 366,
+        "category": "extraction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0109",
+        "correct": true,
+        "predicted": "{\"name\":\"Hana Fairbank\",\"phone\":null}",
+        "expected": "{\"name\":\"Hana Fairbank\",\"phone\":null}",
+        "latency_ms": 10638.456,
+        "output_tokens": 369,
+        "category": "extraction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "json-0110",
+        "correct": true,
+        "predicted": "{\"name\":\"Cai Ivers\",\"phone\":null}",
+        "expected": "{\"name\":\"Cai Ivers\",\"phone\":null}",
+        "latency_ms": 13821.08,
+        "output_tokens": 698,
+        "category": "extraction",
+        "difficulty": "hard"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [
+    {
+      "severity": "info",
+      "text": "GPU CLOCK IS A HIDDEN VARIABLE ON THIS BOX AND IT IS NOT AT MAXIMUM. Sampled at workload start: 2405MHz,3003MHz. nvidia-smi reports no active clock event reason - no SW power cap, no HW slowdown, no thermal slowdown, no applications-clock setting - and the clock cannot be raised without root, which this account does not have. Under load the SM clock sits around 2470-2490 MHz against a 3003 MHz ceiling, roughly 82 percent. On this model the effect is small: the author's own TTFT benchmark reproduced to within 4 percent. On a much larger model measured on the same box the same day the gap to the author's published decode figure was about 11 percent. Treat any comparison against a figure from another Spark as carrying this unknown unless that box's clock state is also stated."
+    },
+    {
+      "severity": "info",
+      "text": "Quantization is mixed, not uniform NVFP4, and the registry bits figure reflects that. Read out of the shard headers: routed experts are NVFP4 (packed U8 values with per-block F8_E4M3 scales and F32 global scales, 7830 of each per shard), attention is F8_E4M3 with BF16, and the router, gates and norms stay BF16. The router in particular is full precision because a routing error is discrete - a different set of experts fires - rather than a small numeric one. The pack is 6.06 bits per parameter overall, not 4."
+    },
+    {
+      "severity": "info",
+      "text": "Speculative decoding is the model's own MTP head at 2 tokens with moe_backend triton, and the linear backend is flashinfer_b12x with a soft fallback to auto for layers that are not NVFP4. Both are the recipe's defaults, both change decode throughput, and neither is comparable with a cell run without them."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "739135bb073a352b38310c35bffd07fdafa5666aea5b4c8b3fd1e0ef96bdafb3",
+    "payload_path": null,
+    "payload": {
+      "scorer": "json",
+      "scorers_used": [
+        "json"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8888/v1",
+        "served_model_id": "Qwen/Qwen3.6-35B-A3B-FP8",
+        "advertised_models": [
+          "Qwen/Qwen3.6-35B-A3B-FP8"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-31T09:15:43Z",
+    "finished_at": "2026-08-31T09:29:10Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Box was dedicated: no desktop session, no other GPU work, and the reverse-proxy SSH tunnel that is the only external route in was stopped for the whole sweep. NVIDIA DGX Spark (ASUS Ascent GX10, GB10 / SM121, 128 GB unified, ~121 GiB usable), Ubuntu 24.04.4, kernel 6.17.0-1029-nvidia aarch64, driver 580.173.02, CUDA 13.0, swap off. Server is the published recipe at github.com/MiaAI-Lab/Unsloth-Qwen3.6-35b-NVFP4-DGX-Spark run unmodified via its own start.sh: image ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x:latest, which reports vLLM 0.26.1.dev0+gf2654939e.d20260726 and is built on timothystewart6/vllm-gb10 for ARM64/SM121. Weights are unsloth/Qwen3.6-35B-A3B-NVFP4 at revision 739af1e, 19 files, 26.53 GB. Reproduction check before measuring: the recipe author reports 103 ms TTFT at concurrency 1, and his own bench_ttft.py on this box gave a mean of 107 ms over 8 runs (P95 108 ms), so this is his configuration behaving as published rather than a re-tuned one."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}


### PR DESCRIPTION
### Cells filled

- **Engine** — `vllm` `0.26.1.dev0+gf2654939e.d20260726`
- **Model / quant** — `Qwen/Qwen3.6-35B-A3B` / `fp8`
- **Hardware** — `nvidia-gb10-dgx-spark` x1
- **Workload** — `eval-json-v1` (eval)
- **Headline** — accuracy **0.918**, success 1.000

One file: `results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--eval-json-v1--2911f0.json`

### What failed

Nothing failed. 110/110 requests returned, success rate 1.000.

### Gotchas

- **info** — GPU CLOCK IS A HIDDEN VARIABLE ON THIS BOX AND IT IS NOT AT MAXIMUM.
- **info** — Quantization is mixed, not uniform NVFP4, and the registry bits figure reflects that.
- **info** — Speculative decoding is the model's own MTP head at 2 tokens with moe_backend triton, and the linear backend is flashinfer_b12x with a soft fallback to auto for layers that are not NVFP4.

### Conditions

Dedicated box, nothing else resident on the GPU, no compile running. The one route into this machine from elsewhere on its private network is an SSH tunnel from a reverse proxy; it was stopped before the first run and stayed stopped. The harness talks to loopback with no proxy in the measured path.

n-gram table page-cache residency, `mincore(2)`: **2457% before the workload, MHz% after**.

| | |
|---|---:|
| peak host RAM | 107.6 GB |
| average GPU utilisation | 95.4 % |
| average / peak power | 38.1 / 39.4 W |
| max temperature | 67 C |
| thermal throttling | not detected |
| wall clock | 806.6 s |

`pnpm validate` — 0 errors. Read `gpu_util_avg_pct` with the caveat in the gotchas: it is a mean over the whole workload window including ramp-up and drain, not a steady-state figure.
