### PR TITLE
build: fill submitted_at from the adding commit; stamp rows git sees as renames

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -192,7 +192,9 @@ jobs:
         run: |
           BASE="origin/${{ github.event.pull_request.base.ref }}"
           git fetch --no-tags origin +refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-          CHANGED=$(git diff --name-only --diff-filter=AM "$BASE"...HEAD -- results/ | tr '\n' ' ')
+          # --no-renames: a row rewritten in the same pull request that drops a sibling can
+          # look like a rename to git, and a rename is neither A nor M.
+          CHANGED=$(git diff --name-only --no-renames --diff-filter=AM "$BASE"...HEAD -- results/ | tr '\n' ' ')
           if [ -z "$CHANGED" ]; then echo "no result files changed"; exit 0; fi
           pnpm --filter @atlas/tools exec tsx src/resolve-user.ts --changed $CHANGED
 

--- a/app/src/views/contributors-view.ts
+++ b/app/src/views/contributors-view.ts
@@ -191,7 +191,9 @@ export class AtlasContributorsView extends ViewElement {
     const runs = store.index.value
       .filter((r) => loginKey(r.provenance.login) === key)
       .sort((a, b) =>
-        (b.provenance.submitted_at ?? '').localeCompare(a.provenance.submitted_at ?? ''),
+        (b.provenance.submitted_at ?? b.provenance.started_at ?? '').localeCompare(
+          a.provenance.submitted_at ?? a.provenance.started_at ?? '',
+        ),
       );
     if (!c && runs.length === 0) {
       return html`<div class="page">

--- a/app/src/views/engines-view.ts
+++ b/app/src/views/engines-view.ts
@@ -119,7 +119,9 @@ export class AtlasEnginesView extends ViewElement {
     const runs = store.index.value
       .filter((r) => r.engine.id === id)
       .sort((a, b) =>
-        (b.provenance.submitted_at ?? '').localeCompare(a.provenance.submitted_at ?? ''),
+        (b.provenance.submitted_at ?? b.provenance.started_at ?? '').localeCompare(
+          a.provenance.submitted_at ?? a.provenance.started_at ?? '',
+        ),
       );
     const { p, c } = this.covOf(id);
     const versions = e.versions;

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -372,6 +372,7 @@ Eval rows: `{ "id", "category", "difficulty", "prompt"|"messages", "answer", "sc
     "github_login": "khaledbakeer", "github_user_id": null,    // user_id resolved by CI, left null by contributor
     "started_at": "2026-08-23T10:00:00Z", "finished_at": "...", "submitted_at": "...",
     "commit": null, "pr": null,                                  // stamped by build from git history; contributor leaves null
+                                                                 // submitted_at may also be left null: the build fills it from the commit that added the file
     "method": "atlas-bench|manual|issue-form|agent",
     "agent": { "name": "claude-code", "model": "claude-fable-5" } | null,
     "notes": "Ambient 22C, box otherwise idle, embed engine resident (10 GiB)."

--- a/results/exllamav3/deepseek-ai/DeepSeek-V4-Flash-0731/nvidia-gb10-dgx-spark/299da4b40264e1ab--eval-longgen-integrity-v1--87fb7b.json
+++ b/results/exllamav3/deepseek-ai/DeepSeek-V4-Flash-0731/nvidia-gb10-dgx-spark/299da4b40264e1ab--eval-longgen-integrity-v1--87fb7b.json
@@ -583,7 +583,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-03T08:12:57Z",
     "finished_at": "2026-09-03T08:38:45Z",
     "submitted_at": null,

--- a/tools/src/build.ts
+++ b/tools/src/build.ts
@@ -10,7 +10,8 @@
  *
  * 1. **Provenance stamping.** `provenance.commit` and `provenance.pr` are derived from
  *    `git log --diff-filter=A` — the commit that *added* the file — and written only into
- *    the compiled copy. The raw file in `results/` is never rewritten, so what a
+ *    the compiled copy, and a `submitted_at` the contributor left null is filled from the
+ *    same commit: the file arriving on main is the submission. The raw file in `results/` is never rewritten, so what a
  *    contributor committed stays exactly what they committed and the stamp cannot be typed
  *    by hand (SPEC §5, last paragraph).
  * 2. **Overlay merging.** `engines/<id>/overlay.json` carries the hand-curated grouping and
@@ -60,7 +61,11 @@ import type { WrittenFile } from './lib/write.js';
 
 const DEFAULT_OUT = 'app/public/data';
 
-/** Provenance as it appears in the compiled data: the three git-derived fields added. */
+/**
+ * Provenance as it appears in the compiled data: the git-derived fields added, and
+ * `submitted_at` filled from the adding commit when the contributor left it null, so every
+ * sort on submission order (timeline, latest results, scoring) has a date to work with.
+ */
 export interface StampedProvenance extends Provenance {
   commit_short: string | null;
   /** Author date of the commit that added the file — when the measurement became public. */
@@ -159,12 +164,16 @@ export function buildData(options: BuildOptions): BuildOutcome {
 
   const stampProvenance = (result: ResultRecord, path: string): StampedProvenance => {
     const commit = stamps.get(path) ?? null;
+    // Author dates come with whatever offset the author's clock had; the app sorts these as
+    // strings, so they are normalised to UTC like every other timestamp in a result.
+    const merged = commit ? utcIso(commit.date) : null;
     return {
       ...result.provenance,
       commit: commit?.commit ?? null,
       commit_short: commit?.commit_short ?? null,
       pr: commit ? parsePr(commit.subject) : null,
-      merged_at: commit?.date ?? null,
+      merged_at: merged,
+      submitted_at: result.provenance.submitted_at ?? merged,
     };
   };
 
@@ -501,6 +510,12 @@ function registryCredits(root: string, repo: Repo): RegistryCredits {
     bucket[id] = login;
   }
   return credits;
+}
+
+/** `2026-09-03T02:12:33-07:00` → `2026-09-03T09:12:33Z`; an unparseable date is kept as is. */
+function utcIso(date: string): string {
+  const ms = Date.parse(date);
+  return Number.isNaN(ms) ? date : new Date(ms).toISOString().replace(/\.\d{3}Z$/, 'Z');
 }
 
 /* ------------------------------------------------- fork contributor user ids */

--- a/tools/test/build.test.ts
+++ b/tools/test/build.test.ts
@@ -369,6 +369,7 @@ describe('determinism and provenance', () => {
   it('stamps the commit and pull request number from git history', () => {
     repo.initGit('seed: registries');
     const carol = makeResult(repo, { login: 'carol', startedAt: '2026-08-05T10:00:00Z' });
+    carol.provenance.submitted_at = null; // what atlas-bench writes
     const path = repo.writeResult(carol);
     repo.commit('results: carol on a 4090 (#42)');
     const head = repo.git('rev-parse', 'HEAD').trim();
@@ -382,17 +383,36 @@ describe('determinism and provenance', () => {
     expect(compiled.provenance.commit).toBe(head);
     expect(compiled.provenance.commit_short).toBe(head.slice(0, 7));
     expect(compiled.provenance.pr).toBe(42);
-    expect(typeof compiled.provenance.merged_at).toBe('string');
+    expect(compiled.provenance.merged_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    // A submitted_at the contributor left null is the adding commit's date, so the
+    // timeline and the scoring order have something to sort on.
+    expect(compiled.provenance.submitted_at).toBe(compiled.provenance.merged_at);
 
     // The raw file is never rewritten: the stamp exists only in the compiled copy.
     const raw = repo.read<{ provenance: Record<string, unknown> }>(path);
     expect(raw.provenance.commit).toBeNull();
     expect(raw.provenance.pr).toBeNull();
+    expect(raw.provenance.submitted_at ?? null).toBeNull();
 
     const row = read<BuiltIndexRow[]>('index.json').find((r) => r.run_id === carol.run_id)!;
     expect(row.provenance.commit).toBe(head);
     expect(row.provenance.pr).toBe(42);
+    expect(row.provenance.submitted_at).toBe(compiled.provenance.merged_at);
     expect(read<{ git: boolean }>('manifest.json').git).toBe(true);
+  });
+
+  it('keeps a submitted_at the contributor wrote', () => {
+    repo.initGit('seed: registries');
+    const erin = makeResult(repo, { login: 'erin', startedAt: '2026-08-07T10:00:00Z' });
+    erin.provenance.submitted_at = '2026-08-07T12:00:00Z';
+    const path = repo.writeResult(erin);
+    repo.commit('results: erin (#43)');
+    expect(buildData({ root: repo.root, out }).ok).toBe(true);
+    const compiled = read<{ provenance: Record<string, unknown> }>(
+      `runs/${path.replace(/^results\//, '')}`,
+    );
+    expect(compiled.provenance.submitted_at).toBe('2026-08-07T12:00:00Z');
+    expect(compiled.provenance.submitted_at).not.toBe(compiled.provenance.merged_at);
   });
 
   it('understands a merge-commit subject as well as a squash subject', () => {


### PR DESCRIPTION
Two things the contributor page made visible after #201.

**Timeline order.** Every atlas-bench result leaves `provenance.submitted_at` null, and the contributor timeline and engine pages sort on that field alone, so 0xBakeer's timeline opened with a row from four days ago while runs merged today sat further down (index order, not time). The build now fills `submitted_at` from the commit that added the file when the contributor left it null, normalised to UTC so string sorts across author time zones hold, and the two views fall back to `started_at` like every other sort in the app. The raw file is still never rewritten; SPEC's provenance example notes the fill. Tests cover the fill, the UTC shape, and that an explicit `submitted_at` is kept.

**A second avatar-less 0xBakeer.** `stamp-user-ids` diffs with rename detection on. In #201 the exllamav3 integrity row replaced a dropped sibling with mostly identical bytes, git reported a rename, and a rename is neither `A` nor `M`, so the row kept `github_user_id: null` and rendered with the initials avatar next to rows carrying the real one. The job now diffs with `--no-renames`; the row that slipped through is stamped by hand (the author's own file).

Local build: 302 runs, 0 with a null `submitted_at`, 0 of 0xBakeer's with a null id. Validator unchanged (0 errors, 203 warnings). 599 tests pass.