### PR TITLE
results: point the atlas#572 gotcha at Atlas-Inf, by commit

### DIFF
--- a/results/atlas/Qwen/Qwen3.8-27B/nvidia-gb10-dgx-spark/51e73b9c4540fa1d--longctx-depth-sweep-v1--f4b141.json
+++ b/results/atlas/Qwen/Qwen3.8-27B/nvidia-gb10-dgx-spark/51e73b9c4540fa1d--longctx-depth-sweep-v1--f4b141.json
@@ -468,7 +468,7 @@
     },
     {
       "severity": "info",
-      "text": "The published container azeezish/atlas-gb10:latest (digest sha256:faa6e5820c42dd86d0ae9e12cbaf2a2e9f32d0f7a9ab348a75ee54d4253929a6) CANNOT run these recipes: its spark serve --help has no --prefill-varlen-batch and its --ssm-h-dtype accepts only f32 and f16, not f16-pool. Both landed in https://github.com/Avarok-Cybersecurity/atlas/pull/572 on 2026-08-18 and the image predates them despite a later tag date. This run is therefore a source build, not that image."
+      "text": "The published container azeezish/atlas-gb10:latest (digest sha256:faa6e5820c42dd86d0ae9e12cbaf2a2e9f32d0f7a9ab348a75ee54d4253929a6) CANNOT run these recipes: its spark serve --help has no --prefill-varlen-batch and its --ssm-h-dtype accepts only f32 and f16, not f16-pool. Both landed in https://github.com/Atlas-Inf/atlas/commit/60370b9532a7 on 2026-08-18 and the image predates them despite a later tag date. This run is therefore a source build, not that image."
     },
     {
       "severity": "info",

--- a/results/atlas/Qwen/Qwen3.8-27B/nvidia-gb10-dgx-spark/51e73b9c4540fa1d--serve-chat-c8-i1k-o256-v1--08b0ef.json
+++ b/results/atlas/Qwen/Qwen3.8-27B/nvidia-gb10-dgx-spark/51e73b9c4540fa1d--serve-chat-c8-i1k-o256-v1--08b0ef.json
@@ -180,7 +180,7 @@
     },
     {
       "severity": "info",
-      "text": "The published container azeezish/atlas-gb10:latest (digest sha256:faa6e5820c42dd86d0ae9e12cbaf2a2e9f32d0f7a9ab348a75ee54d4253929a6) CANNOT run these recipes: its spark serve --help has no --prefill-varlen-batch and its --ssm-h-dtype accepts only f32 and f16, not f16-pool. Both landed in https://github.com/Avarok-Cybersecurity/atlas/pull/572 on 2026-08-18 and the image predates them despite a later tag date. This run is therefore a source build, not that image."
+      "text": "The published container azeezish/atlas-gb10:latest (digest sha256:faa6e5820c42dd86d0ae9e12cbaf2a2e9f32d0f7a9ab348a75ee54d4253929a6) CANNOT run these recipes: its spark serve --help has no --prefill-varlen-batch and its --ssm-h-dtype accepts only f32 and f16, not f16-pool. Both landed in https://github.com/Atlas-Inf/atlas/commit/60370b9532a7 on 2026-08-18 and the image predates them despite a later tag date. This run is therefore a source build, not that image."
     },
     {
       "severity": "info",

--- a/results/atlas/Qwen/Qwen3.8-27B/nvidia-gb10-dgx-spark/51e73b9c4540fa1d--serve-single-i256-o256-v1--3550c6.json
+++ b/results/atlas/Qwen/Qwen3.8-27B/nvidia-gb10-dgx-spark/51e73b9c4540fa1d--serve-single-i256-o256-v1--3550c6.json
@@ -181,7 +181,7 @@
     },
     {
       "severity": "info",
-      "text": "The published container azeezish/atlas-gb10:latest (digest sha256:faa6e5820c42dd86d0ae9e12cbaf2a2e9f32d0f7a9ab348a75ee54d4253929a6) CANNOT run these recipes: its spark serve --help has no --prefill-varlen-batch and its --ssm-h-dtype accepts only f32 and f16, not f16-pool. Both landed in https://github.com/Avarok-Cybersecurity/atlas/pull/572 on 2026-08-18 and the image predates them despite a later tag date. This run is therefore a source build, not that image."
+      "text": "The published container azeezish/atlas-gb10:latest (digest sha256:faa6e5820c42dd86d0ae9e12cbaf2a2e9f32d0f7a9ab348a75ee54d4253929a6) CANNOT run these recipes: its spark serve --help has no --prefill-varlen-batch and its --ssm-h-dtype accepts only f32 and f16, not f16-pool. Both landed in https://github.com/Atlas-Inf/atlas/commit/60370b9532a7 on 2026-08-18 and the image predates them despite a later tag date. This run is therefore a source build, not that image."
     },
     {
       "severity": "info",

--- a/results/atlas/Qwen/Qwen3.8-27B/nvidia-gb10-dgx-spark/960e8782ef7fdb70--longctx-depth-sweep-v1--5d797c.json
+++ b/results/atlas/Qwen/Qwen3.8-27B/nvidia-gb10-dgx-spark/960e8782ef7fdb70--longctx-depth-sweep-v1--5d797c.json
@@ -517,7 +517,7 @@
     },
     {
       "severity": "info",
-      "text": "The published container azeezish/atlas-gb10:latest (digest sha256:faa6e5820c42dd86d0ae9e12cbaf2a2e9f32d0f7a9ab348a75ee54d4253929a6) CANNOT run these recipes: its spark serve --help has no --prefill-varlen-batch and its --ssm-h-dtype accepts only f32 and f16, not f16-pool. Both landed in https://github.com/Avarok-Cybersecurity/atlas/pull/572 on 2026-08-18 and the image predates them despite a later tag date. This run is therefore a source build, not that image."
+      "text": "The published container azeezish/atlas-gb10:latest (digest sha256:faa6e5820c42dd86d0ae9e12cbaf2a2e9f32d0f7a9ab348a75ee54d4253929a6) CANNOT run these recipes: its spark serve --help has no --prefill-varlen-batch and its --ssm-h-dtype accepts only f32 and f16, not f16-pool. Both landed in https://github.com/Atlas-Inf/atlas/commit/60370b9532a7 on 2026-08-18 and the image predates them despite a later tag date. This run is therefore a source build, not that image."
     },
     {
       "severity": "info",

--- a/results/atlas/Qwen/Qwen3.8-27B/nvidia-gb10-dgx-spark/960e8782ef7fdb70--serve-chat-c8-i1k-o256-v1--6f5a2a.json
+++ b/results/atlas/Qwen/Qwen3.8-27B/nvidia-gb10-dgx-spark/960e8782ef7fdb70--serve-chat-c8-i1k-o256-v1--6f5a2a.json
@@ -177,7 +177,7 @@
     },
     {
       "severity": "info",
-      "text": "The published container azeezish/atlas-gb10:latest (digest sha256:faa6e5820c42dd86d0ae9e12cbaf2a2e9f32d0f7a9ab348a75ee54d4253929a6) CANNOT run these recipes: its spark serve --help has no --prefill-varlen-batch and its --ssm-h-dtype accepts only f32 and f16, not f16-pool. Both landed in https://github.com/Avarok-Cybersecurity/atlas/pull/572 on 2026-08-18 and the image predates them despite a later tag date. This run is therefore a source build, not that image."
+      "text": "The published container azeezish/atlas-gb10:latest (digest sha256:faa6e5820c42dd86d0ae9e12cbaf2a2e9f32d0f7a9ab348a75ee54d4253929a6) CANNOT run these recipes: its spark serve --help has no --prefill-varlen-batch and its --ssm-h-dtype accepts only f32 and f16, not f16-pool. Both landed in https://github.com/Atlas-Inf/atlas/commit/60370b9532a7 on 2026-08-18 and the image predates them despite a later tag date. This run is therefore a source build, not that image."
     },
     {
       "severity": "info",

--- a/results/atlas/Qwen/Qwen3.8-27B/nvidia-gb10-dgx-spark/960e8782ef7fdb70--serve-single-i256-o256-v1--4f652e.json
+++ b/results/atlas/Qwen/Qwen3.8-27B/nvidia-gb10-dgx-spark/960e8782ef7fdb70--serve-single-i256-o256-v1--4f652e.json
@@ -178,7 +178,7 @@
     },
     {
       "severity": "info",
-      "text": "The published container azeezish/atlas-gb10:latest (digest sha256:faa6e5820c42dd86d0ae9e12cbaf2a2e9f32d0f7a9ab348a75ee54d4253929a6) CANNOT run these recipes: its spark serve --help has no --prefill-varlen-batch and its --ssm-h-dtype accepts only f32 and f16, not f16-pool. Both landed in https://github.com/Avarok-Cybersecurity/atlas/pull/572 on 2026-08-18 and the image predates them despite a later tag date. This run is therefore a source build, not that image."
+      "text": "The published container azeezish/atlas-gb10:latest (digest sha256:faa6e5820c42dd86d0ae9e12cbaf2a2e9f32d0f7a9ab348a75ee54d4253929a6) CANNOT run these recipes: its spark serve --help has no --prefill-varlen-batch and its --ssm-h-dtype accepts only f32 and f16, not f16-pool. Both landed in https://github.com/Atlas-Inf/atlas/commit/60370b9532a7 on 2026-08-18 and the image predates them despite a later tag date. This run is therefore a source build, not that image."
     },
     {
       "severity": "info",


### PR DESCRIPTION
Follow-up to #182, correcting something I got wrong there.

In #182 you flagged that `Atlas-Inf/atlas#572` did not resolve, and you were right — PR numbers did not survive the Avarok → Atlas-Inf migration (`Atlas-Inf/atlas` restarts numbering low; it is at #19). I repointed to `Avarok-Cybersecurity/atlas/pull/572`, which resolves.

But that put a **dead upstream** into a permanent result record. `Avarok-Cybersecurity/atlas` is a read-only history mirror; `Atlas-Inf/atlas` is the live repo and the only one Atlas work belongs in. A gotcha outlives the number it sits next to, so it should send a reader to the repo that is still maintained.

There was a third option neither of us took: **cite the commit.** SHAs did survive the migration.

```
$ gh api repos/Atlas-Inf/atlas/commits/60370b9532a7
FOUND 60370b9532a7  perf: Atlas beats vLLM at every concurrency C=1..128 on Qwen3.8-27B (certified) (#572)  2026-08-18T00:49:35Z
```

Same object in both repos, and it is the commit that added `--prefill-varlen-batch` and the `f16-pool` value for `--ssm-h-dtype`. So `https://github.com/Atlas-Inf/atlas/commit/60370b9532a7`:

- resolves today,
- points at the live repo,
- and cannot break on a future migration, which a bare `owner/repo#number` can and already did once.

Six files, gotcha text only. No metric, config, or id changed; `pnpm validate` is clean at 0 errors. These six strings were the only `Avarok` references anywhere in the repo, so this leaves it with none.
