### PR TITLE
new hardware: Apple M5 Max (128 GB) SoC registry entry

### DIFF
--- a/hardware/apple-m5-max-128gb.json
+++ b/hardware/apple-m5-max-128gb.json
@@ -18,7 +18,7 @@
   "msrp_usd": null,
   "typical_cloud_usd_per_h": null,
   "form_factor": "laptop",
-  "notes": "40-core GPU part, 18-core CPU (6 super + 12 performance), announced 2026-03-03 with the 16-inch MacBook Pro; also configurable in Mac Studio. Bandwidth 614 GB/s is the figure Apple published for the 40-core GPU / 128 GB part. Memory type LPDDR5x-8533 per notebookcheck, not vendor-published. arch verified from the live device (IORegistry AGXG17X). FP32/FP16 null: Apple publishes no tensor throughput, only the relative claim of >4x AI peak vs M4 Max. TDP 75 W is a notebookcheck review measurement, not vendor-published. MSRP null: the same chip is priced differently in MacBook Pro and Mac Studio. Id is memory-specific because unified memory is the binding constraint; the 36/48/64 GB parts of this chip are different ids.",
+  "notes": "40-core GPU part, 18-core CPU (6 super + 12 performance), announced 2026-03-03 with the 16-inch MacBook Pro; also configurable in Mac Studio. Bandwidth 614 GB/s is the figure Apple published for the 40-core GPU / 128 GB part. Memory is LPDDR5X-9600: Apple does not publish the speed, but 614 GB/s over the 512-bit bus of the 40-core part is 9600 MT/s, and the same memory on 384 bits gives the 460 GB/s of the 32-core part. arch verified from the live device (IORegistry AGXG17X). FP32/FP16 null: Apple publishes no tensor throughput, only the relative claim of >4x AI peak vs M4 Max. TDP 75 W is a notebookcheck review measurement, not vendor-published. MSRP null: the same chip is priced differently in MacBook Pro and Mac Studio. Id is memory-specific because unified memory is the binding constraint; the 36/48/64 GB parts of this chip are different ids.",
   "detect": {
     "apple_chip": [
       "Apple M5 Max"
@@ -28,5 +28,7 @@
     ],
     "memory_gb": 128
   },
-  "links": {}
+  "links": {
+    "vendor": "https://www.apple.com/newsroom/2026/03/apple-debuts-m5-pro-and-m5-max-to-supercharge-the-most-demanding-pro-workflows/"
+  }
 }

--- a/hardware/apple-m5-max-128gb.json
+++ b/hardware/apple-m5-max-128gb.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "id": "apple-m5-max-128gb",
+  "name": "Apple M5 Max (128 GB)",
+  "vendor": "apple",
+  "kind": "soc",
+  "memory_gb": 128,
+  "memory_type": "LPDDR5x",
+  "memory_bandwidth_gbs": 614,
+  "compute": {
+    "arch": "apple-gpu-g17",
+    "cores": 40,
+    "fp32_tflops": null,
+    "fp16_tflops": null
+  },
+  "tdp_w": 75,
+  "release_year": 2026,
+  "msrp_usd": null,
+  "typical_cloud_usd_per_h": null,
+  "form_factor": "laptop",
+  "notes": "40-core GPU part, 18-core CPU (6 super + 12 performance), announced 2026-03-03 with the 16-inch MacBook Pro; also configurable in Mac Studio. Bandwidth 614 GB/s is the figure Apple published for the 40-core GPU / 128 GB part. Memory type LPDDR5x-8533 per notebookcheck, not vendor-published. arch verified from the live device (IORegistry AGXG17X). FP32/FP16 null: Apple publishes no tensor throughput, only the relative claim of >4x AI peak vs M4 Max. TDP 75 W is a notebookcheck review measurement, not vendor-published. MSRP null: the same chip is priced differently in MacBook Pro and Mac Studio. Id is memory-specific because unified memory is the binding constraint; the 36/48/64 GB parts of this chip are different ids.",
+  "detect": {
+    "apple_chip": [
+      "Apple M5 Max"
+    ],
+    "cpu_model": [
+      "Apple M5 Max"
+    ],
+    "memory_gb": 128
+  },
+  "links": {}
+}


### PR DESCRIPTION
Adds a hardware registry entry: **apple-m5-max-128gb** — Apple M5 Max (128 GB), 40-core GPU, 614 GB/s.

- **Added** — `hardware/apple-m5-max-128gb.json`: id `apple-m5-max-128gb`, kind `soc`, 128 GB LPDDR5x, 614 GB/s (Apple's published figure for the 128 GB / 40-core GPU part), compute arch `apple-gpu-g17` (verified live from IORegistry `AGXG17X`), 40 GPU cores, TDP 75 W (review measurement), release 2026.
- **What failed** — nothing. Local `pnpm validate` and the full bench test suite (497 passed / 3 skipped) are green.
- **Gotchas** — Apple publishes no tensor throughput, so `fp32_tflops`/`fp16_tflops` are `null` (the >4x AI claim is relative to M4 Max, not a tflops figure). TDP and MSRP are also `null`-justified in `notes`: TDP is a notebookcheck review measurement, and the same chip is priced differently in MacBook Pro and Mac Studio. The 36/48/64 GB and 32-core parts of this chip are different ids (460 GB/s variant), so `detect.memory_gb` is pinned to 128.
- **Conditions** — captured on a live MacBook Pro 16-inch (Mac17,7), Apple M5 Max, 18-core CPU / 40-core GPU / 128 GB, idle, nothing else resident. `detect` uses the strings the capture actually printed (`apple_chip`/`cpu_model` = "Apple M5 Max") plus `memory_gb: 128`.
