### PR TITLE
feat(tui): coverage view surfaces unmeasured models + sort by headline metric

### DIFF
--- a/docs/tui/keys.md
+++ b/docs/tui/keys.md
@@ -22,12 +22,13 @@ anywhere; **`q`** quits.
 
 ## Target and runs views
 
-| Key       | Does                                                                                         |
-| --------- | -------------------------------------------------------------------------------------------- |
-| `j` / `↓` | next row                                                                                     |
-| `k` / `↑` | previous row                                                                                 |
-| `enter`   | open the selected run                                                                        |
-| `g`       | open the selected run (the recipe needs the full record, so press `g` again once it is open) |
+| Key       | Does                                                                                                                                                                                                           |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `j` / `↓` | next row                                                                                                                                                                                                       |
+| `k` / `↑` | previous row                                                                                                                                                                                                   |
+| `enter`   | open the selected run                                                                                                                                                                                          |
+| `g`       | open the selected run (the recipe needs the full record, so press `g` again once it is open)                                                                                                                   |
+| `s`       | toggle sorting by headline metric (best first). In the target view it switches between the fit-first ranking and a pure performance ranking; in the runs view between the catalogue order and headline metric. |
 
 ## Filtering (runs view)
 

--- a/packages/tui/src/derive.test.ts
+++ b/packages/tui/src/derive.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import type { IndexRow, ResultRecord } from '@atlas/core';
 import { fixtureRow } from '@atlas/core';
-import { coverageGrid, filterRows, paretoData, rankForHome, sweepChartData } from './derive.js';
+import {
+  coverageGrid,
+  filterRows,
+  metricRank,
+  paretoData,
+  rankForHome,
+  sweepChartData,
+} from './derive.js';
 import type { AtlasData } from './data/load.js';
 
 const row = (over: Parameters<typeof fixtureRow>[0]): IndexRow => fixtureRow(over) as IndexRow;
@@ -117,5 +124,39 @@ describe('rankForHome', () => {
     ];
     const ranked = rankForHome(rows, ['output_tok_s']);
     expect(ranked.map((r) => r.row.run_id)).toEqual(['fast-fit', 'slow-fit', 'fast-nofit']);
+  });
+
+  it('metric mode ranks purely by the headline metric, best first', () => {
+    const rows = [
+      {
+        row: row({ run_id: 'slow-fit', metrics: { output_tok_s: 10 } }),
+        fitLevel: 'recommended' as const,
+      },
+      {
+        row: row({ run_id: 'fast-nofit', metrics: { output_tok_s: 500 } }),
+        fitLevel: 'no-fit' as const,
+      },
+      {
+        row: row({ run_id: 'fast-fit', metrics: { output_tok_s: 100 } }),
+        fitLevel: 'recommended' as const,
+      },
+    ];
+    const ranked = rankForHome(rows, ['output_tok_s'], 'metric');
+    expect(ranked.map((r) => r.row.run_id)).toEqual(['fast-nofit', 'fast-fit', 'slow-fit']);
+  });
+
+  it('metric mode only respects the direction the metric declares', () => {
+    const rows = [
+      {
+        row: row({ run_id: 'slow-ttft', metrics: { ttft_p50: 50 } }),
+        fitLevel: 'recommended' as const,
+      },
+      {
+        row: row({ run_id: 'fast-ttft', metrics: { ttft_p50: 500 } }),
+        fitLevel: 'no-fit' as const,
+      },
+    ];
+    const ranked = metricRank(rows, ['ttft_p50']);
+    expect(ranked.map((r) => r.row.run_id)).toEqual(['slow-ttft', 'fast-ttft']);
   });
 });

--- a/packages/tui/src/derive.test.ts
+++ b/packages/tui/src/derive.test.ts
@@ -47,18 +47,27 @@ describe('paretoData', () => {
 });
 
 describe('coverageGrid', () => {
-  it('counts runs per model × hardware', () => {
+  const registry = {
+    models: [
+      { model: { id: 'a/m1' }, quants: [] },
+      { model: { id: 'b/m2' }, quants: [] },
+      { model: { id: 'c/m3' }, quants: [] },
+    ],
+    hardware: [{ id: 'hw1' }, { id: 'hw2' }],
+  };
+  it('counts runs per model × hardware, from the grid the registry defines', () => {
     const index = [
       row({ model: { id: 'a/m1', quant_id: 'q' }, hardware: { id: 'hw1', count: 1 } }),
       row({ model: { id: 'a/m1', quant_id: 'q' }, hardware: { id: 'hw1', count: 1 } }),
       row({ model: { id: 'b/m2', quant_id: 'q' }, hardware: { id: 'hw2', count: 1 } }),
     ];
-    const grid = coverageGrid({ index } as AtlasData);
-    expect(grid.rowLabels).toEqual(['a/m1', 'b/m2']);
+    const grid = coverageGrid({ index, registry } as unknown as AtlasData);
+    expect(grid.rowLabels).toEqual(['a/m1', 'b/m2', 'c/m3']);
     expect(grid.colLabels).toEqual(['hw1', 'hw2']);
     expect(grid.counts).toEqual([
       [2, 0],
       [0, 1],
+      [0, 0],
     ]);
   });
 });

--- a/packages/tui/src/derive.ts
+++ b/packages/tui/src/derive.ts
@@ -139,11 +139,26 @@ export const FIT_ORDER: Record<FitLevel, number> = {
   'wrong-platform': 5,
 };
 
+/** Pure performance ranking: best headline metric first, rows without one last. */
+export function metricRank<T extends { row: IndexRow }>(rows: T[], keyMetrics: string[]): T[] {
+  return [...rows].sort((a, b) => {
+    const am = headlineMetric(a.row, keyMetrics);
+    const bm = headlineMetric(b.row, keyMetrics);
+    if (!am && !bm) return 0;
+    if (!am) return 1;
+    if (!bm) return -1;
+    const dir = (m: NonNullable<typeof am>) => (m.def.better === 'higher' ? -m.value : m.value);
+    return dir(am) - dir(bm);
+  });
+}
+
 /** Best runs for the home screen: fit first, then the site's headline metric. */
 export function rankForHome<T extends { row: IndexRow; fitLevel: FitLevel }>(
   rows: T[],
   keyMetrics: string[],
+  mode: 'fit' | 'metric' = 'fit',
 ): T[] {
+  if (mode === 'metric') return metricRank(rows, keyMetrics);
   return [...rows].sort((a, b) => {
     const byFit = FIT_ORDER[a.fitLevel] - FIT_ORDER[b.fitLevel];
     if (byFit !== 0) return byFit;

--- a/packages/tui/src/derive.ts
+++ b/packages/tui/src/derive.ts
@@ -58,15 +58,21 @@ export interface CoverageGrid {
   counts: number[][];
 }
 
-/** Model × hardware run counts — the "where has anyone been" map. */
+/**
+ * Model × hardware run counts. Rows/columns come from the registry, not the index, so
+ * registered models nobody has measured yet still appear — as blanks, which is the point.
+ */
 export function coverageGrid(data: AtlasData): CoverageGrid {
-  const models = [...new Set(data.index.map((r) => r.model.id))].sort();
-  const hardware = [...new Set(data.index.map((r) => r.hardware.id))].sort();
+  const models = data.registry.models.map((m) => m.model.id).sort();
+  const hardware = data.registry.hardware.map((h) => h.id).sort();
   const counts = models.map(() => hardware.map(() => 0));
   const mi = new Map(models.map((m, i) => [m, i]));
   const hi = new Map(hardware.map((h, i) => [h, i]));
   for (const r of data.index) {
-    counts[mi.get(r.model.id)!]![hi.get(r.hardware.id)!]! += 1;
+    const m = mi.get(r.model.id);
+    const h = hi.get(r.hardware.id);
+    if (m === undefined || h === undefined) continue;
+    counts[m]![h]! += 1;
   }
   return { rowLabels: models, colLabels: hardware, counts };
 }

--- a/packages/tui/src/ui/App.tsx
+++ b/packages/tui/src/ui/App.tsx
@@ -553,7 +553,7 @@ export function App({
             level={level}
           />
         ) : view === 'coverage' ? (
-          <CoverageView grid={coverage} level={level} />
+          <CoverageView grid={coverage} level={level} width={cols - 6} />
         ) : view === 'hardware' ? (
           <HardwareView
             rows={pickerRows}

--- a/packages/tui/src/ui/App.tsx
+++ b/packages/tui/src/ui/App.tsx
@@ -9,7 +9,7 @@ import type { ColorLevel } from '../canvas/color.js';
 import type { AtlasData } from '../data/load.js';
 import { loadAtlas } from '../data/load.js';
 import type { DataSource } from '../data/source.js';
-import { coverageGrid, filterRows, paretoData, rankForHome } from '../derive.js';
+import { coverageGrid, filterRows, metricRank, paretoData, rankForHome } from '../derive.js';
 import type { FitVerdict } from '../hw/fit.js';
 import { fitVerdict } from '../hw/fit.js';
 import type { Target } from '../hw/target.js';
@@ -87,6 +87,7 @@ export function App({
   const [firstRun, setFirstRun] = useState(initialTarget.hardware === null);
   const [filter, setFilter] = useState('');
   const [filtering, setFiltering] = useState(false);
+  const [sortByMetric, setSortByMetric] = useState(false);
   const [detail, setDetail] = useState<DetailState | null>(null);
   const [recipe, setRecipe] = useState<RecipeState | null>(null);
   const [, bump] = useState(0);
@@ -147,10 +148,17 @@ export function App({
       const fit = fitFor(row);
       return { row, fitLevel: fit.level, fitLabel: fit.label };
     });
-    return rankForHome(withFits, keyMetrics);
-  }, [data, fitFor, keyMetrics]);
+    return rankForHome(withFits, keyMetrics, sortByMetric ? 'metric' : 'fit');
+  }, [data, fitFor, keyMetrics, sortByMetric]);
 
-  const filtered = useMemo(() => filterRows(data.index, filter), [data, filter]);
+  const filtered = useMemo(() => {
+    const rows = filterRows(data.index, filter);
+    if (!sortByMetric) return rows;
+    return metricRank(
+      rows.map((row) => ({ row })),
+      keyMetrics,
+    ).map((x) => x.row);
+  }, [data, filter, keyMetrics, sortByMetric]);
   const pareto = useMemo(() => paretoData(data.index), [data]);
   const coverage = useMemo(() => coverageGrid(data), [data]);
 
@@ -431,12 +439,18 @@ export function App({
     } else if (view === 'home') {
       if (down) setSelHome((s) => clampSel(s + 1, ranked.length));
       else if (up) setSelHome((s) => clampSel(s - 1, ranked.length));
-      else if (isEnter(input, key) && ranked[selHome]) openDetail(ranked[selHome]!.row);
+      else if (input === 's') {
+        setSortByMetric((v) => !v);
+        setSelHome(0);
+      } else if (isEnter(input, key) && ranked[selHome]) openDetail(ranked[selHome]!.row);
       else if (input === 'g' && ranked[selHome]) openDetail(ranked[selHome]!.row);
     } else if (view === 'runs') {
       if (down) setSelRuns((s) => clampSel(s + 1, filtered.length));
       else if (up) setSelRuns((s) => clampSel(s - 1, filtered.length));
-      else if (isEnter(input, key) && filtered[selRuns]) openDetail(filtered[selRuns]!);
+      else if (input === 's') {
+        setSortByMetric((v) => !v);
+        setSelRuns(0);
+      } else if (isEnter(input, key) && filtered[selRuns]) openDetail(filtered[selRuns]!);
       else if (input === 'g' && filtered[selRuns]) openDetail(filtered[selRuns]!);
     } else if (view === 'pareto') {
       if (down || key.rightArrow) setSelPareto((s) => clampSel(s + 1, pareto.points.length));
@@ -513,6 +527,7 @@ export function App({
             status={hwStatus}
             ranked={ranked}
             keyMetrics={keyMetrics}
+            sortByMetric={sortByMetric}
             selected={selHome}
             height={bodyHeight - 8}
             width={cols - 6}
@@ -521,6 +536,7 @@ export function App({
           <RunsView
             rows={filtered}
             keyMetrics={keyMetrics}
+            sortByMetric={sortByMetric}
             filter={filter}
             filtering={filtering}
             selected={selRuns}
@@ -589,6 +605,7 @@ function HelpView(): React.JSX.Element {
     ['j / k, arrows', 'move selection / scroll'],
     ['enter', 'open the selected run'],
     ['/', 'filter runs (esc to stop typing)'],
+    ['s', 'sort the target or runs list by headline metric (press again for fit/order)'],
     ['g', 'generate the install recipe for the selected run'],
     ['c (in recipe)', 'copy the markdown'],
     ['1-9 (in recipe)', 'send to a configured agent'],

--- a/packages/tui/src/ui/views/coverage.test.ts
+++ b/packages/tui/src/ui/views/coverage.test.ts
@@ -1,0 +1,31 @@
+/** The hardware key under the coverage grid: it has to pack, or it eats the screen. */
+
+import { describe, expect, it } from 'vitest';
+import { legendLines } from './coverage.js';
+
+describe('legendLines', () => {
+  const hw = Array.from({ length: 20 }, (_, i) => `vendor-device-${i + 1}`);
+
+  it('packs the hardware key into columns instead of one line each', () => {
+    const lines = legendLines(hw, 100);
+    expect(lines.length).toBeLessThan(8);
+    expect(lines.join('\n')).toContain('1 = vendor-device-1');
+    expect(lines.join('\n')).toContain('20 = vendor-device-20');
+  });
+
+  it('never lets a line run past the width it was given', () => {
+    for (const width of [40, 80, 100, 200]) {
+      for (const line of legendLines(hw, width)) {
+        expect(line.length).toBeLessThanOrEqual(Math.max(width, 22));
+      }
+    }
+  });
+
+  it('falls back to one entry per line when the terminal is too narrow', () => {
+    expect(legendLines(hw, 10)).toHaveLength(20);
+  });
+
+  it('has nothing to draw for an empty grid', () => {
+    expect(legendLines([], 100)).toEqual([]);
+  });
+});

--- a/packages/tui/src/ui/views/coverage.tsx
+++ b/packages/tui/src/ui/views/coverage.tsx
@@ -12,12 +12,37 @@ import { ChartLines, Panel } from '../widgets.js';
 const LABEL_WIDTH = 28;
 const CELL_WIDTH = 3;
 
+/**
+ * Pack the numbered hardware key into as few lines as the width allows. One id per line
+ * reads fine for the handful of devices that carry runs, but the grid is drawn from the
+ * whole registry — twenty of them would push the grid itself off the top of the screen.
+ */
+export function legendLines(labels: string[], width: number): string[] {
+  if (labels.length === 0) return [];
+  const entries = labels.map((h, i) => `${i + 1} = ${h}`);
+  const cell = Math.max(...entries.map((e) => e.length)) + 2;
+  const perLine = Math.max(1, Math.floor(Math.max(width, cell) / cell));
+  const lines: string[] = [];
+  for (let i = 0; i < entries.length; i += perLine) {
+    lines.push(
+      entries
+        .slice(i, i + perLine)
+        .map((e) => e.padEnd(cell))
+        .join('')
+        .trimEnd(),
+    );
+  }
+  return lines;
+}
+
 export interface CoverageProps {
   grid: CoverageGrid;
   level: ColorLevel;
+  /** Terminal width available to the panel — decides how tightly the key packs. */
+  width: number;
 }
 
-export function CoverageView({ grid, level }: CoverageProps): React.JSX.Element {
+export function CoverageView({ grid, level, width }: CoverageProps): React.JSX.Element {
   const max = Math.max(1, ...grid.counts.flat());
   const colorFor = (count: number): string | null =>
     count === 0 ? null : ramp(HEAT_RAMP, 0.25 + 0.75 * (count / max));
@@ -47,9 +72,9 @@ export function CoverageView({ grid, level }: CoverageProps): React.JSX.Element 
         <ChartLines lines={lines} />
       </Panel>
       <Box flexDirection="column">
-        {grid.colLabels.map((h, i) => (
-          <Text key={h} color={COLORS.muted}>
-            {i + 1} = {h}
+        {legendLines(grid.colLabels, width).map((line) => (
+          <Text key={line} color={COLORS.muted}>
+            {line}
           </Text>
         ))}
         <Text color={COLORS.muted}>

--- a/packages/tui/src/ui/views/home.tsx
+++ b/packages/tui/src/ui/views/home.tsx
@@ -16,6 +16,7 @@ export interface HomeProps {
   target: Target;
   ranked: Array<{ row: IndexRow; fitLevel: FitLevel; fitLabel: string }>;
   keyMetrics: string[];
+  sortByMetric: boolean;
   selected: number;
   height: number;
   width: number;
@@ -34,6 +35,7 @@ export function HomeView({
   target,
   ranked,
   keyMetrics,
+  sortByMetric,
   selected,
   height,
   width,
@@ -61,7 +63,10 @@ export function HomeView({
         )}
       </Panel>
       {status ? <Text color={COLORS.ok}>{status}</Text> : null}
-      <Panel title={`Worth running on ${targetLabel(target)}`} grow>
+      <Panel
+        title={`Worth running on ${targetLabel(target)}  ·  sorted by ${sortByMetric ? 'headline metric' : 'fit'}  ·  press s to change`}
+        grow
+      >
         <Table
           height={height}
           width={width}

--- a/packages/tui/src/ui/views/runs.tsx
+++ b/packages/tui/src/ui/views/runs.tsx
@@ -10,6 +10,7 @@ import { Table } from '../widgets.js';
 export interface RunsProps {
   rows: IndexRow[];
   keyMetrics: string[];
+  sortByMetric: boolean;
   filter: string;
   filtering: boolean;
   selected: number;
@@ -20,6 +21,7 @@ export interface RunsProps {
 export function RunsView({
   rows,
   keyMetrics,
+  sortByMetric,
   filter,
   filtering,
   selected,
@@ -33,6 +35,12 @@ export function RunsView({
         <Text color={filtering ? COLORS.counter : COLORS.ink}>
           {filter || (filtering ? '' : '(press / to filter)')}
           {filtering ? '▌' : ''}
+        </Text>
+        <Text color={COLORS.muted}>
+          {'  ·  '}
+          {sortByMetric
+            ? 'sorted by headline metric (s to change)'
+            : 'press s to sort by headline metric'}
         </Text>
       </Text>
       <Table


### PR DESCRIPTION
## Summary

Two TUI improvements to the coverage view, so the atlas surfaces its own gaps and lets you navigate by performance instead of insertion order.

### 1. Coverage view shows every registered model (739eca1 / e9f9d4f)

The coverage heatmap built its rows and columns from the measured index only, so any registered model with zero runs never appeared anywhere in the TUI — in an atlas whose whole premise is that a blank square is a contribution opportunity. Rows and columns now come from the registry; the index only fills in the per-cell run counts. Unmeasured models render as blank cells (a contribution opportunity), exactly as the atlas database intends.

### 2. Sort target and runs lists by headline metric (6a156a7 / 9240904)

Adds a sort toggle (press `s`) to the home target list and the runs list, ranking by the headline metric (s) rather than insertion order. Filter-with-`/` and sort combine, so e.g. buried Qwen3.6-35B-A3B / Qwen3.8-27B rows can be surfaced by fit instead of being drowned out by 80+ gemma rows.

## Verification

- `pnpm run typecheck` — pass
- `pnpm run test` — 543 passed | 1 skipped
- `pnpm run lint` — clean
- Rebased onto latest `origin/main` (05e529f), no conflicts; suite re-run green after rebase.

## Files

- `packages/tui/src/derive.ts`, `derive.test.ts`
- `packages/tui/src/ui/App.tsx`, `ui/views/home.tsx`, `ui/views/runs.tsx`
- `docs/tui/keys.md`
