### PR TITLE
Registry: NVIDIA's own NVFP4 pack of Qwen3.6-35B-A3B

### DIFF
--- a/models/Qwen/Qwen3.6-35B-A3B/quants/nvfp4-modelopt.json
+++ b/models/Qwen/Qwen3.6-35B-A3B/quants/nvfp4-modelopt.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "nvfp4-modelopt",
+  "model_id": "Qwen/Qwen3.6-35B-A3B",
+  "format": "nvfp4",
+  "bits": 5.36,
+  "hf_id": "nvidia/Qwen3.6-35B-A3B-NVFP4",
+  "revision": "1355db6a052410cfd62085d94b58866fd0f2c3c5",
+  "size_gb": 23.46,
+  "engines": [
+    "vllm"
+  ],
+  "source": "official",
+  "calibration": null,
+  "links": {
+    "hf": "https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4",
+    "recipe": "https://github.com/NVIDIA/dgx-spark-playbooks/tree/main/nvidia/vllm"
+  },
+  "notes": "NVIDIA's own NVFP4 pack of this model, kept separate from the community `nvfp4` entry so the two packers can be compared with everything else held constant. Declared as quant_method modelopt with quant_algo MIXED_PRECISION, 291 quantized layers and 2 ignored, against the community pack's mixed FP8-dense/NVFP4-expert layout. bits 5.36 is the artefact on disk measured against the vendor's 35B parameter count (23,462,482,761 bytes x 8 / 35e9), not a per-tensor figure; it sits below the community pack's 6.06 and the 23.46 GB against 26.53 GB is the same difference seen from the other side. 17 files, 3 shards, 124,468 tensors - more tensors than the 8-bit pack because NVFP4 splits every quantized weight into packed values plus block scales plus a global scale. The MTP draft head and the vision tower are both present and complete: 333 visual tensors, and an mtp block that looks smaller than the FP8 pack's only because the 256 routed experts are stored as two stacked tensors (mtp.layers.0.mlp.experts.gate_up_proj and .down_proj) instead of 256 separate ones per projection. calibration is null because the card states none. Only vllm is listed: this pack needs an engine with NVFP4 kernels for SM121."
+}


### PR DESCRIPTION
Third rung of the ladder, and the one that isolates the **packer**: same model, same box, same engine build, same serve flags as the community NVFP4 rung — only who did the quantization changes.

It gets its own quant id rather than sharing `nvfp4`. Two packs a reader would otherwise read as repeats of one configuration is the same collision the `engine.build` rule was written to stop, one level up.

Read out of the checkpoint, not the card:

| | community `nvfp4` | this `nvfp4-modelopt` |
|---|---|---|
| packer | unsloth | `quant_method: modelopt`, `quant_algo: MIXED_PRECISION` |
| source | community | official |
| on disk | 26.53 GB, 19 files | 23.46 GB, 17 files, 3 shards |
| bits | 6.06 | **5.36** |
| tensors | — | 124,468 |
| quantized layers | — | 291 (2 ignored) |

More tensors than the 8-bit pack, because NVFP4 splits every quantized weight into packed values + block scales + a global scale.

**On the MTP head — worth stating, because it nearly went in wrong.** The `mtp` block has **19** tensors here against **1,560** in the FP8 pack. That reads like a truncated draft head. It is not: listing the keys shows the 256 routed experts stored as two stacked tensors (`mtp.layers.0.mlp.experts.gate_up_proj`, `.down_proj`) where the FP8 pack stores 256 separate tensors per projection, each with its own scale. Nothing is missing — the layout differs. Vision is 333 tensors in both.

So all three rungs are comparable on capability, not just on flags.
