### PR TITLE
results: Qwen/Qwen3.6-35B-A3B FP8 on nvidia-gb10-dgx-spark — eval-vision-v1

### DIFF
--- a/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--eval-vision-v1--accbb0.json
+++ b/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--eval-vision-v1--accbb0.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -86,9 +86,9 @@
       "temperature": 0.6,
       "top_p": 0.95,
       "top_k": 20,
-      "min_p": 0.0,
-      "presence_penalty": 0.0,
-      "repetition_penalty": 1.0
+      "min_p": 0,
+      "presence_penalty": 0,
+      "repetition_penalty": 1
     }
   },
   "args_canonical": "@build=ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931;@dtype=auto;@quant=fp8;attention-backend=flashinfer;default-chat-template-kwargs={\"enable_thinking\":true,\"preserve_thinking\":true};enable-auto-tool-choice=true;gpu-memory-utilization=0.8;kv-cache-dtype=fp8;limit-mm-per-prompt={\"image\":4};max-model-len=262144;max-num-batched-tokens=32768;max-num-seqs=24;no-async-scheduling=true;no-enable-chunked-prefill=true;no-trust-remote-code=true;override-generation-config={\"min_p\":0,\"presence_penalty\":0,\"repetition_penalty\":1,\"temperature\":0.6,\"top_k\":20,\"top_p\":0.95};reasoning-parser=qwen3;speculative-config={\"method\":\"mtp\",\"moe_backend\":\"triton\",\"num_speculative_tokens\":2};tool-call-parser=qwen3_coder",
@@ -102,7 +102,7 @@
       "items": 60,
       "concurrency": 4,
       "max_output_tokens": 2048,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -115,7 +115,7 @@
     "requests_total": 60,
     "requests_ok": 60,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 223.49,
     "input_tokens_total": 8104,
     "output_tokens_total": 27921,
@@ -134,7 +134,7 @@
     "power_peak_w": 40.01,
     "energy_wh": 2.3214,
     "gpu_util_avg_pct": 94.37,
-    "temp_max_c": 65.0,
+    "temp_max_c": 65,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -142,7 +142,7 @@
     "total": 60,
     "correct": 50,
     "accuracy": 0.833333,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "arrows": {
         "total": 8,
@@ -843,7 +843,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-31T10:47:40Z",
     "finished_at": "2026-08-31T10:51:23Z",
     "submitted_at": null,

--- a/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--eval-vision-v1--accbb0.json
+++ b/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--eval-vision-v1--accbb0.json
@@ -1,0 +1,861 @@
+{
+  "schema_version": 1,
+  "run_id": "8cd52c733b36ecb7--eval-vision-v1--accbb0",
+  "config_id": "8cd52c733b36ecb7",
+  "cell_id": "803dc89250a5",
+  "workload_id": "eval-vision-v1",
+  "kind": "eval",
+  "engine": {
+    "id": "vllm",
+    "version": "0.26.1.dev0+gf2654939e.d20260726",
+    "commit": null,
+    "build": "ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931",
+    "container": "ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x:latest",
+    "install_method": "docker"
+  },
+  "model": {
+    "id": "Qwen/Qwen3.6-35B-A3B",
+    "quant_id": "fp8",
+    "hf_id": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "95a723d08a94",
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "tensor-parallel-size": 1,
+    "trust-remote-code": true,
+    "moe-backend": "auto",
+    "gpu-memory-utilization": 0.8,
+    "attention-backend": "flashinfer",
+    "max-model-len": 262144,
+    "max-num-seqs": 24,
+    "max-num-batched-tokens": 32768,
+    "enable-chunked-prefill": true,
+    "async-scheduling": true,
+    "kv-cache-dtype": "fp8",
+    "limit-mm-per-prompt": {
+      "image": 4
+    },
+    "speculative-config": {
+      "method": "mtp",
+      "num_speculative_tokens": 2,
+      "moe_backend": "triton"
+    },
+    "reasoning-parser": "qwen3",
+    "tool-call-parser": "qwen3_coder",
+    "enable-auto-tool-choice": true,
+    "default-chat-template-kwargs": {
+      "enable_thinking": true,
+      "preserve_thinking": true
+    },
+    "override-generation-config": {
+      "temperature": 0.6,
+      "top_p": 0.95,
+      "top_k": 20,
+      "min_p": 0.0,
+      "presence_penalty": 0.0,
+      "repetition_penalty": 1.0
+    }
+  },
+  "args_canonical": "@build=ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931;@dtype=auto;@quant=fp8;attention-backend=flashinfer;default-chat-template-kwargs={\"enable_thinking\":true,\"preserve_thinking\":true};enable-auto-tool-choice=true;gpu-memory-utilization=0.8;kv-cache-dtype=fp8;limit-mm-per-prompt={\"image\":4};max-model-len=262144;max-num-batched-tokens=32768;max-num-seqs=24;no-async-scheduling=true;no-enable-chunked-prefill=true;no-trust-remote-code=true;override-generation-config={\"min_p\":0,\"presence_penalty\":0,\"repetition_penalty\":1,\"temperature\":0.6,\"top_k\":20,\"top_p\":0.95};reasoning-parser=qwen3;speculative-config={\"method\":\"mtp\",\"moe_backend\":\"triton\",\"num_speculative_tokens\":2};tool-call-parser=qwen3_coder",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-vision-v1",
+    "resolved_params": {
+      "dataset_id": "eval-vision-v1",
+      "suite": "vision",
+      "scorer": "vision",
+      "items": 60,
+      "concurrency": 4,
+      "max_output_tokens": 2048,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 60,
+    "requests_ok": 60,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 223.49,
+    "input_tokens_total": 8104,
+    "output_tokens_total": 27921,
+    "e2e_ms": {
+      "mean": 14648.469,
+      "p50": 7217.207,
+      "p90": 38037.855,
+      "p95": 62552.499,
+      "p99": 64218.855,
+      "min": 2744.804,
+      "max": 64586.619
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 107.882,
+    "power_avg_w": 37.47,
+    "power_peak_w": 40.01,
+    "energy_wh": 2.3214,
+    "gpu_util_avg_pct": 94.37,
+    "temp_max_c": 65.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "vision",
+    "total": 60,
+    "correct": 50,
+    "accuracy": 0.833333,
+    "success_rate": 1.0,
+    "by_category": {
+      "arrows": {
+        "total": 8,
+        "correct": 8
+      },
+      "chart": {
+        "total": 10,
+        "correct": 10
+      },
+      "clock": {
+        "total": 8,
+        "correct": 6
+      },
+      "dice": {
+        "total": 6,
+        "correct": 6
+      },
+      "grid": {
+        "total": 6,
+        "correct": 6
+      },
+      "ocr": {
+        "total": 10,
+        "correct": 2
+      },
+      "shapes": {
+        "total": 12,
+        "correct": 12
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 38,
+        "correct": 32
+      },
+      "hard": {
+        "total": 8,
+        "correct": 6
+      },
+      "medium": {
+        "total": 14,
+        "correct": 12
+      }
+    },
+    "avg_output_tokens": 465.35,
+    "avg_latency_ms": 14648.47,
+    "failures": 0,
+    "items": [
+      {
+        "id": "vis-0001",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 6133.015,
+        "output_tokens": 181,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0002",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 26620.842,
+        "output_tokens": 823,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0003",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 5615.808,
+        "output_tokens": 166,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0004",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 7776.642,
+        "output_tokens": 232,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0005",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 6143.549,
+        "output_tokens": 179,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0006",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 5706.21,
+        "output_tokens": 184,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0007",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 6189.067,
+        "output_tokens": 192,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0008",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 6567.25,
+        "output_tokens": 203,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0009",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 6136.621,
+        "output_tokens": 187,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0010",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 7434.867,
+        "output_tokens": 233,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0011",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 6012.864,
+        "output_tokens": 170,
+        "category": "shapes",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0012",
+        "correct": true,
+        "predicted": "bottom-right",
+        "expected": "bottom-right",
+        "latency_ms": 6357.084,
+        "output_tokens": 197,
+        "category": "shapes",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0013",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 8148.777,
+        "output_tokens": 244,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0014",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 53945.648,
+        "output_tokens": 1681,
+        "category": "chart",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0015",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 7153.39,
+        "output_tokens": 222,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0016",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 5205.064,
+        "output_tokens": 162,
+        "category": "chart",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0017",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 33198.178,
+        "output_tokens": 1024,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0018",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 10872.482,
+        "output_tokens": 362,
+        "category": "chart",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0019",
+        "correct": true,
+        "predicted": "no",
+        "expected": "no",
+        "latency_ms": 5203.44,
+        "output_tokens": 161,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0020",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 7720.321,
+        "output_tokens": 252,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0021",
+        "correct": true,
+        "predicted": "yes",
+        "expected": "yes",
+        "latency_ms": 6181.832,
+        "output_tokens": 196,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0022",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 6232.392,
+        "output_tokens": 202,
+        "category": "chart",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0023",
+        "correct": true,
+        "predicted": "104170",
+        "expected": "104170",
+        "latency_ms": 5577.402,
+        "output_tokens": 171,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0024",
+        "correct": false,
+        "predicted": "A93-207",
+        "expected": "A32-9207",
+        "latency_ms": 2884.179,
+        "output_tokens": 80,
+        "category": "ocr",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0025",
+        "correct": false,
+        "predicted": "ONER",
+        "expected": "COMPASS",
+        "latency_ms": 18085.346,
+        "output_tokens": 564,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0026",
+        "correct": false,
+        "predicted": "",
+        "expected": "926725",
+        "latency_ms": 62139.804,
+        "output_tokens": 2048,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0027",
+        "correct": true,
+        "predicted": "P10-9941",
+        "expected": "P10-9941",
+        "latency_ms": 2744.804,
+        "output_tokens": 83,
+        "category": "ocr",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0028",
+        "correct": false,
+        "predicted": "",
+        "expected": "PLATFORM",
+        "latency_ms": 63665.168,
+        "output_tokens": 2048,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0029",
+        "correct": false,
+        "predicted": "2101",
+        "expected": "921021",
+        "latency_ms": 5549.105,
+        "output_tokens": 177,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0030",
+        "correct": false,
+        "predicted": "S2F5",
+        "expected": "S33-7805",
+        "latency_ms": 2934.782,
+        "output_tokens": 80,
+        "category": "ocr",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0031",
+        "correct": false,
+        "predicted": "",
+        "expected": "PLATFORM",
+        "latency_ms": 64586.619,
+        "output_tokens": 2048,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0032",
+        "correct": false,
+        "predicted": "4819",
+        "expected": "498775",
+        "latency_ms": 11384.321,
+        "output_tokens": 357,
+        "category": "ocr",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0033",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 6473.553,
+        "output_tokens": 203,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0034",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 36270.323,
+        "output_tokens": 1179,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0035",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 6752.51,
+        "output_tokens": 204,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0036",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 11001.125,
+        "output_tokens": 351,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0037",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 14450.519,
+        "output_tokens": 454,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0038",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 11842.104,
+        "output_tokens": 367,
+        "category": "grid",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0039",
+        "correct": true,
+        "predicted": "up",
+        "expected": "up",
+        "latency_ms": 4585.355,
+        "output_tokens": 132,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0040",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 5736.314,
+        "output_tokens": 162,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0041",
+        "correct": true,
+        "predicted": "left",
+        "expected": "left",
+        "latency_ms": 4777.525,
+        "output_tokens": 134,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0042",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 6636.608,
+        "output_tokens": 201,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0043",
+        "correct": true,
+        "predicted": "up",
+        "expected": "up",
+        "latency_ms": 4598.919,
+        "output_tokens": 132,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0044",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 8892.058,
+        "output_tokens": 276,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0045",
+        "correct": true,
+        "predicted": "up",
+        "expected": "up",
+        "latency_ms": 4525.086,
+        "output_tokens": 132,
+        "category": "arrows",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0046",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 7281.025,
+        "output_tokens": 222,
+        "category": "arrows",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0047",
+        "correct": true,
+        "predicted": "12:10",
+        "expected": "12:10",
+        "latency_ms": 12736.117,
+        "output_tokens": 398,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0048",
+        "correct": false,
+        "predicted": "",
+        "expected": "6:10",
+        "latency_ms": 63963.29,
+        "output_tokens": 2048,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0049",
+        "correct": true,
+        "predicted": "1:25",
+        "expected": "1:25",
+        "latency_ms": 19665.428,
+        "output_tokens": 617,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0050",
+        "correct": false,
+        "predicted": "",
+        "expected": "11:20",
+        "latency_ms": 62493.938,
+        "output_tokens": 2048,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0051",
+        "correct": true,
+        "predicted": "11:00",
+        "expected": "11:00",
+        "latency_ms": 7890.81,
+        "output_tokens": 260,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0052",
+        "correct": true,
+        "predicted": "6:20",
+        "expected": "6:20",
+        "latency_ms": 12491.519,
+        "output_tokens": 414,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0053",
+        "correct": true,
+        "predicted": "10:35",
+        "expected": "10:35",
+        "latency_ms": 14344.714,
+        "output_tokens": 466,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0054",
+        "correct": true,
+        "predicted": "9:20",
+        "expected": "9:20",
+        "latency_ms": 22336.755,
+        "output_tokens": 702,
+        "category": "clock",
+        "difficulty": "hard"
+      },
+      {
+        "id": "vis-0055",
+        "correct": true,
+        "predicted": "11",
+        "expected": "11",
+        "latency_ms": 9686.93,
+        "output_tokens": 322,
+        "category": "dice",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0056",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 6139.817,
+        "output_tokens": 188,
+        "category": "dice",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0057",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 6176.396,
+        "output_tokens": 194,
+        "category": "dice",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0058",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 4697.108,
+        "output_tokens": 140,
+        "category": "dice",
+        "difficulty": "easy"
+      },
+      {
+        "id": "vis-0059",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 10152.995,
+        "output_tokens": 359,
+        "category": "dice",
+        "difficulty": "medium"
+      },
+      {
+        "id": "vis-0060",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 12202.452,
+        "output_tokens": 507,
+        "category": "dice",
+        "difficulty": "easy"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [
+    {
+      "severity": "info",
+      "text": "GPU CLOCK IS A HIDDEN VARIABLE ON THIS BOX AND IT IS NOT AT MAXIMUM. Sampled at workload start: 2392MHz,3003MHz. nvidia-smi reports no active clock event reason - no SW power cap, no HW slowdown, no thermal slowdown, no applications-clock setting - and the clock cannot be raised without root on this account. Under load the SM clock sits around 2470-2490 MHz against a 3003 MHz ceiling, roughly 82 percent. Treat any comparison against a figure from another Spark as carrying this unknown unless that box clock state is also stated. The same gotcha is recorded on the NVFP4 rung, so the two rungs of this ladder carry it equally and comparing them against each other is unaffected."
+    },
+    {
+      "severity": "info",
+      "text": "The pack is block-scaled FP8 and the registry bits figure of 8.57 is not a rounding error. config.json declares quant_method fp8, fmt e4m3, activation_scheme dynamic and weight_block_size 128x128, so weights carry one scale per 128x128 tile and activations are scaled at runtime rather than from a calibration set. 648 modules are listed in modules_to_not_convert and stay wider than 8 bits. Both the MTP draft head (1,560 tensors) and the vision tower (333 tensors) are present in the checkpoint, so this rung supports the same speculative decoding and image input as the NVFP4 rung and the two are comparable on capability, not only on flags."
+    },
+    {
+      "severity": "info",
+      "text": "Speculative decoding is the model own MTP head at 2 tokens with moe_backend triton, matching the NVFP4 rung. Prefix caching is OFF - the engine log confirms enable_prefix_caching=False - so no workload in this rung benefits from a shared prefix, and cells run with it on are not comparable. --linear-backend is left at auto here rather than the NVFP4 rung flashinfer_b12x, which is the only intentional flag difference between the two rungs."
+    },
+    {
+      "severity": "info",
+      "text": "THE ENGINE SILENTLY CHANGED ITS OWN FP8 KERNEL CHOICE FOR ACCURACY REASONS, AND THE TWO HALVES OF THE MODEL ENDED UP ON DIFFERENT BACKENDS. At startup it logged: Auto-disabled DeepGemm for model_type=qwen3_5_moe_text on Blackwell, DeepGemm E8M0 scale format causes accuracy degradation for this architecture, falling back to CUTLASS - and then selected CutlassFp8BlockScaledMMKernel for the dense linear layers while separately selecting the DEEPGEMM Fp8 MoE backend for the experts. Neither choice was requested on the command line, both are decided by the engine from the architecture and the GPU, and a build without that auto-disable would run the dense path on DeepGemm instead. Any eval score in this rung is a score for that kernel pairing on this build, not for FP8 in the abstract."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "49b6c6fc7d6c6608ed2f6a511d4e2db94d16ef94d8f6bf2dcb537cb133319248",
+    "payload_path": null,
+    "payload": {
+      "scorer": "vision",
+      "scorers_used": [
+        "exact"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8888/v1",
+        "served_model_id": "Qwen/Qwen3.6-35B-A3B-FP8",
+        "advertised_models": [
+          "Qwen/Qwen3.6-35B-A3B-FP8"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-31T10:47:40Z",
+    "finished_at": "2026-08-31T10:51:23Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Rung 2 of a quantization ladder on one box: same hardware, same container image, same engine build and the same serve flags as the NVFP4 rung, with only the weights changed, so a difference between the two rungs is attributable to the pack rather than to the setup. The one flag not carried over is --linear-backend flashinfer_b12x, which selects an NVFP4 GEMM path and has nothing to apply to here. Box was dedicated: no desktop session, no other GPU work, and the reverse-proxy SSH tunnel that is the only external route in was stopped for the whole sweep. NVIDIA DGX Spark (ASUS Ascent GX10, GB10 / SM121, 128 GB unified, ~121 GiB usable), Ubuntu 24.04.4, kernel 6.17.0-1029-nvidia aarch64, driver 580.173.02, CUDA 13.0, swap off. Image is ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x:latest, reporting vLLM 0.26.1.dev0+gf2654939e.d20260726; unlike the NVFP4 rung it is not launched through the MiaAI-Lab recipe start.sh but directly with --entrypoint /usr/local/bin/vllm, because that script hard-codes its own checkpoint. Weights are the official Qwen/Qwen3.6-35B-A3B-FP8 at revision 95a723d08a94, 42 shards, 37.49 GB on disk. At startup the server reported a GPU KV cache of 4,690,997 tokens and a maximum concurrency of 17.89x for 262,144-token requests."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}


### PR DESCRIPTION
### Cells filled

- **Engine** — `vllm` `0.26.1.dev0+gf2654939e.d20260726`
- **Model / quant** — `Qwen/Qwen3.6-35B-A3B` / `fp8`
- **Hardware** — `nvidia-gb10-dgx-spark` x1
- **Workload** — `eval-vision-v1` (eval)
- **Headline** — accuracy **0.833**, success 1.000

One file: `results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--eval-vision-v1--accbb0.json`

### What failed

Nothing failed. 60/60 requests returned, success rate 1.000.

### Gotchas

- **info** — GPU CLOCK IS A HIDDEN VARIABLE ON THIS BOX AND IT IS NOT AT MAXIMUM.
- **info** — The pack is block-scaled FP8 and the registry bits figure of 8.57 is not a rounding error.
- **info** — Speculative decoding is the model own MTP head at 2 tokens with moe_backend triton, matching the NVFP4 rung.
- **info** — THE ENGINE SILENTLY CHANGED ITS OWN FP8 KERNEL CHOICE FOR ACCURACY REASONS, AND THE TWO HALVES OF THE MODEL ENDED UP ON DIFFERENT BACKENDS.

### Conditions

Dedicated box, nothing else resident on the GPU, no compile running. The one route into this machine from elsewhere on its private network is an SSH tunnel from a reverse proxy; it was stopped before the first run and stayed stopped. The harness talks to loopback with no proxy in the measured path.

n-gram table page-cache residency, `mincore(2)`: **2457% before the workload, MHz% after**.

| | |
|---|---:|
| peak host RAM | 107.9 GB |
| average GPU utilisation | 94.4 % |
| average / peak power | 37.5 / 40.0 W |
| max temperature | 65 C |
| thermal throttling | not detected |
| wall clock | 223.5 s |

`pnpm validate` — 0 errors. Read `gpu_util_avg_pct` with the caveat in the gotchas: it is a mean over the whole workload window including ramp-up and drain, not a steady-state figure.
