### PR TITLE
results: Qwen/Qwen3.6-35B-A3B FP8 on nvidia-gb10-dgx-spark — prefill-128k-v1

### DIFF
--- a/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--prefill-128k-v1--20470d.json
+++ b/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--prefill-128k-v1--20470d.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -86,9 +86,9 @@
       "temperature": 0.6,
       "top_p": 0.95,
       "top_k": 20,
-      "min_p": 0.0,
-      "presence_penalty": 0.0,
-      "repetition_penalty": 1.0
+      "min_p": 0,
+      "presence_penalty": 0,
+      "repetition_penalty": 1
     }
   },
   "args_canonical": "@build=ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931;@dtype=auto;@quant=fp8;attention-backend=flashinfer;default-chat-template-kwargs={\"enable_thinking\":true,\"preserve_thinking\":true};enable-auto-tool-choice=true;gpu-memory-utilization=0.8;kv-cache-dtype=fp8;limit-mm-per-prompt={\"image\":4};max-model-len=262144;max-num-batched-tokens=32768;max-num-seqs=24;no-async-scheduling=true;no-enable-chunked-prefill=true;no-trust-remote-code=true;override-generation-config={\"min_p\":0,\"presence_penalty\":0,\"repetition_penalty\":1,\"temperature\":0.6,\"top_k\":20,\"top_p\":0.95};reasoning-parser=qwen3;speculative-config={\"method\":\"mtp\",\"moe_backend\":\"triton\",\"num_speculative_tokens\":2};tool-call-parser=qwen3_coder",
@@ -103,7 +103,7 @@
       "warmup_requests": 1,
       "prompts_padded": false,
       "needle_check": false,
-      "timeout_s": 900.0,
+      "timeout_s": 900,
       "seed": 42
     }
   },
@@ -111,7 +111,7 @@
     "requests_total": 10,
     "requests_ok": 10,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 641.98,
     "input_tokens_total": 1609125,
     "output_tokens_total": 160,
@@ -171,7 +171,7 @@
     "power_peak_w": 101.65,
     "energy_wh": 16.5292,
     "gpu_util_avg_pct": 95.42,
-    "temp_max_c": 85.0,
+    "temp_max_c": 85,
     "thermal_throttle_detected": false
   },
   "failures": [],
@@ -365,7 +365,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-08-31T11:23:11Z",
     "finished_at": "2026-08-31T11:34:57Z",
     "submitted_at": null,

--- a/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--prefill-128k-v1--20470d.json
+++ b/results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--prefill-128k-v1--20470d.json
@@ -1,0 +1,383 @@
+{
+  "schema_version": 1,
+  "run_id": "8cd52c733b36ecb7--prefill-128k-v1--20470d",
+  "config_id": "8cd52c733b36ecb7",
+  "cell_id": "803dc89250a5",
+  "workload_id": "prefill-128k-v1",
+  "kind": "prefill",
+  "engine": {
+    "id": "vllm",
+    "version": "0.26.1.dev0+gf2654939e.d20260726",
+    "commit": null,
+    "build": "ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931",
+    "container": "ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x:latest",
+    "install_method": "docker"
+  },
+  "model": {
+    "id": "Qwen/Qwen3.6-35B-A3B",
+    "quant_id": "fp8",
+    "hf_id": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "95a723d08a94",
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "tensor-parallel-size": 1,
+    "trust-remote-code": true,
+    "moe-backend": "auto",
+    "gpu-memory-utilization": 0.8,
+    "attention-backend": "flashinfer",
+    "max-model-len": 262144,
+    "max-num-seqs": 24,
+    "max-num-batched-tokens": 32768,
+    "enable-chunked-prefill": true,
+    "async-scheduling": true,
+    "kv-cache-dtype": "fp8",
+    "limit-mm-per-prompt": {
+      "image": 4
+    },
+    "speculative-config": {
+      "method": "mtp",
+      "num_speculative_tokens": 2,
+      "moe_backend": "triton"
+    },
+    "reasoning-parser": "qwen3",
+    "tool-call-parser": "qwen3_coder",
+    "enable-auto-tool-choice": true,
+    "default-chat-template-kwargs": {
+      "enable_thinking": true,
+      "preserve_thinking": true
+    },
+    "override-generation-config": {
+      "temperature": 0.6,
+      "top_p": 0.95,
+      "top_k": 20,
+      "min_p": 0.0,
+      "presence_penalty": 0.0,
+      "repetition_penalty": 1.0
+    }
+  },
+  "args_canonical": "@build=ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931;@dtype=auto;@quant=fp8;attention-backend=flashinfer;default-chat-template-kwargs={\"enable_thinking\":true,\"preserve_thinking\":true};enable-auto-tool-choice=true;gpu-memory-utilization=0.8;kv-cache-dtype=fp8;limit-mm-per-prompt={\"image\":4};max-model-len=262144;max-num-batched-tokens=32768;max-num-seqs=24;no-async-scheduling=true;no-enable-chunked-prefill=true;no-trust-remote-code=true;override-generation-config={\"min_p\":0,\"presence_penalty\":0,\"repetition_penalty\":1,\"temperature\":0.6,\"top_k\":20,\"top_p\":0.95};reasoning-parser=qwen3;speculative-config={\"method\":\"mtp\",\"moe_backend\":\"triton\",\"num_speculative_tokens\":2};tool-call-parser=qwen3_coder",
+  "serve_command": null,
+  "workload": {
+    "id": "prefill-128k-v1",
+    "resolved_params": {
+      "concurrency": 1,
+      "num_requests": 10,
+      "input_tokens": 131072,
+      "output_tokens": 16,
+      "warmup_requests": 1,
+      "prompts_padded": false,
+      "needle_check": false,
+      "timeout_s": 900.0,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 10,
+    "requests_ok": 10,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 641.98,
+    "input_tokens_total": 1609125,
+    "output_tokens_total": 160,
+    "output_tok_s": 0.249,
+    "total_tok_s": 2506.752,
+    "req_s": 0.016,
+    "prefill_tok_s": 2515.495,
+    "ttft_ms": {
+      "mean": 63968.527,
+      "p50": 63989.015,
+      "p90": 64166.316,
+      "p95": 64214.204,
+      "p99": 64252.514,
+      "min": 63615.41,
+      "max": 64262.092
+    },
+    "tpot_ms": {
+      "mean": 15.294,
+      "p50": 15.203,
+      "p90": 17.815,
+      "p95": 18.068,
+      "p99": 18.271,
+      "min": 13.436,
+      "max": 18.322
+    },
+    "itl_ms": {
+      "mean": 41.567,
+      "p50": 54.916,
+      "p90": 58.658,
+      "p95": 59.036,
+      "p99": 61.918,
+      "min": 0.015,
+      "max": 62.825
+    },
+    "e2e_ms": {
+      "mean": 64197.937,
+      "p50": 64241.283,
+      "p90": 64372.781,
+      "p95": 64432.298,
+      "p99": 64479.912,
+      "min": 63841.781,
+      "max": 64491.815
+    },
+    "decode_tok_s_per_request": {
+      "mean": 66.035,
+      "p50": 65.781,
+      "p90": 73.658,
+      "p95": 74.043,
+      "p99": 74.352,
+      "min": 54.58,
+      "max": 74.429
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 113.851,
+    "kv_cache_tokens": null,
+    "power_avg_w": 84.31,
+    "power_peak_w": 101.65,
+    "energy_wh": 16.5292,
+    "gpu_util_avg_pct": 95.42,
+    "temp_max_c": 85.0,
+    "thermal_throttle_detected": false
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [
+    {
+      "severity": "info",
+      "text": "GPU CLOCK IS A HIDDEN VARIABLE ON THIS BOX AND IT IS NOT AT MAXIMUM. Sampled at workload start: 2392MHz,3003MHz. nvidia-smi reports no active clock event reason - no SW power cap, no HW slowdown, no thermal slowdown, no applications-clock setting - and the clock cannot be raised without root on this account. Under load the SM clock sits around 2470-2490 MHz against a 3003 MHz ceiling, roughly 82 percent. Treat any comparison against a figure from another Spark as carrying this unknown unless that box clock state is also stated. The same gotcha is recorded on the NVFP4 rung, so the two rungs of this ladder carry it equally and comparing them against each other is unaffected."
+    },
+    {
+      "severity": "info",
+      "text": "The pack is block-scaled FP8 and the registry bits figure of 8.57 is not a rounding error. config.json declares quant_method fp8, fmt e4m3, activation_scheme dynamic and weight_block_size 128x128, so weights carry one scale per 128x128 tile and activations are scaled at runtime rather than from a calibration set. 648 modules are listed in modules_to_not_convert and stay wider than 8 bits. Both the MTP draft head (1,560 tensors) and the vision tower (333 tensors) are present in the checkpoint, so this rung supports the same speculative decoding and image input as the NVFP4 rung and the two are comparable on capability, not only on flags."
+    },
+    {
+      "severity": "info",
+      "text": "Speculative decoding is the model own MTP head at 2 tokens with moe_backend triton, matching the NVFP4 rung. Prefix caching is OFF - the engine log confirms enable_prefix_caching=False - so no workload in this rung benefits from a shared prefix, and cells run with it on are not comparable. --linear-backend is left at auto here rather than the NVFP4 rung flashinfer_b12x, which is the only intentional flag difference between the two rungs."
+    },
+    {
+      "severity": "info",
+      "text": "THE ENGINE SILENTLY CHANGED ITS OWN FP8 KERNEL CHOICE FOR ACCURACY REASONS, AND THE TWO HALVES OF THE MODEL ENDED UP ON DIFFERENT BACKENDS. At startup it logged: Auto-disabled DeepGemm for model_type=qwen3_5_moe_text on Blackwell, DeepGemm E8M0 scale format causes accuracy degradation for this architecture, falling back to CUTLASS - and then selected CutlassFp8BlockScaledMMKernel for the dense linear layers while separately selecting the DEEPGEMM Fp8 MoE backend for the experts. Neither choice was requested on the command line, both are decided by the engine from the architecture and the GPU, and a build without that auto-disable would run the dense path on DeepGemm instead. Any eval score in this rung is a score for that kernel pairing on this build, not for FP8 in the abstract."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": 0.003,
+    "tok_s_per_gb_bandwidth": 0.241886,
+    "bandwidth_efficiency": 0.756904,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "a041ce21896e8bc9b6fcf4cd524eadbf1272ef71663f47bf7ae17498d7e70ea7",
+    "payload_path": null,
+    "payload": {
+      "requests": [
+        {
+          "id": "prefill-w00000",
+          "prompt_id": "hay-128k-d10",
+          "warmup": true,
+          "status": "ok",
+          "ttft_ms": 63270.817,
+          "e2e_ms": 63500.346,
+          "prompt_tokens": 161022,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00000",
+          "prompt_id": "hay-128k-d10",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 63615.41,
+          "e2e_ms": 63841.781,
+          "prompt_tokens": 161022,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00001",
+          "prompt_id": "hay-128k-multi",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 63719.399,
+          "e2e_ms": 63931.764,
+          "prompt_tokens": 160737,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00002",
+          "prompt_id": "hay-128k-d50",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 64083.002,
+          "e2e_ms": 64284.537,
+          "prompt_tokens": 161098,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00003",
+          "prompt_id": "hay-128k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 63876.081,
+          "e2e_ms": 64142.456,
+          "prompt_tokens": 160826,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00004",
+          "prompt_id": "hay-128k-d10",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 64008.174,
+          "e2e_ms": 64237.886,
+          "prompt_tokens": 161022,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00005",
+          "prompt_id": "hay-128k-multi",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 63878.573,
+          "e2e_ms": 64115.93,
+          "prompt_tokens": 160737,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00006",
+          "prompt_id": "hay-128k-d50",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 64155.674,
+          "e2e_ms": 64359.555,
+          "prompt_tokens": 161098,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00007",
+          "prompt_id": "hay-128k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 63969.855,
+          "e2e_ms": 64244.679,
+          "prompt_tokens": 160826,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00008",
+          "prompt_id": "hay-128k-d10",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 64117.008,
+          "e2e_ms": 64328.961,
+          "prompt_tokens": 161022,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        },
+        {
+          "id": "prefill-r00009",
+          "prompt_id": "hay-128k-multi",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 64262.092,
+          "e2e_ms": 64491.815,
+          "prompt_tokens": 160737,
+          "completion_tokens": 16,
+          "token_source": "usage",
+          "finish_reason": "length",
+          "error_category": null
+        }
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8888/v1",
+        "served_model_id": "Qwen/Qwen3.6-35B-A3B-FP8",
+        "advertised_models": [
+          "Qwen/Qwen3.6-35B-A3B-FP8"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-08-31T11:23:11Z",
+    "finished_at": "2026-08-31T11:34:57Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Rung 2 of a quantization ladder on one box: same hardware, same container image, same engine build and the same serve flags as the NVFP4 rung, with only the weights changed, so a difference between the two rungs is attributable to the pack rather than to the setup. The one flag not carried over is --linear-backend flashinfer_b12x, which selects an NVFP4 GEMM path and has nothing to apply to here. Box was dedicated: no desktop session, no other GPU work, and the reverse-proxy SSH tunnel that is the only external route in was stopped for the whole sweep. NVIDIA DGX Spark (ASUS Ascent GX10, GB10 / SM121, 128 GB unified, ~121 GiB usable), Ubuntu 24.04.4, kernel 6.17.0-1029-nvidia aarch64, driver 580.173.02, CUDA 13.0, swap off. Image is ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x:latest, reporting vLLM 0.26.1.dev0+gf2654939e.d20260726; unlike the NVFP4 rung it is not launched through the MiaAI-Lab recipe start.sh but directly with --entrypoint /usr/local/bin/vllm, because that script hard-codes its own checkpoint. Weights are the official Qwen/Qwen3.6-35B-A3B-FP8 at revision 95a723d08a94, 42 shards, 37.49 GB on disk. At startup the server reported a GPU KV cache of 4,690,997 tokens and a maximum concurrency of 17.89x for 262,144-token requests."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}


### PR DESCRIPTION
### Cells filled

- **Engine** — `vllm` `0.26.1.dev0+gf2654939e.d20260726`
- **Model / quant** — `Qwen/Qwen3.6-35B-A3B` / `fp8`
- **Hardware** — `nvidia-gb10-dgx-spark` x1
- **Workload** — `prefill-128k-v1` (prefill)
- **Headline** — prefill **2,515.5 tok/s**, TTFT p50 63,989.0 ms, success 1.000

One file: `results/vllm/Qwen/Qwen3.6-35B-A3B/nvidia-gb10-dgx-spark/8cd52c733b36ecb7--prefill-128k-v1--20470d.json`

### What failed

Nothing failed. 10/10 requests returned, success rate 1.000.

### Gotchas

- **info** — GPU CLOCK IS A HIDDEN VARIABLE ON THIS BOX AND IT IS NOT AT MAXIMUM.
- **info** — The pack is block-scaled FP8 and the registry bits figure of 8.57 is not a rounding error.
- **info** — Speculative decoding is the model own MTP head at 2 tokens with moe_backend triton, matching the NVFP4 rung.
- **info** — THE ENGINE SILENTLY CHANGED ITS OWN FP8 KERNEL CHOICE FOR ACCURACY REASONS, AND THE TWO HALVES OF THE MODEL ENDED UP ON DIFFERENT BACKENDS.

### Conditions

Dedicated box, nothing else resident on the GPU, no compile running. The one route into this machine from elsewhere on its private network is an SSH tunnel from a reverse proxy; it was stopped before the first run and stayed stopped. The harness talks to loopback with no proxy in the measured path.

n-gram table page-cache residency, `mincore(2)`: **2359% before the workload, MHz% after**.

| | |
|---|---:|
| peak host RAM | 113.9 GB |
| average GPU utilisation | 95.4 % |
| average / peak power | 84.3 / 101.7 W |
| max temperature | 85 C |
| thermal throttling | not detected |
| wall clock | 642.0 s |

`pnpm validate` — 0 errors. Read `gpu_util_avg_pct` with the caveat in the gotchas: it is a mean over the whole workload window including ramp-up and drain, not a steady-state figure.
