### PR TITLE
Count this model's parameters instead of taking the headline

### DIFF
--- a/models/Qwen/Qwen3.6-35B-A3B/model.json
+++ b/models/Qwen/Qwen3.6-35B-A3B/model.json
@@ -5,7 +5,7 @@
   "hf_id": "Qwen/Qwen3.6-35B-A3B",
   "family": "qwen3.6",
   "vendor": "alibaba",
-  "params_b": 35.0,
+  "params_b": 35.952,
   "active_params_b": 3.0,
   "architecture": "qwen3_5_moe",
   "moe": true,

--- a/models/Qwen/Qwen3.6-35B-A3B/quants/bf16.json
+++ b/models/Qwen/Qwen3.6-35B-A3B/quants/bf16.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "bf16",
+  "model_id": "Qwen/Qwen3.6-35B-A3B",
+  "format": "bf16",
+  "bits": 16.01,
+  "hf_id": "Qwen/Qwen3.6-35B-A3B",
+  "revision": "995ad96eacd98c81ed38be0c5b274b04031597b0",
+  "size_gb": 71.93,
+  "engines": [
+    "vllm"
+  ],
+  "source": "official",
+  "calibration": null,
+  "links": {
+    "hf": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B"
+  },
+  "notes": "The unquantized release, and the reference the other three packs of this model are measured against. 71,926,880,711 bytes, 26 shards, 1,045 tensors, no quantization_config. bits 16.01 (71,926,880,711 x 8 / 35.952e9) is what makes this entry worth reading: a BF16 pack must land at 16 bits per parameter, and it only does so against the counted parameter total. Against the vendor's rounded 35B headline it would read 16.44, which no BF16 artefact can be - that is the check that established the divisor for every quant of this model. The stacked routed-expert layout (mtp.layers.0.mlp.experts.gate_up_proj and .down_proj as single tensors) is upstream's own here, so it is the FP8 pack that departs from it by splitting the 256 experts into separate tensors to carry a block scale each. MTP draft head 0.845B parameters, vision tower 0.447B, main body 34.661B. Only vllm is listed because that is what has been tried; vLLM's own recipes page puts BF16 of this model on 1x H200 or 2x H100, and no published single-Spark BF16 recipe was found, so whether one GB10 serves it is the open question this entry exists to answer."
+}

--- a/models/Qwen/Qwen3.6-35B-A3B/quants/fp8.json
+++ b/models/Qwen/Qwen3.6-35B-A3B/quants/fp8.json
@@ -3,7 +3,7 @@
   "id": "fp8",
   "model_id": "Qwen/Qwen3.6-35B-A3B",
   "format": "fp8",
-  "bits": 8.57,
+  "bits": 8.34,
   "hf_id": "Qwen/Qwen3.6-35B-A3B-FP8",
   "revision": "95a723d08a9490559dae23d0cff1d9466213d989",
   "size_gb": 37.5,
@@ -15,5 +15,5 @@
   "links": {
     "hf": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8"
   },
-  "notes": "First-party FP8 release from Qwen. quantization_config read out of the served checkpoint: quant_method fp8, fmt e4m3, activation_scheme dynamic, with a modules_to_not_convert list that keeps parts of the vision tower unquantized. 42 shards, 64,196 tensors, of which 1,560 are the NextN/MTP draft head and 333 the vision tower - both kept, so this pack supports the same speculative decoding and image input as the NVFP4 pack of the same model. bits 8.57 is the artefact measured against the vendor's 35B parameter count (37.5e9 x 8 / 35e9); it sits above 8 because the unconverted modules and the scales are wider than the fp8 body. calibration is null because the card states none and activation scaling is dynamic rather than calibrated."
+  "notes": "First-party FP8 release from Qwen. quantization_config read out of the served checkpoint: quant_method fp8, fmt e4m3, activation_scheme dynamic, with a modules_to_not_convert list that keeps parts of the vision tower unquantized. 42 shards, 64,196 tensors, of which 1,560 are the NextN/MTP draft head and 333 the vision tower - both kept, so this pack supports the same speculative decoding and image input as the NVFP4 pack of the same model. bits 8.34 is the artefact measured against the counted parameter total of 35.952B (37,493,037,107 bytes x 8 / 35.952e9); it sits above 8 because the unconverted modules and the scales are wider than the fp8 body. calibration is null because the card states none and activation scaling is dynamic rather than calibrated."
 }

--- a/models/Qwen/Qwen3.6-35B-A3B/quants/nvfp4-modelopt.json
+++ b/models/Qwen/Qwen3.6-35B-A3B/quants/nvfp4-modelopt.json
@@ -3,7 +3,7 @@
   "id": "nvfp4-modelopt",
   "model_id": "Qwen/Qwen3.6-35B-A3B",
   "format": "nvfp4",
-  "bits": 5.36,
+  "bits": 5.22,
   "hf_id": "nvidia/Qwen3.6-35B-A3B-NVFP4",
   "revision": "1355db6a052410cfd62085d94b58866fd0f2c3c5",
   "size_gb": 23.46,
@@ -16,5 +16,5 @@
     "hf": "https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4",
     "recipe": "https://github.com/NVIDIA/dgx-spark-playbooks/tree/main/nvidia/vllm"
   },
-  "notes": "NVIDIA's own NVFP4 pack of this model, kept separate from the community `nvfp4` entry so the two packers can be compared with everything else held constant. Declared as quant_method modelopt with quant_algo MIXED_PRECISION, 291 quantized layers and 2 ignored, against the community pack's mixed FP8-dense/NVFP4-expert layout. bits 5.36 is the artefact on disk measured against the vendor's 35B parameter count (23,462,482,761 bytes x 8 / 35e9), not a per-tensor figure; it sits below the community pack's 6.06 and the 23.46 GB against 26.53 GB is the same difference seen from the other side. 17 files, 3 shards, 124,468 tensors - more tensors than the 8-bit pack because NVFP4 splits every quantized weight into packed values plus block scales plus a global scale. The MTP draft head and the vision tower are both present and complete: 333 visual tensors, and an mtp block that looks smaller than the FP8 pack's only because the 256 routed experts are stored as two stacked tensors (mtp.layers.0.mlp.experts.gate_up_proj and .down_proj) instead of 256 separate ones per projection. calibration is null because the card states none. Only vllm is listed: this pack needs an engine with NVFP4 kernels for SM121."
+  "notes": "NVIDIA's own NVFP4 pack of this model, kept separate from the community `nvfp4` entry so the two packers can be compared with everything else held constant. Declared as quant_method modelopt with quant_algo MIXED_PRECISION, 291 quantized layers and 2 ignored, against the community pack's mixed FP8-dense/NVFP4-expert layout. bits 5.22 is the artefact on disk measured against the counted parameter total of 35.952B (23,462,482,761 bytes x 8 / 35.952e9), not a per-tensor figure; it sits below the community pack's 5.90 and the 23.46 GB against 26.53 GB is the same difference seen from the other side. 17 files, 3 shards, 124,468 tensors - more tensors than the 8-bit pack because NVFP4 splits every quantized weight into packed values plus block scales plus a global scale. The MTP draft head and the vision tower are both present and complete: 333 visual tensors, and an mtp block that looks smaller than the FP8 pack's only because the 256 routed experts are stored as two stacked tensors (mtp.layers.0.mlp.experts.gate_up_proj and .down_proj) instead of 256 separate ones per projection. calibration is null because the card states none. Only vllm is listed: this pack needs an engine with NVFP4 kernels for SM121."
 }

--- a/models/Qwen/Qwen3.6-35B-A3B/quants/nvfp4.json
+++ b/models/Qwen/Qwen3.6-35B-A3B/quants/nvfp4.json
@@ -3,7 +3,7 @@
   "id": "nvfp4",
   "model_id": "Qwen/Qwen3.6-35B-A3B",
   "format": "nvfp4",
-  "bits": 6.06,
+  "bits": 5.9,
   "hf_id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
   "revision": "739af1e7aac320af1682ed1e0cce369af4c5265d",
   "size_gb": 26.53,
@@ -16,5 +16,5 @@
     "hf": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
     "recipe": "https://github.com/MiaAI-Lab/Unsloth-Qwen3.6-35b-NVFP4-DGX-Spark"
   },
-  "notes": "Mixed precision rather than uniform NVFP4: the recipe that serves it describes FP8 dense layers with NVFP4 experts, which is why bits works out above 4. bits 6.06 is the published artefact measured against the vendor's 35B parameter count (26,533,000,000 bytes x 8 / 35e9), not a per-tensor figure. 19 files, revision 739af1e. calibration is null because the card states none; a guess would be worse than nothing. Only vllm is listed: NVFP4 needs an engine with the kernels for it, and this pack is served on GB10 through a build carrying --linear-backend flashinfer_b12x."
+  "notes": "Mixed precision rather than uniform NVFP4: the recipe that serves it describes FP8 dense layers with NVFP4 experts, which is why bits works out above 4. bits 5.90 is the published artefact measured against the counted parameter total of 35.952B (26,533,000,000 bytes x 8 / 35.952e9), not a per-tensor figure. 19 files, revision 739af1e. calibration is null because the card states none; a guess would be worse than nothing. Only vllm is listed: NVFP4 needs an engine with the kernels for it, and this pack is served on GB10 through a build carrying --linear-backend flashinfer_b12x."
 }


### PR DESCRIPTION
BF16 caught it.

Every quant of this model recorded `bits` as the artefact's bytes × 8 ÷ the vendor's **35B** headline. By that arithmetic the unquantized release comes out at **16.44 bits per parameter**. No BF16 pack can be wider than 16. The divisor was wrong, not the measurement.

Counted from the safetensors headers, the checkpoint holds **35.952B** parameters:

| | params |
|---|---|
| main body | 34.661B |
| MTP draft head | 0.845B |
| vision tower | 0.447B |
| **total** | **35.952B** |

The 35B headline rounds away the draft head and the vision tower — 3.6% of the weights, and precisely the parts this ladder cares about, since they are what makes the packs comparable on capability rather than only on flags.

`params_b` is now the counted figure, and every `bits` value is recomputed against it:

| quant | was | now |
|---|---|---|
| `nvfp4` | 6.06 | **5.90** |
| `fp8` | 8.57 | **8.34** |
| `nvfp4-modelopt` | 5.36 | **5.22** |
| `bf16` | — | **16.01** (new) |

BF16 landing on 16.01 is the check that the divisor is now right.

**A caveat that belongs with the numbers.** Parameter counts read from a packed format are not comparable this way: NVFP4 stores two values per byte, so its headers count 21.581B *elements* for the same 35.952B parameters. Every figure above is bytes-on-disk over the BF16 parameter count, which is the comparison that means something.

**On the eleven already-merged results.** They keep the `derived` values they were written with. Nothing validates `derived` against the registry, no fingerprint moves, and restamping eleven results to shift a bandwidth ratio by 2.7% would churn more than it tells anyone.

The new `bf16` entry also records something the ladder had backwards: the stacked routed-expert layout is **upstream's own**, so it is the FP8 pack that departs from it by splitting the 256 experts into separate tensors to carry a block scale each.
