### PR TITLE
Fix: one contributor row per person, not one per login casing

### DIFF
--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -3,7 +3,7 @@
  * them in memory, and exposes derived lookups. Initial load = manifest + registry + index +
  * coverage + stats; gaps, contributors, engine version files and full runs are lazy.
  */
-import { computeCoverage } from '@atlas/core';
+import { computeCoverage, loginKey } from '@atlas/core';
 import type { EngineVersion, Gap, ResultRecord, SiteConfig } from '@atlas/core';
 import siteFallbackJson from '../../site/config.json';
 import { atlasCells, buildLookups, type Lookups, type PossibleCell } from './data/derive.js';
@@ -146,7 +146,7 @@ class Store {
     coverage: CoverageMap,
     _manifest: Manifest,
   ): Stats {
-    const logins = new Set(index.map((r) => r.provenance.login));
+    const logins = new Set(index.map((r) => loginKey(r.provenance.login)));
     let last: string | null = null;
     for (const r of index) {
       const t = r.provenance.submitted_at ?? r.provenance.started_at ?? null;
@@ -204,7 +204,8 @@ class Store {
     const by = new Map<string, ContributorRow>();
     for (const r of this.index.value) {
       const login = r.provenance.login;
-      let c = by.get(login);
+      const key = loginKey(login);
+      let c = by.get(key);
       if (!c) {
         c = {
           login,
@@ -231,7 +232,7 @@ class Store {
             registry_workloads: 0,
           },
         };
-        by.set(login, c);
+        by.set(key, c);
       }
       c.runs += 1;
       if (!c.hardware_ids.includes(r.hardware.id)) c.hardware_ids.push(r.hardware.id);
@@ -243,7 +244,9 @@ class Store {
     }
     for (const c of by.values()) {
       const cells = new Set(
-        this.index.value.filter((r) => r.provenance.login === c.login).map((r) => r.cell_id),
+        this.index.value
+          .filter((r) => loginKey(r.provenance.login) === loginKey(c.login))
+          .map((r) => r.cell_id),
       );
       c.cells_filled = cells.size;
     }

--- a/app/src/views/contributors-view.ts
+++ b/app/src/views/contributors-view.ts
@@ -13,6 +13,7 @@ import {
   when,
 } from '../components/ui.js';
 import type { ContributorRow } from '../data/types.js';
+import { loginKey } from '@atlas/core';
 import { href } from '../router.js';
 import { store } from '../store.js';
 import { absDate } from '../util/dates.js';
@@ -183,18 +184,22 @@ export class AtlasContributorsView extends ViewElement {
     </div>`;
   }
 
-  private profile(login: string, list: ContributorRow[]): TemplateResult {
-    const c = list.find((x) => x.login === login);
+  private profile(typed: string, list: ContributorRow[]): TemplateResult {
+    // A login in a URL can be spelled with any casing; GitHub treats them as one person.
+    const key = loginKey(typed);
+    const c = list.find((x) => loginKey(x.login) === key);
     const runs = store.index.value
-      .filter((r) => r.provenance.login === login)
+      .filter((r) => loginKey(r.provenance.login) === key)
       .sort((a, b) =>
         (b.provenance.submitted_at ?? '').localeCompare(a.provenance.submitted_at ?? ''),
       );
     if (!c && runs.length === 0) {
       return html`<div class="page">
-        ${emptyState({ title: `No contributor “${login}”`, text: 'Nobody with this login has a result file on main yet.', action: html`<a class="btn" href="#/contributors">Leaderboard</a>` })}
+        ${emptyState({ title: `No contributor “${typed}”`, text: 'Nobody with this login has a result file on main yet.', action: html`<a class="btn" href="#/contributors">Leaderboard</a>` })}
       </div>`;
     }
+    // Whatever the URL said, show the spelling the data carries.
+    const login = c?.login ?? runs[0]?.provenance.login ?? typed;
     const cc: ContributorRow = c ?? {
       login,
       user_id: null,
@@ -221,7 +226,7 @@ export class AtlasContributorsView extends ViewElement {
     };
     const engines = [...new Set(runs.map((r) => r.engine.id))];
     const rank =
-      [...list].sort((a, b) => b.points - a.points).findIndex((x) => x.login === login) + 1;
+      [...list].sort((a, b) => b.points - a.points).findIndex((x) => loginKey(x.login) === key) + 1;
     const earned = BADGES.filter((b) => b.earned(cc, runs.length));
     const keyMetrics = store.site.coverage.key_metrics;
     const bd = cc.breakdown;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,7 +38,7 @@ export {
 export type { PlausibilityIssue, PlausibilityInput } from './plausibility.js';
 export { resolveConditions, conditionsComparability } from './conditions.js';
 export type { ResolvedConditions, ConditionsSource, Comparability } from './conditions.js';
-export { computeScores } from './scoring.js';
+export { computeScores, loginKey } from './scoring.js';
 export type { ScoringInput, ScoringOutput, ScoredRun, RegistryCredits } from './scoring.js';
 export { computeCoverage, emptyCell, isReleaseVersion, minorsBehind } from './coverage.js';
 export type { CoverageRegistry, CoverageOptions } from './coverage.js';

--- a/packages/core/src/scoring.test.ts
+++ b/packages/core/src/scoring.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeScores } from './scoring.js';
+import { computeScores, loginKey } from './scoring.js';
 import type { CompiledIndexRow } from './types.js';
 
 function row(
@@ -154,5 +154,47 @@ describe('contributor scoring', () => {
     expect(alice.hardware_ids).toEqual(['apple-m2-max-32gb', 'nvidia-rtx-4090']);
     expect(alice.first_seen).toBe('2026-08-01T00:00:00Z');
     expect(alice.last_seen).toBe('2026-08-05T00:00:00Z');
+  });
+
+  it('is one person however their login is cased', () => {
+    // A result file carries `AzeezIsh`; the registry credit is read out of a noreply address.
+    const scored = computeScores({
+      rows: [
+        row('AzeezIsh', 'cell-a', {}, '2026-09-01T00:00:00Z'),
+        row('azeezish', 'cell-a', {}, '2026-09-02T00:00:00Z'),
+      ],
+      registryCredits: { engines: { atlas: 'AZEEZISH' } },
+    });
+    expect(scored.contributors).toHaveLength(1);
+    const only = scored.contributors[0]!;
+    expect(only.login).toBe('AzeezIsh');
+    expect(only.runs).toBe(2);
+    expect(only.cells_filled).toBe(1);
+    expect(only.breakdown.registry_engines).toBe(1);
+    expect(scored.runs.every((r) => r.login === 'AzeezIsh')).toBe(true);
+  });
+
+  it('does not pay a second run in the same cell as a reproduction of yourself', () => {
+    const scored = computeScores({
+      rows: [
+        row('AzeezIsh', 'cell-a', {}, '2026-09-01T00:00:00Z'),
+        row('azeezish', 'cell-a', {}, '2026-09-02T00:00:00Z'),
+      ],
+    });
+    expect(scored.runs.map((r) => r.role)).toEqual(['fill', 'additional']);
+    expect(scored.runs[1]!.factor).toBeLessThan(1);
+  });
+
+  it('keeps a registry-only contributor listed under the spelling git recorded', () => {
+    const scored = computeScores({
+      rows: [],
+      registryCredits: { engines: { atlas: 'AzeezIsh' } },
+    });
+    expect(scored.contributors[0]!.login).toBe('AzeezIsh');
+  });
+
+  it('loginKey folds case and surrounding space', () => {
+    expect(loginKey('  AzeezIsh ')).toBe('azeezish');
+    expect(loginKey('0xBakeer')).toBe(loginKey('0xbakeer'));
   });
 });

--- a/packages/core/src/scoring.ts
+++ b/packages/core/src/scoring.ts
@@ -39,6 +39,19 @@ const DEFAULT_DIMINISHING = {
   max_runs_counted_per_cell: null as number | null,
 };
 
+/**
+ * The identity a login belongs to, for grouping.
+ *
+ * GitHub logins are unique but not case-sensitive, and the same person reaches this file
+ * spelled two ways: `provenance.login` is the login as the contributor's result file carries
+ * it, while a registry credit is read out of a `…@users.noreply.github.com` address. One
+ * casing difference used to split a person into two rows on the leaderboard, half their
+ * points on each. Group on this; display the spelling that came with the data.
+ */
+export function loginKey(login: string): string {
+  return login.trim().toLowerCase();
+}
+
 /** Who first registered each piece of the registry. `tools/build` derives this from git history. */
 export interface RegistryCredits {
   hardware?: Record<string, string>;
@@ -106,9 +119,9 @@ export function computeScores(input: ScoringInput): ScoringOutput {
   const rows = chronological(input.rows);
 
   const seenCells = new Set<string>();
-  /** cell + config + workload → logins that have already run it, for reproduction credit. */
+  /** cell + config + workload → identities that have already run it, for reproduction credit. */
   const seenExact = new Map<string, Set<string>>();
-  /** login + cell → how many runs that person already has there, for diminishing returns. */
+  /** identity + cell → how many runs that person already has there, for diminishing returns. */
   const perLoginCell = new Map<string, number>();
 
   const contributors = new Map<string, Contributor>();
@@ -116,7 +129,8 @@ export function computeScores(input: ScoringInput): ScoringOutput {
 
   for (const row of rows) {
     const login = row.provenance.login;
-    const contributor = contributors.get(login) ?? {
+    const key = loginKey(login);
+    const contributor = contributors.get(key) ?? {
       login,
       user_id: row.provenance.user_id ?? null,
       runs: 0,
@@ -128,7 +142,7 @@ export function computeScores(input: ScoringInput): ScoringOutput {
       points: 0,
       breakdown: emptyBreakdown(),
     };
-    contributors.set(login, contributor);
+    contributors.set(key, contributor);
     if (contributor.user_id === null && row.provenance.user_id != null) {
       contributor.user_id = row.provenance.user_id;
     }
@@ -136,9 +150,9 @@ export function computeScores(input: ScoringInput): ScoringOutput {
     const exactKey = `${row.cell_id}|${row.config_id}|${row.workload_id}`;
     const priorLogins = seenExact.get(exactKey) ?? new Set<string>();
     const isFill = !seenCells.has(row.cell_id);
-    const isReproduction = !isFill && priorLogins.size > 0 && !priorLogins.has(login);
+    const isReproduction = !isFill && priorLogins.size > 0 && !priorLogins.has(key);
 
-    const perCellKey = `${login}|${row.cell_id}`;
+    const perCellKey = `${key}|${row.cell_id}`;
     const priorOwnRuns = perLoginCell.get(perCellKey) ?? 0;
     const capped =
       diminishing.max_runs_counted_per_cell != null &&
@@ -195,10 +209,17 @@ export function computeScores(input: ScoringInput): ScoringOutput {
       }
     }
 
-    scoredRuns.push({ run_id: row.run_id, login, cell_id: row.cell_id, points, role, factor });
+    scoredRuns.push({
+      run_id: row.run_id,
+      login: contributor.login,
+      cell_id: row.cell_id,
+      points,
+      role,
+      factor,
+    });
 
     seenCells.add(row.cell_id);
-    priorLogins.add(login);
+    priorLogins.add(key);
     seenExact.set(exactKey, priorLogins);
     perLoginCell.set(perCellKey, priorOwnRuns + 1);
   }
@@ -213,8 +234,9 @@ export function computeScores(input: ScoringInput): ScoringOutput {
   ];
   for (const [kind, weight, field] of creditKinds) {
     for (const login of Object.values(credits[kind] ?? {})) {
+      const key = loginKey(login);
       const contributor =
-        contributors.get(login) ??
+        contributors.get(key) ??
         ({
           login,
           user_id: null,
@@ -227,7 +249,7 @@ export function computeScores(input: ScoringInput): ScoringOutput {
           points: 0,
           breakdown: emptyBreakdown(),
         } satisfies Contributor);
-      contributors.set(login, contributor);
+      contributors.set(key, contributor);
       contributor.points += weight;
       contributor.breakdown[field] += 1;
     }

--- a/tools/src/lib/git.ts
+++ b/tools/src/lib/git.ts
@@ -155,11 +155,15 @@ export function addCommits(root: string, paths: string[]): Map<string, GitCommit
  * verbatim, which is the only place git history knows about GitHub identities at all.
  * Anything else returns null and the credit is simply not awarded — guessing a login from
  * a display name would put points on somebody else's account.
+ *
+ * The address spells the login the way GitHub does, so it is returned unchanged: a login
+ * lowercased here and mixed-case in a result file used to score as two people. Compare
+ * logins with `loginKey` from `@atlas/core` rather than by lowercasing at the source.
  */
 export function loginFromEmail(email: string): string | null {
   const match =
     /^(?:\d+\+)?([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)@users\.noreply\.github\.com$/.exec(
       email.trim(),
     );
-  return match ? match[1]!.toLowerCase() : null;
+  return match ? match[1]! : null;
 }

--- a/tools/test/lib.test.ts
+++ b/tools/test/lib.test.ts
@@ -262,5 +262,7 @@ describe('git helpers', () => {
     expect(loginFromEmail('1234+octocat@users.noreply.github.com')).toBe('octocat');
     expect(loginFromEmail('octocat@users.noreply.github.com')).toBe('octocat');
     expect(loginFromEmail('someone@example.com')).toBeNull();
+    // GitHub's own casing, so the credit lands on the same identity as the result file.
+    expect(loginFromEmail('95100110+AzeezIsh@users.noreply.github.com')).toBe('AzeezIsh');
   });
 });


### PR DESCRIPTION
The contributors page listed the same person twice after #182 merged: `azeezish` with 45 points and no runs, `AzeezIsh` with 38.7 points and six.

Both rows are one GitHub account. A result file carries `provenance.login` the way the contributor wrote it (`AzeezIsh`), while a registry credit is derived from the adding commit's `…@users.noreply.github.com` address — and `loginFromEmail` lowercased what it found there. GitHub logins are unique but not case-sensitive, so `computeScores` keyed its map on two spellings of one identity and split the points: the engine (40) and quant (5) credits landed on one row, the six runs on the other.

## What changed

- **`loginKey(login)` in `@atlas/core`** — the identity a login belongs to. `computeScores` now groups contributors on it, and so do the two places inside the loop that were also comparing spellings: per-cell diminishing returns, and the reproduction check that decides whether a run is somebody else's cell or your own. Under the old code a second run under a different casing of your own login would have been paid as a reproduction of a stranger.
- **`loginFromEmail` keeps GitHub's casing.** The noreply address spells the login the way GitHub renders it, so lowercasing it threw away the one piece of canonical casing git history has. Grouping no longer depends on it, but a credit and a result file now agree on sight.
- **The displayed spelling is the one the data carries**, not a normalised one — result rows win over a registry credit, since they are chronologically first for anyone who has both.
- **The app matches the same way**: the leaderboard's index fallback, the contributor count in the stats bar, and `#/contributors/<login>` — a URL with any casing now finds the person, and the profile header shows the spelling from the data rather than whatever was typed in the hash.

`tools/src/lib/ownership.ts` has compared logins case-insensitively since it was written ("matches the login case-insensitively, the way GitHub does"). This is scoring catching up with the rule the ownership check already follows.

## Verification

`pnpm vitest run` — 418 pass, 1 skipped, including four new cases: two spellings plus a `AZEEZISH` registry credit collapse to one contributor with 6 runs and both credits; a second run under a different casing is scored `additional`, not `reproduction`; a registry-only contributor keeps the spelling git recorded; and `loginKey` folds case and space. `pnpm lint`, `pnpm format:check` and `pnpm -r typecheck` are clean.

Rebuilt data locally: **4 contributors**, `AzeezIsh` at 83.65 points with 6 runs, 1 cell, `registry_engines: 1`, `registry_quants: 1`, `user_id: 95100110`. No result file changes and no id changes — the fix is entirely in how the build groups them.

## Not fixed here

`0xBakeer` is credited for none of the 19 hardware, 22 model, 70 quant and 36 workload registrations, because those commits are authored from a real email address rather than a noreply one and `loginFromEmail` correctly refuses to guess a login from a display name. That is a separate decision about whether the maintainer's own registry work should score at all, and it belongs in its own change.
