### PR TITLE
tui: Enter on WSL, and a visible outcome for "add my box"

### DIFF
--- a/docs/tui/keys.md
+++ b/docs/tui/keys.md
@@ -61,7 +61,7 @@ The selected point is drawn as `◉` and named in the panel underneath.
 | `k` / `↑`                  | previous device                                                                             |
 | `+` / `=` / `→`            | one more of this device                                                                     |
 | `-` / `_` / `←`            | one fewer                                                                                   |
-| `enter`                    | target the highlighted device, and save it to your config                                   |
+| `enter`                    | target the highlighted device, save it to your config, and return to the target view        |
 | `enter` on **not listed?** | propose your box for the registry (asks first)                                              |
 | `esc`                      | back — unless the app has not identified your machine yet, in which case it wants an answer |
 

--- a/docs/tui/target-box.md
+++ b/docs/tui/target-box.md
@@ -49,7 +49,8 @@ information.
 ## Choosing a box
 
 Press **`b`**. The list is every hardware entry in the registry, the detected one first and
-marked. `+` / `-` set how many devices. `enter` selects.
+marked. `+` / `-` set how many devices. `enter` selects — and drops you back on the target
+view, with everything re-ranked against the box you just chose.
 
 Your choice is written to `~/.config/inference-atlas/config.toml`:
 

--- a/docs/tui/troubleshooting.md
+++ b/docs/tui/troubleshooting.md
@@ -88,6 +88,13 @@ the installed memory does not match what the registry expects. Just pick the rig
 Detection counts `nvidia-smi` lines. If some cards are hidden by `CUDA_VISIBLE_DEVICES`, or
 you are targeting a machine other than this one, set it by hand with `+`/`-` in the picker.
 
+### The `+` key adjusts the count but `enter` does not select
+
+Fixed in current versions. Some terminals — several WSL and ConPTY setups among them, and a
+few multiplexers — send a line feed for Enter where others send a carriage return, and the
+app used to recognise only the latter. Every Enter now works. If you are on an older build,
+`inference-atlas --hardware <id> --count <n>` sets the same thing from the command line.
+
 ### Every verdict says "wrong platform"
 
 Your target's platform does not match the engines you are looking at — a Metal engine
@@ -152,6 +159,8 @@ sudo apt install xclip        # X11
 sudo apt install wl-clipboard # Wayland
 ```
 
+Under WSL the app uses `clip.exe`, which is always there — nothing to install.
+
 Over ssh, OSC 52 needs your local terminal to permit clipboard writes — many do by default,
 some need it enabled.
 
@@ -175,6 +184,20 @@ Only `--repo` mode reads local files, and only after the shards are built:
 ```bash
 pnpm build:data && inference-atlas --repo .
 ```
+
+## Adding your box to the registry
+
+### `enter` / `y` on "not listed?" does nothing
+
+Fixed in current versions. Confirming opens your browser at a pre-filled issue form, and on
+a shell with no browser it can reach — WSL without `wslu`, a headless server, a container —
+the failure was invisible.
+
+The app now tries `wslview` and `powershell.exe Start-Process` on WSL, then `$BROWSER`,
+`xdg-open`, `gio open` and `sensible-browser`. If none of them works it says so, puts the
+link on your clipboard, and writes it to
+`<recipes dir>/hardware-request-<id>.txt` — open that from any machine and submit the form
+there. Nothing is ever sent without you submitting it yourself.
 
 ## Starting over
 

--- a/packages/tui/src/recipe/send.test.ts
+++ b/packages/tui/src/recipe/send.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The escape hatches out of the terminal. WSL is the case worth pinning down: it looks
+ * like linux to node, has no `xdg-open`, and its browser and clipboard are Windows-side.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { clipboardTools, osc52, urlOpeners } from './send.js';
+
+const names = (rows: Array<[string, string[]]>): string[] => rows.map(([cmd]) => cmd);
+
+const savedBrowser = process.env['BROWSER'];
+afterEach(() => {
+  if (savedBrowser === undefined) delete process.env['BROWSER'];
+  else process.env['BROWSER'] = savedBrowser;
+});
+
+describe('urlOpeners', () => {
+  const url = 'https://github.com/o/r/issues/new?template=new-hardware.yml&id=nvidia-rtx-4000';
+
+  it('uses the one opener that exists on macOS', () => {
+    expect(urlOpeners(url, 'darwin', false)).toEqual([['open', [url]]]);
+  });
+
+  it('reaches for the Windows side first on WSL, and still falls back to the linux tools', () => {
+    delete process.env['BROWSER'];
+    const tried = names(urlOpeners(url, 'linux', true));
+    expect(tried.slice(0, 2)).toEqual(['wslview', 'powershell.exe']);
+    expect(tried).toContain('xdg-open');
+    expect(tried.indexOf('wslview')).toBeLessThan(tried.indexOf('xdg-open'));
+  });
+
+  it('passes the URL to PowerShell as one quoted argument, so `&` survives', () => {
+    const ps = urlOpeners(url, 'linux', true).find(([cmd]) => cmd === 'powershell.exe')!;
+    const command = ps[1].at(-1)!;
+    expect(command).toBe(`Start-Process '${url}'`);
+    expect(command).toContain('&id=');
+  });
+
+  it('does not offer the Windows tools on a plain linux box', () => {
+    delete process.env['BROWSER'];
+    const tried = names(urlOpeners(url, 'linux', false));
+    expect(tried).not.toContain('wslview');
+    expect(tried).not.toContain('powershell.exe');
+    expect(tried[0]).toBe('xdg-open');
+  });
+
+  it('honours $BROWSER ahead of the generic openers', () => {
+    process.env['BROWSER'] = 'firefox';
+    const tried = names(urlOpeners(url, 'linux', false));
+    expect(tried[0]).toBe('firefox');
+  });
+});
+
+describe('clipboardTools', () => {
+  it('uses clip.exe on WSL before the X/Wayland tools that are not installed there', () => {
+    const tried = names(clipboardTools('linux', true));
+    expect(tried[0]).toBe('clip.exe');
+    expect(tried.indexOf('clip.exe')).toBeLessThan(tried.indexOf('xclip'));
+  });
+
+  it('stays with the display-server tools on a plain linux box', () => {
+    expect(names(clipboardTools('linux', false))).toEqual(['wl-copy', 'xclip', 'xsel']);
+  });
+
+  it('uses pbcopy on macOS', () => {
+    expect(names(clipboardTools('darwin', false))).toEqual(['pbcopy']);
+  });
+});
+
+describe('osc52', () => {
+  it('wraps base64 in the terminal clipboard sequence', () => {
+    expect(osc52('hi')).toBe('\u001b]52;c;aGk=\u0007');
+  });
+});

--- a/packages/tui/src/recipe/send.ts
+++ b/packages/tui/src/recipe/send.ts
@@ -2,10 +2,18 @@
  * Getting a recipe out of the terminal: write it to the recipes directory, copy it to the
  * clipboard, or hand it to a configured agent command. Clipboard goes through OSC 52 first —
  * it works over ssh — with the platform tool as fallback.
+ *
+ * "The platform" is not one thing. WSL reports itself as linux and has neither a display
+ * server nor, usually, `xdg-open`: the Linux path fails there with a bare ENOENT, so both
+ * the browser and the clipboard need the Windows-side tools tried as well. Each helper
+ * therefore walks a list of candidates rather than trusting one command, and reports which
+ * ones it tried when none of them worked — a silent failure here reads to the user as the
+ * key doing nothing at all.
  */
 
 import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import type { AgentTarget } from '../config.js';
 
@@ -22,6 +30,105 @@ export function osc52(text: string): string {
   return `\u001b]52;c;${b64}\u0007`;
 }
 
+/**
+ * Are we inside WSL? `process.platform` says linux, but the browser and the clipboard live
+ * on the Windows side. WSL2 puts "microsoft" in the kernel release; WSL1 and every distro
+ * launched by the standard interop set `WSL_DISTRO_NAME`.
+ */
+export function isWsl(): boolean {
+  if (process.platform !== 'linux') return false;
+  if (process.env['WSL_DISTRO_NAME'] || process.env['WSL_INTEROP']) return true;
+  try {
+    return /microsoft/i.test(os.release());
+  } catch {
+    return false;
+  }
+}
+
+/** A command to try, with its arguments already built for this URL/text. */
+export type Candidate = [cmd: string, args: string[]];
+
+/** PowerShell single-quoted string: the only escape inside one is a doubled quote. */
+const psQuote = (s: string): string => `'${s.replaceAll("'", "''")}'`;
+
+/**
+ * The browser openers to try, most likely to work first. Exported for testing, because
+ * the interesting part of `openUrl` is exactly this ordering.
+ */
+export function urlOpeners(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+  wsl: boolean = isWsl(),
+): Candidate[] {
+  if (platform === 'darwin') return [['open', [url]]];
+  if (platform === 'win32') return [['cmd', ['/c', 'start', '', url]]];
+
+  const candidates: Candidate[] = [];
+  if (wsl) {
+    // wslu's opener when it is installed, then Windows itself. `Start-Process` takes the
+    // URL as one quoted argument, so the `&` between issue-form fields survives — which
+    // `cmd /c start` would swallow.
+    candidates.push(['wslview', [url]]);
+    candidates.push([
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', `Start-Process ${psQuote(url)}`],
+    ]);
+  }
+  const browser = process.env['BROWSER'];
+  if (browser) candidates.push([browser, [url]]);
+  candidates.push(['xdg-open', [url]]);
+  candidates.push(['gio', ['open', url]]);
+  candidates.push(['sensible-browser', [url]]);
+  candidates.push(['x-www-browser', [url]]);
+  return candidates;
+}
+
+/**
+ * Hand a URL to the desktop browser. Never called without the user having confirmed what
+ * the URL contains — opening a page is an outward-facing act.
+ *
+ * Returns the command that worked so the UI can say so, and the list of failures when
+ * nothing did, so "nothing happened" is never the whole story.
+ */
+export function openUrl(url: string): { ok: boolean; via?: string; error?: string } {
+  const tried: string[] = [];
+  for (const [cmd, args] of urlOpeners(url)) {
+    const res = spawnSync(cmd, args, { timeout: 5000, stdio: 'ignore' });
+    if (res.error) {
+      const code = (res.error as NodeJS.ErrnoException).code;
+      // Not installed is the normal case for most of this list; keep walking quietly.
+      tried.push(code === 'ENOENT' ? `${cmd} (not installed)` : `${cmd} (${res.error.message})`);
+      continue;
+    }
+    if (res.status === 0) return { ok: true, via: cmd };
+    tried.push(`${cmd} exited ${res.status ?? '?'}`);
+  }
+  return { ok: false, error: `tried ${tried.join(', ')}` };
+}
+
+/** The clipboard tools to try, in order. Exported for the same reason as `urlOpeners`. */
+export function clipboardTools(
+  platform: NodeJS.Platform = process.platform,
+  wsl: boolean = isWsl(),
+): Candidate[] {
+  if (platform === 'darwin') return [['pbcopy', []]];
+  if (platform === 'win32') return [['clip', []]];
+  const candidates: Candidate[] = [];
+  // On WSL the Windows clipboard is the one the user pastes from, and clip.exe is always
+  // there — no X server, no Wayland socket, no package to install.
+  if (wsl) {
+    candidates.push(['clip.exe', []]);
+    candidates.push([
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', '$input | Set-Clipboard'],
+    ]);
+  }
+  candidates.push(['wl-copy', []]);
+  candidates.push(['xclip', ['-selection', 'clipboard']]);
+  candidates.push(['xsel', ['--input', '--clipboard']]);
+  return candidates;
+}
+
 export function copyToClipboard(text: string, out: NodeJS.WriteStream = process.stdout): boolean {
   // OSC 52 costs nothing and works over ssh/tmux for terminals that allow it.
   try {
@@ -29,35 +136,11 @@ export function copyToClipboard(text: string, out: NodeJS.WriteStream = process.
   } catch {
     /* a closed stream is fine — the platform tool below still runs */
   }
-  const tools: Array<[string, string[]]> =
-    process.platform === 'darwin'
-      ? [['pbcopy', []]]
-      : [
-          ['wl-copy', []],
-          ['xclip', ['-selection', 'clipboard']],
-        ];
-  for (const [cmd, args] of tools) {
+  for (const [cmd, args] of clipboardTools()) {
     const res = spawnSync(cmd, args, { input: text, timeout: 3000 });
-    if (res.status === 0) return true;
+    if (!res.error && res.status === 0) return true;
   }
   return false;
-}
-
-/**
- * Hand a URL to the desktop browser. Never called without the user having confirmed what
- * the URL contains — opening a page is an outward-facing act.
- */
-export function openUrl(url: string): { ok: boolean; error?: string } {
-  const [cmd, args]: [string, string[]] =
-    process.platform === 'darwin'
-      ? ['open', [url]]
-      : process.platform === 'win32'
-        ? ['cmd', ['/c', 'start', '', url]]
-        : ['xdg-open', [url]];
-  const res = spawnSync(cmd, args, { timeout: 5000, stdio: 'ignore' });
-  if (res.error) return { ok: false, error: res.error.message };
-  if (res.status !== 0) return { ok: false, error: `${cmd} exited ${res.status ?? '?'}` };
-  return { ok: true };
 }
 
 export function agentCommand(target: AgentTarget, recipeFile: string): string {

--- a/packages/tui/src/ui/App.tsx
+++ b/packages/tui/src/ui/App.tsx
@@ -20,6 +20,7 @@ import { copyToClipboard, openUrl } from '../recipe/send.js';
 import { saveTarget } from '../config.js';
 import { generateRecipe, recipeFileName } from '../recipe/generate.js';
 import { agentCommand, runAgentCommand, writeRecipe } from '../recipe/send.js';
+import { isConfirm, isEnter, printableInput } from './keys.js';
 import { COLORS } from './theme.js';
 import { KeyHints } from './widgets.js';
 import { CoverageView } from './views/coverage.js';
@@ -240,6 +241,12 @@ export function App({
     setPendingRequest({ request, url: hardwareIssueUrl(request, data.registry.site) });
   }, [initialTarget, data]);
 
+  /**
+   * Commit a box. Picking hardware is only ever a means to an end — the point is what is
+   * worth running on it — so the selection lands on the home view with the re-ranked list
+   * already in front of you. Leaving the user parked in the picker (and only revealing the
+   * answer once they pressed esc) hid the entire result of the action they just took.
+   */
   const selectHardware = useCallback(
     (choice: HardwareChoice) => {
       const next = chooseTarget(choice.hardware, choice.count, initialTarget.captured);
@@ -252,6 +259,7 @@ export function App({
           ? `${targetLabel(next)} — saved to ${saved.file}`
           : `selected, but could not write the config: ${saved.error}`,
       );
+      setView('home');
     },
     [initialTarget],
   );
@@ -263,20 +271,51 @@ export function App({
     }));
   }, []);
 
+  /**
+   * Say yes to the registry request. A headless box — WSL above all — often has no browser
+   * this process can reach, and the old code left the dialog sitting there with an invisible
+   * error, which reads as the key having done nothing. So a failure is never the end: the
+   * link goes to the clipboard and to a file, and the dialog says where it went.
+   */
+  const openRequest = useCallback(
+    (pending: { request: HardwareRequest; url: string }) => {
+      const opened = openUrl(pending.url);
+      if (opened.ok) {
+        setHwStatus(
+          `opened the registry request in your browser${opened.via ? ` (${opened.via})` : ''} — nothing is sent until you submit it there`,
+        );
+        setPendingRequest(null);
+        return;
+      }
+      const copied = copyToClipboard(pending.url);
+      let file: string | null = null;
+      try {
+        file = writeRecipe(
+          recipesDir(config),
+          `hardware-request-${pending.request.id}.txt`,
+          `${pending.url}\n`,
+        );
+      } catch {
+        /* the clipboard is the important half; a read-only recipes dir must not swallow it */
+      }
+      setHwStatus(
+        `no browser this shell can reach (${opened.error ?? 'unknown'}). The link is ` +
+          `${copied ? 'on your clipboard' : 'in your terminal clipboard via OSC52'}` +
+          `${file ? ` and saved to ${file}` : ''} — paste it into a browser. esc closes this.`,
+      );
+    },
+    [config],
+  );
+
   useInput((input, key) => {
     // The confirmation dialog owns the keyboard while it is up: opening a browser is an
     // outward-facing act and must not happen on a stray keypress.
     if (pendingRequest) {
-      if (key.escape || input === 'n' || input === 'q') setPendingRequest(null);
-      else if (key.return || input === 'y') {
-        const opened = openUrl(pendingRequest.url);
-        setHwStatus(
-          opened.ok
-            ? 'opened the registry request in your browser — nothing is sent until you submit it there'
-            : `could not open a browser (${opened.error ?? 'unknown'}) — press c to copy the link`,
-        );
-        if (opened.ok) setPendingRequest(null);
-      } else if (input === 'c') {
+      if (key.escape || input === 'n' || input === 'N' || input === 'q') {
+        setPendingRequest(null);
+        setHwStatus(null);
+      } else if (isConfirm(input, key)) openRequest(pendingRequest);
+      else if (input === 'c') {
         const ok = copyToClipboard(pendingRequest.url);
         setHwStatus(
           ok ? 'link copied to the clipboard' : 'link sent via OSC52 (terminal permitting)',
@@ -288,9 +327,9 @@ export function App({
 
     // Filter entry swallows everything printable.
     if (filtering) {
-      if (key.return || key.escape) setFiltering(false);
+      if (isEnter(input, key) || key.escape) setFiltering(false);
       else if (key.backspace || key.delete) setFilter((f) => f.slice(0, -1));
-      else if (input && !key.ctrl && !key.meta) setFilter((f) => f + input);
+      else if (printableInput(input) && !key.ctrl && !key.meta) setFilter((f) => f + input);
       setSelRuns(0);
       return;
     }
@@ -387,22 +426,23 @@ export function App({
       else if (up) setSelHw((s) => clampSel(s - 1, pickerRows.length));
       else if (choice && (input === '+' || input === '=' || key.rightArrow)) bumpCount(choice, 1);
       else if (choice && (input === '-' || input === '_' || key.leftArrow)) bumpCount(choice, -1);
-      else if (key.return && choice) selectHardware(choice);
-      else if (key.return && row && isAddRow(row)) askToAddBox();
+      else if (isEnter(input, key) && choice) selectHardware(choice);
+      else if (isEnter(input, key) && row && isAddRow(row)) askToAddBox();
     } else if (view === 'home') {
       if (down) setSelHome((s) => clampSel(s + 1, ranked.length));
       else if (up) setSelHome((s) => clampSel(s - 1, ranked.length));
-      else if (key.return && ranked[selHome]) openDetail(ranked[selHome]!.row);
+      else if (isEnter(input, key) && ranked[selHome]) openDetail(ranked[selHome]!.row);
       else if (input === 'g' && ranked[selHome]) openDetail(ranked[selHome]!.row);
     } else if (view === 'runs') {
       if (down) setSelRuns((s) => clampSel(s + 1, filtered.length));
       else if (up) setSelRuns((s) => clampSel(s - 1, filtered.length));
-      else if (key.return && filtered[selRuns]) openDetail(filtered[selRuns]!);
+      else if (isEnter(input, key) && filtered[selRuns]) openDetail(filtered[selRuns]!);
       else if (input === 'g' && filtered[selRuns]) openDetail(filtered[selRuns]!);
     } else if (view === 'pareto') {
       if (down || key.rightArrow) setSelPareto((s) => clampSel(s + 1, pareto.points.length));
       else if (up || key.leftArrow) setSelPareto((s) => clampSel(s - 1, pareto.points.length));
-      else if (key.return && pareto.points[selPareto]) openDetail(pareto.points[selPareto]!.row);
+      else if (isEnter(input, key) && pareto.points[selPareto])
+        openDetail(pareto.points[selPareto]!.row);
     } else if (view === 'detail' && detail) {
       if (input === 'g' && detail.record) openRecipe(detail);
     }
@@ -470,6 +510,7 @@ export function App({
           <HomeView
             data={data}
             target={target}
+            status={hwStatus}
             ranked={ranked}
             keyMetrics={keyMetrics}
             selected={selHome}

--- a/packages/tui/src/ui/app.test.tsx
+++ b/packages/tui/src/ui/app.test.tsx
@@ -8,19 +8,37 @@ import os from 'node:os';
 import path from 'node:path';
 import React from 'react';
 import { render } from 'ink-testing-library';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fixtureRow } from '@atlas/core';
 import { DEFAULT_CONFIG } from '../config.js';
 import { loadAtlas } from '../data/load.js';
 import { LocalSource } from '../data/source.js';
 import type { CapturedHardware } from '../hw/capture.js';
 import { matchHardware } from '../hw/match.js';
+import type * as SendModule from '../recipe/send.js';
 import type { Target } from '../hw/target.js';
 import { App } from './App.js';
 
+const outward = vi.hoisted(() => ({
+  openUrl: vi.fn<(url: string) => { ok: boolean; via?: string; error?: string }>(),
+  copyToClipboard: vi.fn<(text: string) => boolean>(),
+}));
+vi.mock('../recipe/send.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof SendModule>()),
+  openUrl: (url: string) => outward.openUrl(url),
+  copyToClipboard: (text: string) => outward.copyToClipboard(text),
+}));
+
 let repo: string;
+let configHome: string;
+const savedConfigHome = process.env['XDG_CONFIG_HOME'];
 beforeEach(() => {
   repo = fs.mkdtempSync(path.join(os.tmpdir(), 'atlas-tui-app-'));
+  // Picking a box persists it; keep that off the developer's real config file.
+  configHome = fs.mkdtempSync(path.join(os.tmpdir(), 'atlas-tui-cfg-'));
+  process.env['XDG_CONFIG_HOME'] = configHome;
+  outward.openUrl.mockReset().mockReturnValue({ ok: true, via: 'open' });
+  outward.copyToClipboard.mockReset().mockReturnValue(true);
   const dataDir = path.join(repo, 'app', 'public', 'data');
   fs.mkdirSync(dataDir, { recursive: true });
   const write = (name: string, value: unknown) =>
@@ -136,6 +154,9 @@ beforeEach(() => {
 });
 afterEach(() => {
   fs.rmSync(repo, { recursive: true, force: true });
+  fs.rmSync(configHome, { recursive: true, force: true });
+  if (savedConfigHome === undefined) delete process.env['XDG_CONFIG_HOME'];
+  else process.env['XDG_CONFIG_HOME'] = savedConfigHome;
 });
 
 const captured: CapturedHardware = {
@@ -156,6 +177,7 @@ async function renderApp(options: { unknownBox?: boolean } = {}) {
   const match = options.unknownBox ? null : matchHardware(captured, data.registry.hardware);
   const config = structuredClone(DEFAULT_CONFIG);
   config.data.refreshMinutes = 0;
+  config.recipes.dir = path.join(configHome, 'recipes');
   const target: Target = {
     hardware: match?.hardware ?? null,
     count: 1,
@@ -271,6 +293,129 @@ describe('App', () => {
     stdin.write('\u001b'); // esc
     await sleep(300);
     expect(lastFrame()).toContain('Worth running on');
+    unmount();
+  });
+  /*
+   * Enter is not one byte. Ink only names `\r` "return"; a terminal that sends `\n` — which
+   * is what several WSL/ConPTY setups do — used to hit every `key.return` branch as a
+   * no-op, so the keys below simply did nothing with no error to show for it.
+   */
+  it('opens a run when Enter arrives as a line feed', async () => {
+    const { stdin, lastFrame, unmount } = await renderApp();
+    stdin.write('2');
+    await sleep(10);
+    stdin.write('\n');
+    await sleep(50);
+    expect(lastFrame()).toContain('Fit on Apple M2 Max 32GB');
+    unmount();
+  });
+
+  it('confirms the registry request when Enter arrives as a line feed', async () => {
+    const { stdin, lastFrame, unmount } = await renderApp();
+    stdin.write('b');
+    await sleep(20);
+    stdin.write('j');
+    await sleep(20);
+    stdin.write('\n');
+    await sleep(30);
+    expect(lastFrame()).toContain('Add your box to the registry?');
+    stdin.write('n'); // never open a browser from a test
+    await sleep(20);
+    unmount();
+  });
+
+  it('does not let a stray line feed leak into the filter text', async () => {
+    const { stdin, lastFrame, unmount } = await renderApp();
+    stdin.write('/');
+    await sleep(10);
+    stdin.write('Qwen');
+    await sleep(10);
+    stdin.write('\n'); // ends the filter, the way enter does
+    await sleep(10);
+    const frame = lastFrame()!;
+    expect(frame).toContain('filter: Qwen');
+    expect(frame).not.toContain('▌'); // the caret is gone: typing stopped
+    expect(frame).toContain('Qwen/Qwen3-8B'); // and the filter still matches
+    unmount();
+  });
+
+  /*
+   * Picking a box is only a means to an end. The answer lives on the home view, so the
+   * selection has to land there — it used to stay in the picker, and the re-ranked list
+   * only appeared once the user pressed esc.
+   */
+  it('lands on the home view with the ranking as soon as a box is picked', async () => {
+    const { stdin, lastFrame, unmount } = await renderApp({ unknownBox: true });
+    await sleep(20);
+    expect(lastFrame()).toContain('Which box are you running models on?');
+    stdin.write('j'); // past the "not listed?" row, which comes first for an unknown box
+    await sleep(20);
+    stdin.write('\r');
+    await sleep(30);
+    const frame = lastFrame()!;
+    expect(frame).toContain('Worth running on Apple M2 Max 32GB');
+    expect(frame).toContain('Qwen/Qwen3-8B');
+    expect(frame).toContain('saved to'); // the confirmation follows you home
+    expect(frame).not.toContain('Pick your hardware');
+    unmount();
+  });
+
+  it('remembers the picked box in the config file', async () => {
+    const { stdin, unmount } = await renderApp({ unknownBox: true });
+    await sleep(20);
+    stdin.write('j');
+    await sleep(20);
+    stdin.write('\n'); // line-feed enter again: the picker must take it too
+    await sleep(30);
+    const toml = fs.readFileSync(path.join(configHome, 'inference-atlas', 'config.toml'), 'utf8');
+    expect(toml).toContain('hardware = "apple-m2-max-32gb"');
+    unmount();
+  });
+  /*
+   * The reported WSL symptom: `xdg-open` is not installed, `openUrl` failed, and the
+   * dialog dropped the error on the floor — so enter and y both looked like dead keys.
+   */
+  it('says what happened when no browser can be reached, and keeps the link reachable', async () => {
+    outward.openUrl.mockReturnValue({ ok: false, error: 'tried xdg-open (not installed)' });
+    const { stdin, lastFrame, unmount } = await renderApp();
+    stdin.write('b');
+    await sleep(20);
+    stdin.write('j');
+    await sleep(20);
+    stdin.write('\r');
+    await sleep(30);
+    expect(lastFrame()).toContain('Add your box to the registry?');
+    stdin.write('y');
+    await sleep(40);
+    const frame = lastFrame()!;
+    expect(frame).toContain('no browser this shell can reach');
+    expect(frame).toContain('xdg-open (not installed)');
+    expect(frame).toContain('on your clipboard');
+    // The dialog stays up rather than vanishing with the link.
+    expect(frame).toContain('Add your box to the registry?');
+    expect(outward.copyToClipboard).toHaveBeenCalledWith(
+      expect.stringContaining('template=new-hardware.yml'),
+    );
+    // …and the link is on disk too, for a shell with no clipboard bridge at all.
+    const saved = fs.readdirSync(path.join(configHome, 'recipes'));
+    expect(saved.some((f) => f.startsWith('hardware-request-'))).toBe(true);
+    unmount();
+  });
+
+  it('confirms and closes when a browser does open', async () => {
+    const { stdin, lastFrame, unmount } = await renderApp();
+    stdin.write('b');
+    await sleep(20);
+    stdin.write('j');
+    await sleep(20);
+    stdin.write('\r');
+    await sleep(30);
+    stdin.write('y');
+    await sleep(40);
+    const frame = lastFrame()!;
+    expect(frame).toContain('opened the registry request in your browser (open)');
+    expect(frame).toContain('Pick your hardware'); // dialog dismissed
+    expect(outward.openUrl).toHaveBeenCalledTimes(1);
     unmount();
   });
 });

--- a/packages/tui/src/ui/keys.test.ts
+++ b/packages/tui/src/ui/keys.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { isConfirm, isEnter, printableInput } from './keys.js';
+
+describe('isEnter', () => {
+  it('accepts the key Ink names `return`', () => {
+    expect(isEnter('\r', { return: true })).toBe(true);
+  });
+
+  it('accepts a bare carriage return', () => {
+    expect(isEnter('\r', {})).toBe(true);
+  });
+
+  it('accepts a line feed — the WSL/ConPTY spelling Ink never flags as return', () => {
+    expect(isEnter('\n', { return: false })).toBe(true);
+  });
+
+  it('is not fooled by ordinary text', () => {
+    expect(isEnter('j', {})).toBe(false);
+    expect(isEnter('', {})).toBe(false);
+  });
+});
+
+describe('isConfirm', () => {
+  it('takes enter in either spelling, and an explicit yes', () => {
+    expect(isConfirm('\n', {})).toBe(true);
+    expect(isConfirm('\r', { return: true })).toBe(true);
+    expect(isConfirm('y', {})).toBe(true);
+    expect(isConfirm('Y', {})).toBe(true);
+  });
+
+  it('does not confirm on anything else', () => {
+    expect(isConfirm('n', {})).toBe(false);
+    expect(isConfirm('c', {})).toBe(false);
+  });
+});
+
+describe('printableInput', () => {
+  it('keeps text and rejects control characters', () => {
+    expect(printableInput('q')).toBe(true);
+    expect(printableInput('Qwen3')).toBe(true);
+    expect(printableInput('\n')).toBe(false);
+    expect(printableInput('\r')).toBe(false);
+    expect(printableInput('')).toBe(false);
+  });
+});

--- a/packages/tui/src/ui/keys.ts
+++ b/packages/tui/src/ui/keys.ts
@@ -1,0 +1,38 @@
+/**
+ * Enter, as terminals actually send it.
+ *
+ * Ink resolves a keypress to a single name, and only carriage return (`\r`) becomes
+ * `key.return`. A line feed (`\n`) is named `enter` and never sets that flag, so a handler
+ * written as `key.return` is dead on every terminal that sends LF — which is what several
+ * WSL/ConPTY setups and some multiplexers do. The symptom is the worst kind: pressing Enter
+ * does nothing at all, with no error to go on.
+ *
+ * `\n` is not in Ink's non-alphanumeric list either, so it also arrives as printable
+ * `input` — which is why `printableInput` exists: without it a stray LF is appended to the
+ * filter string instead of ending the filter.
+ */
+
+/** Ink's key flags, narrowed to what these helpers actually read. */
+export interface EnterKey {
+  return?: boolean;
+}
+
+/** True for Enter however the terminal spelled it: named `return`, CR, or LF. */
+export function isEnter(input: string, key: EnterKey): boolean {
+  return key.return === true || input === '\r' || input === '\n';
+}
+
+/** Enter, or an explicit yes. Used by confirmation dialogs. */
+export function isConfirm(input: string, key: EnterKey): boolean {
+  return isEnter(input, key) || input === 'y' || input === 'Y';
+}
+
+/** Text worth putting in a filter box: no control characters, no empty events. */
+export function printableInput(input: string): boolean {
+  if (input.length === 0) return false;
+  for (const ch of input) {
+    const code = ch.codePointAt(0)!;
+    if (code < 0x20 || code === 0x7f) return false;
+  }
+  return true;
+}

--- a/packages/tui/src/ui/views/hardware.tsx
+++ b/packages/tui/src/ui/views/hardware.tsx
@@ -86,6 +86,9 @@ export function HardwareView({
         <Panel title="Where it goes">
           <Text color={COLORS.muted}>{shortUrl(pending.url)}</Text>
         </Panel>
+        {status ? (
+          <Text color={status.startsWith('no browser') ? COLORS.warn : COLORS.ok}>{status}</Text>
+        ) : null}
       </Box>
     );
   }

--- a/packages/tui/src/ui/views/home.tsx
+++ b/packages/tui/src/ui/views/home.tsx
@@ -19,6 +19,8 @@ export interface HomeProps {
   selected: number;
   height: number;
   width: number;
+  /** Outcome of the last hardware selection — the picker hands its confirmation over here. */
+  status?: string | null;
 }
 
 const SOURCE_NOTE: Record<Target['source'], string> = {
@@ -35,6 +37,7 @@ export function HomeView({
   selected,
   height,
   width,
+  status,
 }: HomeProps): React.JSX.Element {
   const stats = data.manifest?.counts ?? {};
   return (
@@ -57,6 +60,7 @@ export function HomeView({
           </Text>
         )}
       </Panel>
+      {status ? <Text color={COLORS.ok}>{status}</Text> : null}
       <Panel title={`Worth running on ${targetLabel(target)}`} grow>
         <Table
           height={height}


### PR DESCRIPTION
Two bugs reported from WSL (Ubuntu-24.04), both of which presented as keys that do nothing.

### 1. `enter` / `y` on "add my box to the registry" appeared dead

Two independent causes, both fixed:

**Ink names only `\r` "return".** A line feed is named `enter` and never sets `key.return`. Several WSL/ConPTY setups (and some multiplexers) send LF, so *every* `key.return` branch in the TUI was a no-op there: opening a run, selecting a box, confirming the registry request, ending the filter. `ui/keys.ts` adds `isEnter` / `isConfirm`, which take the key however the terminal spelled it, and `printableInput`, which keeps a stray LF out of the filter string instead of appending it.

**`openUrl` knew exactly one Linux opener, `xdg-open`** — which WSL usually does not have. It returned a failure that went into a status line the confirmation dialog never rendered, so the dialog just sat there. Now:

- the opener walks a list: `wslview` and `powershell.exe Start-Process` on WSL (the URL goes through as one quoted argument, so the `&` between issue-form fields survives — `cmd /c start` would swallow it), then `$BROWSER`, `xdg-open`, `gio open`, `sensible-browser`, `x-www-browser`;
- the dialog renders the outcome either way, naming the opener that worked or every command it tried;
- a total failure falls back to the clipboard (`clip.exe` on WSL, which needs no display server) **and** writes the link to `<recipes dir>/hardware-request-<id>.txt`, so a headless shell still has a way to reach the form.

Nothing is ever sent without the user submitting the form themselves — that contract is unchanged.

### 2. "worth running" only appeared after `esc`

Selecting hardware set the target but left the user parked in the picker; the re-ranked list is on the target view, so the entire result of the action only showed up once they pressed `esc`. `enter` in the picker now lands on the target view, with the list re-ranked and the "saved to …" confirmation carried across.

### Testing

- 7 new `App` cases covering both reports, each verified to fail on `main` and pass here: LF-Enter opening a run, LF-Enter raising the registry dialog, LF not leaking into the filter, selection landing on the target view, the config write, the no-browser-reachable path (status visible, dialog stays up, clipboard + file fallback), and the success path.
- `send.test.ts` pins the opener and clipboard ordering per platform, including WSL-before-`xdg-open` and the PowerShell quoting.
- 146 tests in `@atlas/tui`, full workspace suite, `validate.ts` (0 errors), eslint and prettier all clean.
- Driven end to end against the built CLI in a real pty, sending LF for Enter: selecting a box lands on the target view with the ranking; `enter` on "not listed?" raises the confirmation dialog.
