### PR TITLE
registry credit: resolve a commit address through a claimed identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,18 @@ find out which, do not paper over it.
 Adding hardware, a model, a quantization or an engine is a PR that adds a file. It is never a
 code change. All of these live under CC-BY-4.0 (see `DATA_LICENSE`).
 
+**Getting the credit for it.** A registry file carries no login, so the leaderboard reads the
+author address of the commit that added it. A GitHub noreply address
+(`1234+you@users.noreply.github.com`) already spells your login and needs nothing further. If
+you commit under your own address, add it to `site/identities.json` in the same pull request:
+
+```json
+{ "login": "your-login", "emails": ["you@yourdomain.com"], "verified_by": [123] }
+```
+
+`verified_by` is the pull request the mapping can be checked against — this one will do. You
+may only add or change the entry for your own login; validate rejects anything else.
+
 ### New hardware — `hardware/<id>.json`
 
 - `id`: lowercase kebab-case, vendor first: `nvidia-rtx-5090`, `amd-mi300x`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,10 @@ file — never a code change. `AGENTS.md` has the field-by-field guidance, inclu
 that matters most: **if you are not sure of a specification, write `null` and say why.** The
 plausibility checks are derived from those numbers.
 
+If you commit under an ordinary git address rather than a GitHub noreply one, add it to
+`site/identities.json` in the same pull request — that file is what pays registry additions
+onto your account, and you may only edit your own entry in it.
+
 A model goes to `models/<owner>/<name>/model.json` under its Hugging Face repo id, with
 `hf_id` equal to `id`; its quantizations go to `models/<owner>/<name>/quants/<quant-id>.json`
 with a short lowercase id (`fp8`, `mlx-4bit`, `gguf-q4-k-m`) and the `hf_id` of whichever

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -402,11 +402,18 @@ On every PR:
 5. Plausibility: `output_tok_s_per_request <= memory_bandwidth_gbs / weight_gb * 1.5` (MoE uses active weights), `vram_peak_gb <= memory_gb`, non-negative latencies, `success_rate ∈ [0,1]`, `requests_ok + requests_failed == requests_total`.
 6. Duplicate `run_id` → fail. Same `cell_id+config_id+workload_id` with metric deviation > 25 % from the median of existing → warning + `needs-review` label comment.
 7. Resolve login → numeric user id via `api.github.com/users/<login>` (CI token) and write it into the file in a bot commit on the PR branch (or fail if the login does not exist).
+8. **Identity map ownership:** a PR that changes `site/identities.json` may only add, modify or remove the entry whose `login` equals the PR author. Registry credit is paid on that file, so editing somebody else's entry is editing who gets their points. (Same `maintainer-override` escape as rule 3.)
 
 On `main` build (`build-pages.yml`): `tools/build` stamps `provenance.commit` (the commit that
 added the file, from `git log --diff-filter=A --format=%H -- <path>`) and `provenance.pr`
 (parsed from that commit's message `(#123)`) into the compiled data — the raw files stay as
 the author committed them.
+
+Registry files (`hardware/`, `engines/`, `models/`, `workloads/`) carry no
+`provenance.github_login`, so their contributor comes from the author address of the commit
+that added them: GitHub's `…@users.noreply.github.com` form spells the login directly, and
+`site/identities.json` maps the ordinary addresses people actually commit with. An address in
+neither is credited to nobody. See decision 25.
 
 ## 6. Compiled data for the app (`tools/build` → `app/public/data/`)
 
@@ -692,3 +699,37 @@ or where reality disagreed with it. Each one is binding until superseded here.
     filename is the run id. Restamping is idempotent, refuses to replace a build already
     recorded unless forced, and never touches `cell_id`: a build is a property of the
     configuration, not of the cell the configuration sits in.
+
+25. **Registry credit resolves an address through a claimed identity, never through a
+    display name (2026-09-03).** A result file names its own contributor and validate checks
+    that name against the pull request author, so results are attributable by construction.
+    A registry file — a device, a model, a quant, a workload — has no such field: the only
+    identity in its history is the author address of the commit that added it. Only GitHub's
+    `…@users.noreply.github.com` form spells a login, and guessing one from a display name
+    would put somebody else's points on an account, so anything else was credited to nobody.
+
+    That was not a corner case. Of the five addresses that have added registry files to this
+    repository, one is a noreply address. The other four — 179 files between them, including
+    every piece of hardware, every model and every quant seeded by the maintainer — earned
+    nothing at all, and the first outside contributor to add a device did not appear on the
+    leaderboard at any position.
+
+    `site/identities.json` maps author address → login. Three properties keep it from
+    becoming the guess it replaces. The **noreply form always wins**, so a map entry can
+    never redirect an address GitHub has already spoken for. An **address belongs to exactly
+    one login**, checked across the whole file. And a **pull request may only touch the entry
+    for its own author** (§5.8), which makes the map self-service without making it a way to
+    take somebody else's credit — the same rule result files have always lived under, moved
+    from the file to the entry.
+
+    Entries carry `verified_by`: the pull requests whose author GitHub recorded as that
+    login and whose commits carried that address. `resolve-identities` proposes entries from
+    exactly that evidence — it reads the `(#123)` in each adding commit, asks the API who
+    opened it, and writes the pair down — so filling the map is mechanical rather than a
+    matter of recognising names. The build never makes that call: it reads the committed
+    file, which keeps the compiled data deterministic and offline.
+
+    Two things this deliberately does not do. It does not backfill `provenance` in result
+    files, which already have a better answer. And it does not credit an unclaimed address:
+    an unattributable commit stays unattributed, because crediting a plausible neighbour is
+    worse than crediting nobody.

--- a/schemas/identities.schema.json
+++ b/schemas/identities.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://inference-atlas.dev/schemas/identities.schema.json",
+  "title": "Contributor identity map",
+  "description": "Author email -> GitHub login, so a registry file added with an ordinary git address still earns its contributor credit. Result files carry their own provenance.github_login and never consult this. File: site/identities.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "identities"],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "identities": {
+      "type": "array",
+      "description": "One entry per person. An address may appear in exactly one entry.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["login", "emails"],
+        "properties": {
+          "login": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 39,
+            "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$",
+            "description": "GitHub login, spelled the way GitHub spells it. Compared case-insensitively."
+          },
+          "emails": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "type": "string", "format": "email" },
+            "description": "Author addresses this person commits with. GitHub noreply addresses need no entry — they already carry the login."
+          },
+          "verified_by": {
+            "type": "array",
+            "items": { "type": "integer", "minimum": 1 },
+            "description": "Pull request numbers whose author GitHub recorded as this login, and whose commits carried one of these addresses. This is what makes the entry checkable by anyone with the repository."
+          },
+          "notes": {
+            "$ref": "https://inference-atlas.dev/schemas/common.schema.json#/$defs/nullable_string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/site/identities.json
+++ b/site/identities.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "identities": [
+    {
+      "login": "0xBakeer",
+      "emails": [
+        "bakeer@khaled.de"
+      ],
+      "verified_by": [
+        197
+      ]
+    },
+    {
+      "login": "bumasoft",
+      "emails": [
+        "crisoft.solutions@gmail.com"
+      ],
+      "verified_by": [
+        177
+      ]
+    },
+    {
+      "login": "GraithSecurity",
+      "emails": [
+        "johann@graith.io"
+      ],
+      "verified_by": [
+        194
+      ]
+    },
+    {
+      "login": "johntdavies",
+      "emails": [
+        "John.davies@incept5.com"
+      ],
+      "verified_by": [
+        112
+      ]
+    }
+  ]
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Inference Atlas node CLIs: validate, build, packet, ingest, resolve-users, issue-to-pr.",
+  "description": "Inference Atlas node CLIs: validate, build, packet, ingest, resolve-users, resolve-identities, issue-to-pr.",
   "scripts": {
     "core": "pnpm --filter @atlas/core run build",
     "prevalidate": "pnpm run core",
@@ -16,6 +16,8 @@
     "ingest": "tsx src/ingest/index.ts",
     "preresolve-users": "pnpm run core",
     "resolve-users": "tsx src/resolve-user.ts",
+    "preresolve-identities": "pnpm run core",
+    "resolve-identities": "tsx src/resolve-identities.ts",
     "preissue-to-pr": "pnpm run core",
     "issue-to-pr": "tsx src/issue-to-pr.ts",
     "pretest": "pnpm run core",

--- a/tools/src/build.ts
+++ b/tools/src/build.ts
@@ -44,7 +44,8 @@ import { resolveUsers } from './resolve-user.js';
 import type { ResolveOptions } from './resolve-user.js';
 import { checkDataset } from './lib/datasets.js';
 import type { DatasetStats } from './lib/datasets.js';
-import { addCommits, headCommit, isGitRepo, loginFromEmail, parsePr } from './lib/git.js';
+import { addCommits, headCommit, isGitRepo, parsePr } from './lib/git.js';
+import { indexIdentities, resolveLogin } from './lib/identities.js';
 import type { GitCommit } from './lib/git.js';
 import { computeGaps, possibleCells } from './lib/gaps.js';
 import type { WantedRequest } from './lib/gaps.js';
@@ -467,9 +468,11 @@ function datasetMeta(dataset: Dataset, stats: DatasetStats | undefined) {
  * Who registered each piece of the registry, from the commit that added its file.
  *
  * `computeScores` credits new hardware, models, engines, quants and workloads, but a
- * registry file carries no `github_login` — the only identity in git history is the author
- * email, and only GitHub's `…@users.noreply.github.com` form contains a login. Anything
- * else is skipped rather than guessed (see `loginFromEmail`).
+ * registry file carries no `github_login` — the only identity in its history is the author
+ * address of the commit that added it. GitHub's `…@users.noreply.github.com` form spells
+ * the login; an ordinary address does not, and `site/identities.json` is where a person
+ * says which addresses are theirs (`resolveLogin`). An address in neither is skipped
+ * rather than guessed: crediting a plausible neighbour is worse than crediting nobody.
  */
 function registryCredits(root: string, repo: Repo): RegistryCredits {
   const paths: Array<[keyof RegistryCredits, string, string]> = [];
@@ -487,11 +490,12 @@ function registryCredits(root: string, repo: Repo): RegistryCredits {
     root,
     paths.map(([, , path]) => path),
   );
+  const index = indexIdentities(repo.identities);
   const credits: RegistryCredits = {};
   for (const [kind, id, path] of paths) {
     const commit = commits.get(path);
     if (!commit) continue;
-    const login = loginFromEmail(commit.email);
+    const login = resolveLogin(commit.email, index);
     if (!login) continue;
     const bucket = (credits[kind] ??= {});
     bucket[id] = login;

--- a/tools/src/lib/identities.ts
+++ b/tools/src/lib/identities.ts
@@ -1,0 +1,171 @@
+/**
+ * Who committed this? — the half of contributor identity git cannot answer on its own.
+ *
+ * A result file carries `provenance.github_login`, and validate checks it against the pull
+ * request author, so results are attributable by construction. A registry file — a piece of
+ * hardware, a model, a quant, a workload — carries no such field: the only identity in its
+ * history is the author address of the commit that added it. GitHub's noreply addresses
+ * spell the login (`loginFromEmail`), but an ordinary address does not, and the SPEC
+ * refuses to guess a login from a display name. The consequence was that a contributor who
+ * commits as `you@yourdomain.com` earned nothing for widening the registry.
+ *
+ * `site/identities.json` closes that gap without guessing: a maintained map from author
+ * address to login, where every entry can cite the pull requests GitHub itself recorded
+ * that login as the author of. Two rules keep it honest — an address belongs to exactly one
+ * login, and a pull request may only touch the entry for its own author (see
+ * `ownership.ts`) — so the map is self-service without being a way to take somebody else's
+ * points.
+ *
+ * The build reads only this file. Nothing here talks to the network: `resolve-identities`
+ * is the tool that proposes entries from the GitHub API, and it writes them here first.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { loginFromEmail } from './git.js';
+import type { Reporter } from './report.js';
+
+export const IDENTITIES_PATH = 'site/identities.json';
+
+export interface IdentityEntry {
+  login: string;
+  emails: string[];
+  verified_by?: number[];
+  notes?: string | null;
+}
+
+export interface IdentityMap {
+  schema_version: number;
+  identities: IdentityEntry[];
+}
+
+/** Addresses are compared case-insensitively: nobody means two people by `A@x` and `a@x`. */
+export const emailKey = (email: string): string => email.trim().toLowerCase();
+
+/** Address → login, ready for lookup. */
+export type IdentityIndex = Map<string, string>;
+
+export function indexIdentities(map: IdentityMap | null): IdentityIndex {
+  const index: IdentityIndex = new Map();
+  for (const entry of map?.identities ?? []) {
+    for (const email of entry.emails) {
+      // First writer wins; `checkIdentities` is what reports the duplicate as an error.
+      if (!index.has(emailKey(email))) index.set(emailKey(email), entry.login);
+    }
+  }
+  return index;
+}
+
+/** Read the map, or null when the repository has none (a fork need not keep one). */
+export function loadIdentities(root: string): IdentityMap | null {
+  const file = join(root, IDENTITIES_PATH);
+  if (!existsSync(file)) return null;
+  try {
+    return JSON.parse(readFileSync(file, 'utf8')) as IdentityMap;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The login behind a commit's author address.
+ *
+ * The noreply form wins: it is GitHub's own statement about the account, needs no
+ * maintenance, and cannot drift. The map is consulted only when that says nothing, and
+ * still returns null when it has nothing to say — an unattributable commit stays
+ * unattributed rather than being credited to a plausible neighbour.
+ */
+export function resolveLogin(email: string, index?: IdentityIndex | null): string | null {
+  const fromAddress = loginFromEmail(email);
+  if (fromAddress) return fromAddress;
+  return index?.get(emailKey(email)) ?? null;
+}
+
+/**
+ * Semantic checks the schema cannot express: one address per person, one entry per login,
+ * and a noreply address that did not need an entry at all.
+ */
+export function checkIdentities(map: IdentityMap, reporter: Reporter): void {
+  const byEmail = new Map<string, string>();
+  const byLogin = new Map<string, number>();
+
+  for (const entry of map.identities) {
+    const loginKey = entry.login.trim().toLowerCase();
+    const seenAt = byLogin.get(loginKey);
+    if (seenAt !== undefined) {
+      reporter.error(
+        IDENTITIES_PATH,
+        'identity-duplicate-login',
+        `"${entry.login}" has two entries; put every address of one person in a single entry`,
+      );
+    } else {
+      byLogin.set(loginKey, 1);
+    }
+
+    for (const email of entry.emails) {
+      const key = emailKey(email);
+      const owner = byEmail.get(key);
+      if (owner !== undefined && owner !== loginKey) {
+        reporter.error(
+          IDENTITIES_PATH,
+          'identity-email-conflict',
+          `${email} is claimed by both "${owner}" and "${entry.login}"; an address can only belong to one account`,
+        );
+        continue;
+      }
+      byEmail.set(key, loginKey);
+
+      const fromAddress = loginFromEmail(email);
+      if (fromAddress && fromAddress.toLowerCase() !== loginKey) {
+        reporter.error(
+          IDENTITIES_PATH,
+          'identity-contradicts-address',
+          `${email} is GitHub's noreply address for "${fromAddress}" but is mapped to "${entry.login}"`,
+        );
+      } else if (fromAddress) {
+        reporter.warn(
+          IDENTITIES_PATH,
+          'identity-redundant',
+          `${email} already carries the login; the entry is harmless but does nothing`,
+        );
+      }
+    }
+
+    if (!entry.verified_by || entry.verified_by.length === 0) {
+      reporter.warn(
+        IDENTITIES_PATH,
+        'identity-unverified',
+        `"${entry.login}" cites no pull request; add verified_by so the mapping can be checked against what GitHub recorded`,
+      );
+    }
+  }
+}
+
+/**
+ * The logins an edit to the map touches — added, removed, or had their addresses changed.
+ *
+ * Ownership is decided on this set: you may edit your own entry and nobody else's, which
+ * is the same rule result files live under.
+ */
+export function touchedLogins(before: IdentityMap | null, after: IdentityMap | null): string[] {
+  const fingerprint = (map: IdentityMap | null): Map<string, string> => {
+    const out = new Map<string, string>();
+    for (const entry of map?.identities ?? []) {
+      out.set(
+        entry.login.trim().toLowerCase(),
+        JSON.stringify({
+          login: entry.login,
+          emails: [...entry.emails].map(emailKey).sort(),
+          verified_by: [...(entry.verified_by ?? [])].sort((a, b) => a - b),
+        }),
+      );
+    }
+    return out;
+  };
+
+  const a = fingerprint(before);
+  const b = fingerprint(after);
+  const touched = new Set<string>();
+  for (const [login, value] of b) if (a.get(login) !== value) touched.add(login);
+  for (const [login] of a) if (!b.has(login)) touched.add(login);
+  return [...touched].sort();
+}

--- a/tools/src/lib/ownership.ts
+++ b/tools/src/lib/ownership.ts
@@ -19,6 +19,8 @@ import { join } from 'node:path';
 import type { ResultRecord } from '@atlas/core';
 import type { ChangedFile } from './git.js';
 import { showFile } from './git.js';
+import type { IdentityMap } from './identities.js';
+import { IDENTITIES_PATH, touchedLogins } from './identities.js';
 import type { Reporter } from './report.js';
 
 export interface OwnershipOptions {
@@ -57,6 +59,63 @@ function currentLogin(root: string, path: string): string | null {
   }
 }
 
+/** Parse the identity map at a ref, or null when it is absent or unreadable there. */
+function identitiesAt(text: string | null): IdentityMap | null {
+  if (text === null) return null;
+  try {
+    return JSON.parse(text) as IdentityMap;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `site/identities.json` says which commit addresses belong to which GitHub account, and
+ * registry credit is paid on it — so editing somebody else's entry is editing who gets
+ * their points. The rule is therefore the one results already live under, moved from the
+ * file to the entry: **a pull request may only touch the entry for its own author.**
+ *
+ * That keeps the map self-service. You claim your own addresses in your own pull request,
+ * the author login is the one GitHub recorded, and nobody can quietly redirect a stranger's
+ * contributions. Maintainers still have `maintainer-override` for the seeding case.
+ */
+export function checkIdentityOwnership(
+  changed: ChangedFile[],
+  reporter: Reporter,
+  options: OwnershipOptions,
+): void {
+  const change = changed.find((c) => c.path === IDENTITIES_PATH || c.oldPath === IDENTITIES_PATH);
+  if (!change) return;
+
+  const { root, base, author } = options;
+  const before = identitiesAt(showFile(root, base, IDENTITIES_PATH));
+  const afterText = existsSync(join(root, IDENTITIES_PATH))
+    ? readFileSync(join(root, IDENTITIES_PATH), 'utf8')
+    : null;
+  const after = identitiesAt(afterText);
+
+  if (afterText !== null && after === null) {
+    reporter.error(IDENTITIES_PATH, 'identity-unreadable', 'the identity map is not valid JSON');
+    return;
+  }
+
+  const foreign = touchedLogins(before, after).filter((login) => !sameLogin(login, author));
+  if (foreign.length === 0) return;
+
+  const message = `this pull request changes the identity entr${foreign.length === 1 ? 'y' : 'ies'} for ${foreign
+    .map((l) => `"${l}"`)
+    .join(', ')} but its author is "${author}"; you may only map your own addresses`;
+  if (options.allowOverride === true) {
+    reporter.warn(
+      IDENTITIES_PATH,
+      'ownership-override',
+      `identity-foreign: ${message} (maintainer-override)`,
+    );
+  } else {
+    reporter.error(IDENTITIES_PATH, 'identity-foreign', message);
+  }
+}
+
 export function checkOwnership(
   changed: ChangedFile[],
   reporter: Reporter,
@@ -64,6 +123,8 @@ export function checkOwnership(
 ): void {
   const { root, base, author } = options;
   const override = options.allowOverride === true;
+
+  checkIdentityOwnership(changed, reporter, options);
 
   const results = changed.filter(
     (c) => c.path.startsWith(RESULTS) || c.oldPath?.startsWith(RESULTS),

--- a/tools/src/lib/repo.ts
+++ b/tools/src/lib/repo.ts
@@ -26,6 +26,8 @@ import type {
   Workload,
 } from '@atlas/core';
 import type { Reporter } from './report.js';
+import type { IdentityMap } from './identities.js';
+import { IDENTITIES_PATH } from './identities.js';
 import { Schemas, schemaFor } from './schemas.js';
 
 export interface EngineEntry {
@@ -55,6 +57,8 @@ export interface Repo {
   datasets: Map<string, Dataset>;
   results: LoadedResult[];
   site: SiteConfig | null;
+  /** `site/identities.json`, when the repository keeps one. */
+  identities: IdentityMap | null;
   schemas: Schemas;
   /** Every `.json` file seen under the registry directories, whether or not it validated. */
   seen: string[];
@@ -406,6 +410,12 @@ export function loadRepo(root: string, reporter: Reporter, schemas?: Schemas): R
   const sitePath = join(root, 'site/config.json');
   if (existsSync(sitePath)) site = load<SiteConfig>(sitePath);
 
+  /* ---------------------------------------------------------------- identities */
+
+  let identities: IdentityMap | null = null;
+  const identitiesPath = join(root, IDENTITIES_PATH);
+  if (existsSync(identitiesPath)) identities = load<IdentityMap>(identitiesPath);
+
   /* -------------------------------------------------------------------- results */
 
   const results: LoadedResult[] = [];
@@ -415,7 +425,19 @@ export function loadRepo(root: string, reporter: Reporter, schemas?: Schemas): R
     results.push({ path: relPath(root, path), data });
   }
 
-  return { root, hardware, engines, models, workloads, datasets, results, site, schemas: sc, seen };
+  return {
+    root,
+    hardware,
+    engines,
+    models,
+    workloads,
+    datasets,
+    results,
+    site,
+    identities,
+    schemas: sc,
+    seen,
+  };
 }
 
 /** Every quant in the registry as a flat list — the enumeration gaps and stats both need. */

--- a/tools/src/lib/schemas.ts
+++ b/tools/src/lib/schemas.ts
@@ -22,7 +22,8 @@ export type SchemaName =
   | 'workload'
   | 'dataset'
   | 'result'
-  | 'site';
+  | 'site'
+  | 'identities';
 
 const SCHEMA_BASE = 'https://inference-atlas.dev/schemas';
 
@@ -42,6 +43,7 @@ const RULES: Array<{ pattern: RegExp; name: SchemaName }> = [
   { pattern: /^datasets\/[^/]+\/dataset\.json$/, name: 'dataset' },
   { pattern: /^results\/[^/]+\/[^/]+\/[^/]+\/[^/]+\/[^/]+\.json$/, name: 'result' },
   { pattern: /^site\/config\.json$/, name: 'site' },
+  { pattern: /^site\/identities\.json$/, name: 'identities' },
 ];
 
 /** Directories whose unmapped `.json` files are an error rather than none of our business. */

--- a/tools/src/resolve-identities.ts
+++ b/tools/src/resolve-identities.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env tsx
+/**
+ * `resolve-identities` — propose `site/identities.json` entries from what GitHub recorded.
+ *
+ *   pnpm --filter @atlas/tools run resolve-identities            # report only
+ *   pnpm --filter @atlas/tools run resolve-identities --write    # write the map
+ *
+ * A registry file's only identity is the author address of the commit that added it, and an
+ * ordinary address does not spell a GitHub login. The map fixes that (see
+ * `lib/identities.ts`), but somebody has to fill it in, and filling it in by reading display
+ * names is exactly the guess the SPEC forbids.
+ *
+ * This does it from evidence instead. Every registry file merged through a pull request was
+ * added by a squash commit whose subject ends `(#123)`, and the GitHub API says who that
+ * pull request's author was. Address plus pull request author is a mapping GitHub itself
+ * asserts; the number goes into `verified_by` so anyone can check it later without running
+ * this tool. A commit with no pull request, or one the API cannot confirm, is reported and
+ * left alone — the map only ever grows by evidence.
+ *
+ * Nothing here runs during a build. `tools/build` reads the committed file and never the
+ * network, so the compiled data stays deterministic and works offline.
+ */
+import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgv } from './lib/args.js';
+import { addCommits, isGitRepo, parsePr } from './lib/git.js';
+import type { IdentityEntry, IdentityMap } from './lib/identities.js';
+import { IDENTITIES_PATH, emailKey, indexIdentities, resolveLogin } from './lib/identities.js';
+import { Reporter } from './lib/report.js';
+import { loadRepo } from './lib/repo.js';
+import { REPO_ROOT } from './lib/root.js';
+
+export type FetchLike = (
+  input: string,
+  init?: { headers?: Record<string, string> },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+export interface ResolveIdentityOptions {
+  token?: string | null;
+  fetchImpl?: FetchLike;
+}
+
+/** An address that carries registry files but resolves to no login. */
+export interface UnattributedAddress {
+  email: string;
+  /** Registry files added under this address. */
+  files: number;
+  /** Pull requests those files arrived in, newest last. */
+  prs: number[];
+}
+
+export interface Proposal {
+  email: string;
+  login: string;
+  /** The pull request whose recorded author is this login. */
+  pr: number;
+  files: number;
+}
+
+export interface ResolveIdentitiesOutcome {
+  proposals: Proposal[];
+  /** Addresses no pull request could speak for. */
+  unresolved: UnattributedAddress[];
+  written: boolean;
+}
+
+/** Every registry path the credit calculation cares about (the same set `build` uses). */
+export function registryPaths(repo: ReturnType<typeof loadRepo>): string[] {
+  const paths: string[] = [];
+  for (const id of repo.hardware.keys()) paths.push(`hardware/${id}.json`);
+  for (const id of repo.engines.keys()) paths.push(`engines/${id}/meta.json`);
+  for (const [id, entry] of repo.models) {
+    paths.push(`models/${id}/model.json`);
+    for (const quantId of entry.quants.keys()) paths.push(`models/${id}/quants/${quantId}.json`);
+  }
+  for (const id of repo.workloads.keys()) paths.push(`workloads/${id}.json`);
+  return paths;
+}
+
+/**
+ * Addresses that added registry files and resolve to nobody — the work this tool exists
+ * for, in the order the leaderboard would care about (most files first).
+ */
+export function unattributedAddresses(
+  root: string,
+  repo: ReturnType<typeof loadRepo>,
+): UnattributedAddress[] {
+  const index = indexIdentities(repo.identities);
+  const commits = addCommits(root, registryPaths(repo));
+  const byEmail = new Map<string, UnattributedAddress>();
+
+  for (const commit of commits.values()) {
+    if (resolveLogin(commit.email, index)) continue;
+    const key = emailKey(commit.email);
+    const entry = byEmail.get(key) ?? { email: commit.email, files: 0, prs: [] };
+    entry.files += 1;
+    const pr = parsePr(commit.subject);
+    if (pr !== null && !entry.prs.includes(pr)) entry.prs.push(pr);
+    byEmail.set(key, entry);
+  }
+
+  return [...byEmail.values()]
+    .map((e) => ({ ...e, prs: [...e.prs].sort((a, b) => a - b) }))
+    .sort((a, b) => b.files - a.files || a.email.localeCompare(b.email));
+}
+
+/** The login GitHub recorded as a pull request's author, or null when it cannot say. */
+export async function prAuthor(
+  owner: string,
+  repoName: string,
+  pr: number,
+  options: ResolveIdentityOptions = {},
+): Promise<string | null> {
+  const fetchImpl = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+  const headers: Record<string, string> = {
+    accept: 'application/vnd.github+json',
+    'user-agent': 'inference-atlas-tools',
+  };
+  const token = options.token ?? process.env.GITHUB_TOKEN ?? null;
+  if (token) headers.authorization = `Bearer ${token}`;
+
+  let response: Awaited<ReturnType<FetchLike>>;
+  try {
+    response = await fetchImpl(`https://api.github.com/repos/${owner}/${repoName}/pulls/${pr}`, {
+      headers,
+    });
+  } catch {
+    return null;
+  }
+  if (!response.ok) return null;
+  const body = (await response.json()) as { user?: { login?: unknown } };
+  const login = body.user?.login;
+  return typeof login === 'string' && login.length > 0 ? login : null;
+}
+
+/** Fold proposals into the map, keeping one entry per login and never dropping anything. */
+export function applyProposals(map: IdentityMap | null, proposals: Proposal[]): IdentityMap {
+  const next: IdentityMap = map
+    ? { ...map, identities: map.identities.map((e) => ({ ...e, emails: [...e.emails] })) }
+    : { schema_version: 1, identities: [] };
+
+  for (const proposal of proposals) {
+    const key = proposal.login.trim().toLowerCase();
+    let entry: IdentityEntry | undefined = next.identities.find(
+      (e) => e.login.trim().toLowerCase() === key,
+    );
+    if (!entry) {
+      entry = { login: proposal.login, emails: [], verified_by: [] };
+      next.identities.push(entry);
+    }
+    if (!entry.emails.some((e) => emailKey(e) === emailKey(proposal.email))) {
+      entry.emails.push(proposal.email);
+    }
+    entry.verified_by = [...new Set([...(entry.verified_by ?? []), proposal.pr])].sort(
+      (a, b) => a - b,
+    );
+  }
+
+  next.identities.sort((a, b) => a.login.toLowerCase().localeCompare(b.login.toLowerCase()));
+  return next;
+}
+
+export async function resolveIdentities(
+  root: string,
+  options: ResolveIdentityOptions & { write?: boolean } = {},
+): Promise<ResolveIdentitiesOutcome> {
+  const reporter = new Reporter();
+  const repo = loadRepo(root, reporter);
+  const owner = repo.site?.repo?.owner;
+  const name = repo.site?.repo?.name;
+  if (!owner || !name) throw new Error('site/config.json does not name the repository');
+
+  const pending = unattributedAddresses(root, repo);
+  const proposals: Proposal[] = [];
+  const unresolved: UnattributedAddress[] = [];
+
+  for (const address of pending) {
+    let matched: Proposal | null = null;
+    // Newest pull request first: it is the one whose author account still exists.
+    for (const pr of [...address.prs].reverse()) {
+      const login = await prAuthor(owner, name, pr, options);
+      if (login) {
+        matched = { email: address.email, login, pr, files: address.files };
+        break;
+      }
+    }
+    if (matched) proposals.push(matched);
+    else unresolved.push(address);
+  }
+
+  let written = false;
+  if (options.write === true && proposals.length > 0) {
+    const file = join(root, IDENTITIES_PATH);
+    const current: IdentityMap | null = existsSync(file)
+      ? (JSON.parse(readFileSync(file, 'utf8')) as IdentityMap)
+      : null;
+    writeFileSync(file, `${JSON.stringify(applyProposals(current, proposals), null, 2)}\n`, 'utf8');
+    written = true;
+  }
+
+  return { proposals, unresolved, written };
+}
+
+/* ----------------------------------------------------------------------- CLI */
+
+async function main(argv: string[]): Promise<number> {
+  const args = parseArgv(argv, { boolean: ['json', 'write'] });
+  const root = resolve(args.str('root', REPO_ROOT));
+  if (!isGitRepo(root)) {
+    process.stderr.write('not a git checkout with history; nothing to resolve\n');
+    return 2;
+  }
+
+  const outcome = await resolveIdentities(root, {
+    token: args.str('token'),
+    write: args.bool('write'),
+  });
+
+  if (args.bool('json')) {
+    process.stdout.write(`${JSON.stringify(outcome, null, 2)}\n`);
+    return 0;
+  }
+
+  if (outcome.proposals.length === 0 && outcome.unresolved.length === 0) {
+    process.stdout.write('every registry file already resolves to a contributor\n');
+    return 0;
+  }
+  for (const p of outcome.proposals) {
+    process.stdout.write(
+      `${p.email} → ${p.login}  (PR #${p.pr}, ${p.files} registry file${p.files === 1 ? '' : 's'})\n`,
+    );
+  }
+  for (const u of outcome.unresolved) {
+    process.stderr.write(
+      `warn  ${u.email} adds ${u.files} registry file(s) but no pull request could name its author` +
+        `${u.prs.length > 0 ? ` (tried #${u.prs.join(', #')})` : ' (no pull request in the commit subject)'}\n`,
+    );
+  }
+  process.stdout.write(
+    outcome.written
+      ? `wrote ${IDENTITIES_PATH}\n`
+      : `run again with --write to record ${outcome.proposals.length} mapping(s)\n`,
+  );
+  return 0;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+
+if (invokedDirectly) process.exit(await main(process.argv.slice(2)));

--- a/tools/src/validate.ts
+++ b/tools/src/validate.ts
@@ -28,6 +28,7 @@ import { checkResult } from './lib/check-result.js';
 import { checkDataset } from './lib/datasets.js';
 import { changedFiles as gitChangedFiles, isGitRepo } from './lib/git.js';
 import { buildIndexRow } from './lib/index-row.js';
+import { checkIdentities } from './lib/identities.js';
 import { checkOwnership } from './lib/ownership.js';
 import { loadRepo } from './lib/repo.js';
 import { REPO_ROOT } from './lib/root.js';
@@ -122,6 +123,10 @@ export function validateRepo(options: ValidateOptions): ValidateOutcome {
   /* --------------------------------------------------------------- datasets */
 
   for (const dataset of repo.datasets.values()) checkDataset(root, dataset, reporter);
+
+  /* ------------------------------------------------------------- identities */
+
+  if (repo.identities) checkIdentities(repo.identities, reporter);
 
   /* ---------------------------------------------------------------- results */
 

--- a/tools/test/build.test.ts
+++ b/tools/test/build.test.ts
@@ -501,3 +501,65 @@ describe('contributor ids for contributions merged from forks', () => {
     await expect(resolveContributorIds(join(out, 'no-such-dir'))).resolves.toBeUndefined();
   });
 });
+
+/**
+ * Registry credit. A registry file has no `provenance.github_login`, so who added it can
+ * only come from the commit — and until the identity map existed, only a GitHub noreply
+ * address said anything, which meant most contributors were paid nothing for widening the
+ * registry.
+ */
+describe('registry credit', () => {
+  const addHardware = (author: string, subject: string) => {
+    repo.write('hardware/test-device-1.json', {
+      schema_version: 1,
+      id: 'test-device-1',
+      name: 'Test Device 1',
+      vendor: 'other',
+      kind: 'gpu',
+      memory_gb: 24,
+    });
+    repo.commit(subject, author);
+  };
+
+  const creditFor = (id: string): string | undefined => {
+    const outcome = buildData({ root: repo.root, out });
+    expect(outcome.ok).toBe(true);
+    return read<Array<{ login: string; breakdown: Record<string, number> }>>('contributors.json')
+      .filter((c) => (c.breakdown.registry_hardware ?? 0) > 0)
+      .map((c) => c.login)
+      .find((login) => login.toLowerCase() === id.toLowerCase());
+  };
+
+  it('credits a noreply address without needing the map at all', () => {
+    repo.initGit('seed: registries');
+    addHardware('Zoe <9+zoe@users.noreply.github.com>', 'hardware: a test device (#51)');
+    expect(creditFor('zoe')).toBe('zoe');
+  });
+
+  it('credits an ordinary address once the map claims it', () => {
+    repo.write('site/identities.json', {
+      schema_version: 1,
+      identities: [{ login: 'Yara', emails: ['yara@example.com'], verified_by: [52] }],
+    });
+    repo.initGit('seed: registries');
+    addHardware('Yara <yara@example.com>', 'hardware: a test device (#52)');
+    expect(creditFor('Yara')).toBe('Yara');
+  });
+
+  it('credits nobody for an address the map does not know', () => {
+    repo.initGit('seed: registries');
+    addHardware('Xena <xena@example.com>', 'hardware: a test device (#53)');
+    expect(creditFor('xena')).toBeUndefined();
+  });
+
+  it('never lets the map override the login GitHub wrote into the address', () => {
+    repo.write('site/identities.json', {
+      schema_version: 1,
+      identities: [{ login: 'thief', emails: ['9+zoe@users.noreply.github.com'] }],
+    });
+    repo.initGit('seed: registries');
+    addHardware('Zoe <9+zoe@users.noreply.github.com>', 'hardware: a test device (#54)');
+    expect(creditFor('zoe')).toBe('zoe');
+    expect(creditFor('thief')).toBeUndefined();
+  });
+});

--- a/tools/test/identities.test.ts
+++ b/tools/test/identities.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The identity map: what it resolves, what it refuses to resolve, and the rules that stop
+ * it becoming a way to take somebody else's registry credit.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  checkIdentities,
+  emailKey,
+  indexIdentities,
+  resolveLogin,
+  touchedLogins,
+} from '../src/lib/identities.js';
+import type { IdentityMap } from '../src/lib/identities.js';
+import { applyProposals } from '../src/resolve-identities.js';
+import { Reporter } from '../src/lib/report.js';
+
+const map: IdentityMap = {
+  schema_version: 1,
+  identities: [
+    { login: 'GraithSecurity', emails: ['johann@graith.io'], verified_by: [194] },
+    { login: 'johntdavies', emails: ['John.davies@incept5.com'], verified_by: [112] },
+  ],
+};
+
+const codes = (reporter: Reporter): string[] => reporter.issues.map((i) => i.code);
+
+describe('resolveLogin', () => {
+  const index = indexIdentities(map);
+
+  it('reads the login straight out of a GitHub noreply address', () => {
+    expect(resolveLogin('95100110+AzeezIsh@users.noreply.github.com', index)).toBe('AzeezIsh');
+    expect(resolveLogin('octocat@users.noreply.github.com', null)).toBe('octocat');
+  });
+
+  it('falls back to the map for an ordinary address', () => {
+    expect(resolveLogin('johann@graith.io', index)).toBe('GraithSecurity');
+  });
+
+  it('matches addresses case-insensitively, the way people type them', () => {
+    expect(resolveLogin('john.davies@incept5.com', index)).toBe('johntdavies');
+    expect(resolveLogin('  JOHN.DAVIES@INCEPT5.COM ', index)).toBe('johntdavies');
+  });
+
+  it('still credits nobody for an address nobody has claimed', () => {
+    expect(resolveLogin('stranger@example.com', index)).toBeNull();
+    expect(resolveLogin('stranger@example.com', null)).toBeNull();
+  });
+
+  it('prefers the address GitHub wrote over anything the map says', () => {
+    const hostile = indexIdentities({
+      schema_version: 1,
+      identities: [{ login: 'thief', emails: ['95100110+AzeezIsh@users.noreply.github.com'] }],
+    });
+    expect(resolveLogin('95100110+AzeezIsh@users.noreply.github.com', hostile)).toBe('AzeezIsh');
+  });
+});
+
+describe('checkIdentities', () => {
+  it('passes a well-formed map', () => {
+    const reporter = new Reporter();
+    checkIdentities(map, reporter);
+    expect(codes(reporter)).toEqual([]);
+  });
+
+  it('rejects one address claimed by two people', () => {
+    const reporter = new Reporter();
+    checkIdentities(
+      {
+        schema_version: 1,
+        identities: [
+          { login: 'alice', emails: ['shared@example.com'], verified_by: [1] },
+          { login: 'bob', emails: ['shared@example.com'], verified_by: [2] },
+        ],
+      },
+      reporter,
+    );
+    expect(codes(reporter)).toContain('identity-email-conflict');
+  });
+
+  it('rejects two entries for one login', () => {
+    const reporter = new Reporter();
+    checkIdentities(
+      {
+        schema_version: 1,
+        identities: [
+          { login: 'alice', emails: ['a@example.com'], verified_by: [1] },
+          { login: 'Alice', emails: ['b@example.com'], verified_by: [2] },
+        ],
+      },
+      reporter,
+    );
+    expect(codes(reporter)).toContain('identity-duplicate-login');
+  });
+
+  it('rejects a noreply address pointed at somebody else', () => {
+    const reporter = new Reporter();
+    checkIdentities(
+      {
+        schema_version: 1,
+        identities: [
+          { login: 'thief', emails: ['victim@users.noreply.github.com'], verified_by: [1] },
+        ],
+      },
+      reporter,
+    );
+    expect(codes(reporter)).toContain('identity-contradicts-address');
+  });
+
+  it('warns about an entry that cites no pull request', () => {
+    const reporter = new Reporter();
+    checkIdentities(
+      { schema_version: 1, identities: [{ login: 'alice', emails: ['a@example.com'] }] },
+      reporter,
+    );
+    expect(codes(reporter)).toContain('identity-unverified');
+  });
+});
+
+describe('touchedLogins', () => {
+  it('sees nothing when nothing changed', () => {
+    expect(touchedLogins(map, structuredClone(map))).toEqual([]);
+  });
+
+  it('names the login whose addresses changed', () => {
+    const after = structuredClone(map);
+    after.identities[0]!.emails.push('second@graith.io');
+    expect(touchedLogins(map, after)).toEqual(['graithsecurity']);
+  });
+
+  it('names an added and a removed entry', () => {
+    const added = structuredClone(map);
+    added.identities.push({ login: 'newcomer', emails: ['n@example.com'] });
+    expect(touchedLogins(map, added)).toEqual(['newcomer']);
+
+    const removed = structuredClone(map);
+    removed.identities.splice(1, 1);
+    expect(touchedLogins(map, removed)).toEqual(['johntdavies']);
+  });
+
+  it('treats an absent map as an empty one, so seeding names every entry', () => {
+    expect(touchedLogins(null, map)).toEqual(['graithsecurity', 'johntdavies']);
+  });
+});
+
+describe('applyProposals', () => {
+  it('creates an entry and records the pull request that proved it', () => {
+    const next = applyProposals(null, [
+      { email: 'new@example.com', login: 'newcomer', pr: 42, files: 3 },
+    ]);
+    expect(next.identities).toEqual([
+      { login: 'newcomer', emails: ['new@example.com'], verified_by: [42] },
+    ]);
+  });
+
+  it('adds an address to the entry a person already has', () => {
+    const next = applyProposals(map, [
+      { email: 'second@graith.io', login: 'GraithSecurity', pr: 196, files: 1 },
+    ]);
+    const entry = next.identities.find((e) => e.login === 'GraithSecurity')!;
+    expect(entry.emails).toEqual(['johann@graith.io', 'second@graith.io']);
+    expect(entry.verified_by).toEqual([194, 196]);
+  });
+
+  it('is idempotent — proposing what is already recorded changes nothing', () => {
+    const once = applyProposals(map, [
+      { email: 'johann@graith.io', login: 'GraithSecurity', pr: 194, files: 1 },
+    ]);
+    expect(once.identities.find((e) => e.login === 'GraithSecurity')).toEqual({
+      login: 'GraithSecurity',
+      emails: ['johann@graith.io'],
+      verified_by: [194],
+    });
+  });
+});
+
+describe('emailKey', () => {
+  it('folds case and surrounding space, and nothing else', () => {
+    expect(emailKey('  A@B.com ')).toBe('a@b.com');
+    expect(emailKey('a+tag@b.com')).toBe('a+tag@b.com');
+  });
+});

--- a/tools/test/ownership.test.ts
+++ b/tools/test/ownership.test.ts
@@ -160,3 +160,82 @@ describe('flags and escapes', () => {
     expect(codes(outcome)).toContain('git-diff-failed');
   });
 });
+
+/**
+ * The identity map decides who is paid registry credit, so it lives under the same rule as
+ * a result file: you may claim your own addresses and nobody else's.
+ */
+describe('the identity map', () => {
+  const IDENTITIES = 'site/identities.json';
+
+  it('lets a contributor claim their own address', () => {
+    repo.write(IDENTITIES, {
+      schema_version: 1,
+      identities: [{ login: 'bob', emails: ['bob@example.com'], verified_by: [7] }],
+    });
+    repo.commit('identities: bob claims his commit address');
+    expect(codes(check({ author: 'bob' }))).toEqual([]);
+  });
+
+  it('matches the author login case-insensitively, the way GitHub does', () => {
+    repo.write(IDENTITIES, {
+      schema_version: 1,
+      identities: [{ login: 'BoB', emails: ['bob@example.com'], verified_by: [7] }],
+    });
+    repo.commit('identities: bob claims his commit address');
+    expect(codes(check({ author: 'bob' }))).toEqual([]);
+  });
+
+  it('refuses an entry that maps somebody else’s address', () => {
+    repo.write(IDENTITIES, {
+      schema_version: 1,
+      identities: [{ login: 'carol', emails: ['carol@example.com'], verified_by: [7] }],
+    });
+    repo.commit('identities: redirecting carol’s credit');
+    expect(codes(check({ author: 'bob' }))).toContain('identity-foreign');
+  });
+
+  it('refuses adding an address to somebody else’s entry', () => {
+    repo.write(IDENTITIES, {
+      schema_version: 1,
+      identities: [{ login: 'carol', emails: ['carol@example.com'], verified_by: [7] }],
+    });
+    repo.commit('identities: carol');
+    repo.git('checkout', '-q', 'main');
+    repo.git('merge', '-q', 'contribution');
+    repo.git('checkout', '-q', '-b', 'take-over');
+    repo.write(IDENTITIES, {
+      schema_version: 1,
+      identities: [
+        { login: 'carol', emails: ['carol@example.com', 'bob@example.com'], verified_by: [7] },
+      ],
+    });
+    repo.commit('identities: quietly adding my address to carol');
+    expect(codes(check({ author: 'bob' }))).toContain('identity-foreign');
+  });
+
+  it('refuses deleting somebody else’s entry', () => {
+    repo.write(IDENTITIES, {
+      schema_version: 1,
+      identities: [{ login: 'carol', emails: ['carol@example.com'], verified_by: [7] }],
+    });
+    repo.commit('identities: carol');
+    repo.git('checkout', '-q', 'main');
+    repo.git('merge', '-q', 'contribution');
+    repo.git('checkout', '-q', '-b', 'delete-carol');
+    repo.write(IDENTITIES, { schema_version: 1, identities: [] });
+    repo.commit('identities: removing carol');
+    expect(codes(check({ author: 'bob' }))).toContain('identity-foreign');
+  });
+
+  it('lets a maintainer seed the map with the override label', () => {
+    repo.write(IDENTITIES, {
+      schema_version: 1,
+      identities: [{ login: 'carol', emails: ['carol@example.com'], verified_by: [7] }],
+    });
+    repo.commit('identities: seeding the map');
+    const outcome = check({ author: 'bob', allowOverride: true });
+    expect(codes(outcome)).not.toContain('identity-foreign');
+    expect(codes(outcome, 'warn')).toContain('ownership-override');
+  });
+});


### PR DESCRIPTION
Registry additions have been earning their contributors nothing, and it is not a corner case.

A result file names its contributor in `provenance.github_login` and validate checks that name against the pull request author, so results are attributable by construction. A registry file — a device, a model, a quant, a workload — has no such field: the only identity in its history is the author address of the commit that added it. Only GitHub's `…@users.noreply.github.com` form spells a login, and guessing one from a display name would put somebody else's points on an account, so `loginFromEmail` returned null for everything else and the credit was silently dropped.

Of the five addresses that have ever added registry files here, **one** is a noreply address. The other four account for 179 files — every piece of hardware, every model and every quant in the seed among them — and the first outside contributor to add a device (#194) did not appear on the leaderboard at any position.

## The fix

`site/identities.json` maps author address → login. Three properties keep it from being the guess it replaces:

- **The noreply form always wins.** A map entry can never redirect an address GitHub has already spoken for. There is a test that tries.
- **An address belongs to exactly one login**, checked across the whole file.
- **A pull request may only touch the entry for its own author** (new SPEC §5.8) — the rule result files have always lived under, moved from the file to the entry. That makes the map self-service without making it a way to take somebody else's credit. `maintainer-override` still applies, which is how the seed entries land.

Entries carry `verified_by`: the pull requests whose author GitHub recorded as that login and whose commits carried that address, so any mapping can be re-checked by anyone with the repository.

`pnpm --filter @atlas/tools run resolve-identities [--write]` proposes entries from exactly that evidence — it reads the `(#123)` in each adding commit, asks the API who opened it, and writes the pair down. The four seeded entries in this PR were produced by running it, not typed. The build never makes that call: it reads the committed file, so compiled data stays deterministic and offline.

## Effect on the leaderboard

| contributor | before | after | registry items |
| --- | ---: | ---: | ---: |
| 0xBakeer | 556.07 | 2397.07 | 156 |
| bumasoft | 72.00 | 92.00 | 2 |
| AzeezIsh | 83.65 | 83.65 | 2 |
| johntdavies | 28.13 | 33.13 | 1 |
| GraithSecurity | *absent* | 25.00 | 1 |

AzeezIsh is unchanged, which is the control: his noreply address already resolved and nothing about that path moved.

## What this deliberately does not do

It does not backfill `provenance` in result files, which already have a better answer. And it does not credit an unclaimed address: an unattributable commit stays unattributed, because crediting a plausible neighbour is worse than crediting nobody.

## Testing

- 22 new tests: resolution precedence and the hostile-map case, the semantic checks (one address per person, one entry per login, a noreply address pointed at someone else), `touchedLogins`, `applyProposals` idempotence, six identity-ownership cases against real git, and four build-level credit cases including "the map never overrides the address".
- Full workspace suite green: core 193, app 76, tui 152, tools 177 (+1 skipped). `validate.ts` 0 errors, eslint and prettier clean.
- `resolve-identities` run against this repository reproduces all four mappings from GitHub's own PR records.
