### PR TITLE
ci: stop the wanted-snapshot job opening empty pull requests

### DIFF
--- a/.github/workflows/wanted-snapshot.yml
+++ b/.github/workflows/wanted-snapshot.yml
@@ -67,19 +67,39 @@ jobs:
               .sort((a, b) => b.reactions - a.reactions || a.issue - b.issue);
 
             fs.mkdirSync('site', { recursive: true });
-            fs.writeFileSync(
-              'site/wanted-requests.json',
-              JSON.stringify(
-                {
-                  schema_version: 1,
-                  generated_at: new Date().toISOString(),
-                  requests,
-                },
-                null,
-                2,
-              ) + '\n',
-            );
-            core.info(`${requests.length} request(s) snapshotted`);
+            const path = 'site/wanted-requests.json';
+
+            // Stamping generated_at unconditionally makes every weekly run a diff, so the
+            // job opened a pull request each week that changed one timestamp and nothing
+            // else. Keep the committed timestamp when the requests themselves have not
+            // moved: create-pull-request then sees a clean tree and opens nothing.
+            let previous = null;
+            try {
+              previous = JSON.parse(fs.readFileSync(path, 'utf8'));
+            } catch {
+              previous = null;
+            }
+            const unchanged =
+              previous !== null &&
+              JSON.stringify(previous.requests ?? null) === JSON.stringify(requests);
+
+            if (unchanged) {
+              core.info(`${requests.length} request(s) snapshotted; unchanged, leaving the file alone`);
+            } else {
+              fs.writeFileSync(
+                path,
+                JSON.stringify(
+                  {
+                    schema_version: 1,
+                    generated_at: new Date().toISOString(),
+                    requests,
+                  },
+                  null,
+                  2,
+                ) + '\n',
+              );
+              core.info(`${requests.length} request(s) snapshotted; file updated`);
+            }
 
       - uses: peter-evans/create-pull-request@v8
         with:


### PR DESCRIPTION
The `wanted-snapshot` job stamps `generated_at` on every run, so the file always differs from the committed one and `create-pull-request` opens a PR every week whose entire content is a new timestamp.

[#157](https://github.com/0xBakeer/inference-atlas/pull/157) is one of those — `requests` is `[]` before and `[]` after:

```diff
-  "generated_at": "2026-08-24T08:55:59.158Z",
+  "generated_at": "2026-08-31T10:48:14.780Z",
   "requests": []
```

This keeps the committed timestamp when the requests array hasn't changed. The tree stays clean, nothing is opened, and a PR from this job again means something a human should actually look at.

`generated_at` still moves whenever the requests do — which is the only time it carries information, since it dates the snapshot the ranking was computed from.
