### PR TITLE
Stop headlining output_tok_s on longctx runs

### DIFF
--- a/app/src/util/metrics.test.ts
+++ b/app/src/util/metrics.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { fixtureRow } from '../data/fixture.js';
+import { headlineMetric } from './metrics.js';
+
+/** The site-wide order, as `site/config.json` carries it. */
+const KEY_METRICS = ['output_tok_s', 'decode_tok_s_per_request', 'accuracy', 'ttft_p50'];
+
+describe('headlineMetric', () => {
+  it('takes the first site key metric present, in order', () => {
+    const hl = headlineMetric(fixtureRow(), KEY_METRICS);
+    expect(hl?.def.key).toBe('output_tok_s');
+    expect(hl?.value).toBe(120.5);
+  });
+
+  it('falls past a key metric the row does not carry', () => {
+    const row = fixtureRow({ metrics: { ttft_p50: 80 } });
+    expect(headlineMetric(row, KEY_METRICS)?.def.key).toBe('ttft_p50');
+  });
+
+  // On a longctx run the model answers a needle question in a handful of tokens, so
+  // output_tok_s collapses to answer-length / TTFT and ranks engines by verbosity: a 6-token
+  // and an 89-token answer differ ~20x on it while their prefill differs under 2.5x.
+  it('does not headline output_tok_s on a longctx run', () => {
+    const row = fixtureRow({
+      workload_id: 'longctx-depth-sweep-v1',
+      kind: 'longctx',
+      metrics: { output_tok_s: 0.276, ttft_p50: 21763.894 },
+    });
+    const hl = headlineMetric(row, KEY_METRICS);
+    expect(hl?.def.key).toBe('ttft_p50');
+    expect(hl?.value).toBe(21763.894);
+  });
+
+  it('still reports output_tok_s on a longctx run that carries nothing better', () => {
+    const row = fixtureRow({
+      workload_id: 'longctx-depth-sweep-v1',
+      kind: 'longctx',
+      metrics: { output_tok_s: 0.276 },
+    });
+    expect(headlineMetric(row, KEY_METRICS)?.def.key).toBe('output_tok_s');
+  });
+
+  it('leaves serving runs on the site order', () => {
+    const row = fixtureRow({ metrics: { output_tok_s: 120.5, ttft_p50: 80 } });
+    expect(headlineMetric(row, KEY_METRICS)?.def.key).toBe('output_tok_s');
+  });
+
+  it('returns null when the row carries no usable metric', () => {
+    expect(headlineMetric(fixtureRow({ metrics: {} }), KEY_METRICS)).toBeNull();
+  });
+});

--- a/app/src/util/metrics.ts
+++ b/app/src/util/metrics.ts
@@ -4,6 +4,7 @@ import type {
   MetricBlock,
   ResultRecord,
   SiteConfig,
+  WorkloadKind,
 } from '@atlas/core';
 import { fmtGB, fmtMs, fmtNum, fmtPct, fmtTokS, fmtW, isNum } from './format.js';
 
@@ -148,12 +149,27 @@ export function metricLabel(site: SiteConfig, key: string): string {
   return site.atlas.metrics?.find((m) => m.key === key)?.label ?? METRIC_BY_KEY[key]?.label ?? key;
 }
 
+/**
+ * Key-metric order for workload kinds where the site-wide order surfaces a misleading number.
+ *
+ * On `longctx` the model answers a needle question, and the answer is a handful of tokens:
+ * Atlas replies in 6 at every depth where SGLang replies in 83–113. `output_tok_s` is
+ * completion tokens over wall clock, so with the whole answer in one delta it collapses to
+ * roughly answer-length / TTFT — it ranks engines by how chatty they are. That reads as a
+ * 20x gap where the prefill gap is 1.7–2.4x. TTFT is the honest headline for a
+ * prefill-dominated workload, and `longctx-needle-*` already leaves `output_tok_s` out of
+ * its `metrics_required` entirely.
+ */
+const KEY_METRICS_BY_KIND: Partial<Record<WorkloadKind, string[]>> = {
+  longctx: ['ttft_p50', 'decode_tok_s_per_request', 'output_tok_s'],
+};
+
 /** Headline number for an index row: first key metric present, in site preference order. */
 export function headlineMetric(
   r: CompiledIndexRow,
   keyMetrics: string[],
 ): { def: MetricDef; value: number } | null {
-  for (const k of keyMetrics) {
+  for (const k of KEY_METRICS_BY_KIND[r.kind] ?? keyMetrics) {
     const def = METRIC_BY_KEY[k];
     if (!def) continue;
     const v = def.fromRow(r);


### PR DESCRIPTION
`headlineMetric` walks `site/config.json`'s `key_metrics`, which begins with `output_tok_s`, so that is the number surfaced for a `longctx` run in the runs table, cell drawer, run picker and atlas view.

On `longctx` the model answers a needle question in a handful of tokens. `output_tok_s` is completion tokens over wall clock (`bench/atlas_bench/metrics.py:142`), so when the whole answer arrives in one delta it collapses to roughly *answer length / TTFT* and ranks engines by verbosity.

Measured on `Qwen/Qwen3.8-27B` / `nvidia-gb10-dgx-spark`, at the four depths both engines reached:

| depth | Atlas out tok | SGLang out tok | Atlas tok/s | SGLang tok/s | prefill ratio |
|---|---|---|---|---|---|
| 1024 | 6 | 99 | 3.686 | 19.319 | 2.41x |
| 4096 | 6 | 95 | 1.159 | 13.988 | 2.13x |
| 8192 | 6 | 83 | 0.590 | 8.780 | 1.76x |
| 16384 | 6 | 89 | 0.276 | 5.488 | 1.74x |

Both engines are labelled `needle found` at every point they reached, so both read the context. The 20x headline gap at 16k is almost entirely answer length.

Key metrics are now ordered per workload kind. `longctx` prefers `ttft_p50`, which is the honest headline for a prefill-dominated workload and is what `longctx-needle-*` already lists in `metrics_required` while omitting `output_tok_s` altogether. `output_tok_s` stays last in that order so a run carrying nothing else still shows a number.

`prefill_tok_s` would be the better headline still, but it is not compiled into `CompiledIndexRow.metrics` — adding it is a larger change than this fix needs, and worth doing separately if the column earns it.

Surfaced by #182. Closes #185.