### PR TITLE
Ling-3.0-flash: v2 eval suites (thinking on) + two longctx rows

### DIFF
--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-commonsense-v2--3e2b1e.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-commonsense-v2--3e2b1e.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -93,7 +93,7 @@
       "items": 116,
       "concurrency": 4,
       "max_output_tokens": 2048,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -106,7 +106,7 @@
     "requests_total": 116,
     "requests_ok": 116,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 286.776,
     "input_tokens_total": 10860,
     "output_tokens_total": 21328,
@@ -125,7 +125,7 @@
     "power_peak_w": 47.05,
     "energy_wh": 3.5273,
     "gpu_util_avg_pct": 95.18,
-    "temp_max_c": 69.0,
+    "temp_max_c": 69,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -133,7 +133,7 @@
     "total": 116,
     "correct": 110,
     "accuracy": 0.948276,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "false_presupposition": {
         "total": 16,
@@ -303,7 +303,7 @@
         "correct": true,
         "predicted": "B",
         "expected": "B",
-        "latency_ms": 6017.0,
+        "latency_ms": 6017,
         "output_tokens": 73,
         "category": "goal_tracking",
         "difficulty": "easy"
@@ -1375,7 +1375,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-09T22:59:52Z",
     "finished_at": "2026-09-09T23:04:38Z",
     "submitted_at": null,

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-commonsense-v2--3e2b1e.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-commonsense-v2--3e2b1e.json
@@ -1,0 +1,1393 @@
+{
+  "schema_version": 1,
+  "run_id": "a3b46e9ee9b29ebc--eval-commonsense-v2--3e2b1e",
+  "config_id": "a3b46e9ee9b29ebc",
+  "cell_id": "4ab17fea2273",
+  "workload_id": "eval-commonsense-v2",
+  "kind": "eval",
+  "engine": {
+    "id": "sglang",
+    "version": "0.0.0.dev1+g079d40460",
+    "commit": null,
+    "build": "github.com/inclusionAI/sglang@079d404",
+    "container": "lmsysorg/sglang:v0.0.0.dev1+g079d40460-cu126",
+    "install_method": "source"
+  },
+  "model": {
+    "id": "inclusionAI/Ling-3.0-flash",
+    "quant_id": "mxfp4",
+    "hf_id": "inclusionAI/Ling-3.0-flash",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "moe-runner-backend": "humming",
+    "speculative-algorithm": "DSPARK",
+    "speculative-draft-model-path": "inclusionAI/Ling-3.0-flash-dspark",
+    "enable-linear-replayssm-spec": true,
+    "linear-replayssm-cache-len": 32,
+    "mem-fraction-static": 0.75,
+    "max-running-requests": 1,
+    "max-mamba-cache-size": 64,
+    "chunked-prefill-size": 8192,
+    "max-prefill-tokens": 16384,
+    "page-size": 64,
+    "attention-backend": "flashinfer",
+    "fp8-gemm-backend": "cutlass",
+    "flashinfer-mxfp4-moe-precision": "default",
+    "disable-shared-experts-fusion": true,
+    "cuda-graph-backend-decode": "full",
+    "cuda-graph-max-bs-decode": 1,
+    "cuda-graph-backend-prefill": "disabled",
+    "reasoning-parser": "deepseek-r1",
+    "tool-call-parser": "qwen25",
+    "trust-remote-code": true,
+    "fp8-lm-head": "online",
+    "default-chat-template-kwargs": {
+      "enable_thinking": true
+    }
+  },
+  "args_canonical": "@build=github.com/inclusionai/sglang@079d404;@dtype=auto;@quant=mxfp4;attention-backend=flashinfer;chunked-prefill-size=8192;cuda-graph-backend-decode=full;cuda-graph-backend-prefill=disabled;cuda-graph-max-bs-decode=1;default-chat-template-kwargs={\"enable_thinking\":true};disable-shared-experts-fusion=true;enable-linear-replayssm-spec=true;fp8-gemm-backend=cutlass;fp8-lm-head=online;linear-replayssm-cache-len=32;max-mamba-cache-size=64;max-running-requests=1;mem-fraction-static=0.75;moe-runner-backend=humming;page-size=64;reasoning-parser=deepseek-r1;speculative-algorithm=DSPARK;speculative-draft-model-path=inclusionAI/Ling-3.0-flash-dspark;tool-call-parser=qwen25;trust-remote-code=true",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-commonsense-v2",
+    "resolved_params": {
+      "dataset_id": "eval-commonsense-v2",
+      "suite": "commonsense",
+      "scorer": "mc",
+      "items": 116,
+      "concurrency": 4,
+      "max_output_tokens": 2048,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 116,
+    "requests_ok": 116,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 286.776,
+    "input_tokens_total": 10860,
+    "output_tokens_total": 21328,
+    "e2e_ms": {
+      "mean": 9778.453,
+      "p50": 7633.595,
+      "p90": 17386.195,
+      "p95": 22108.972,
+      "p99": 38960.941,
+      "min": 3719.827,
+      "max": 39406.55
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 115.704,
+    "power_avg_w": 44.27,
+    "power_peak_w": 47.05,
+    "energy_wh": 3.5273,
+    "gpu_util_avg_pct": 95.18,
+    "temp_max_c": 69.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "commonsense",
+    "total": 116,
+    "correct": 110,
+    "accuracy": 0.948276,
+    "success_rate": 1.0,
+    "by_category": {
+      "false_presupposition": {
+        "total": 16,
+        "correct": 16
+      },
+      "feasibility": {
+        "total": 12,
+        "correct": 11
+      },
+      "goal_tracking": {
+        "total": 22,
+        "correct": 22
+      },
+      "physical": {
+        "total": 20,
+        "correct": 19
+      },
+      "reversed_classics": {
+        "total": 14,
+        "correct": 14
+      },
+      "text_selfref": {
+        "total": 32,
+        "correct": 28
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 27,
+        "correct": 27
+      },
+      "hard": {
+        "total": 31,
+        "correct": 28
+      },
+      "medium": {
+        "total": 58,
+        "correct": 55
+      }
+    },
+    "avg_output_tokens": 183.86,
+    "avg_latency_ms": 9778.45,
+    "failures": 0,
+    "items": [
+      {
+        "id": "common-0001",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4489.878,
+        "output_tokens": 232,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0002",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 5925.383,
+        "output_tokens": 73,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0003",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 6940.09,
+        "output_tokens": 79,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0004",
+        "correct": false,
+        "predicted": "D",
+        "expected": "B",
+        "latency_ms": 22688.517,
+        "output_tokens": 1083,
+        "category": "feasibility",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0005",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 21605.975,
+        "output_tokens": 228,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0006",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 21151.196,
+        "output_tokens": 56,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0007",
+        "correct": false,
+        "predicted": "1.  **Analyze the Request:**\n    *   Input word: \"drawer\"\n    *   Task: Write the word backwards.\n    *   Constraint: Reply with the reversed word *only*.\n\n2.  **Process the Word:**\n    *   Original: d-r-a-w-e-r\n    *   Reversed: r-e-w-a-r-d\n\n3.  **Format the Output:**\n    *   Constraint check: \"Reply with the reversed word only.\"\n    *   Output: \"rewar d\" -> wait, \"rewar d\" has a space. Let's trace carefully.\n    *   d (1)\n    *   r (2)\n    *   a (3)\n    *   w (4)\n    *   e (5)\n    *   r (6)\n  ",
+        "expected": "reward",
+        "latency_ms": 33819.489,
+        "output_tokens": 2048,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0008",
+        "correct": true,
+        "predicted": "45",
+        "expected": "45",
+        "latency_ms": 21687.885,
+        "output_tokens": 316,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0009",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 20513.633,
+        "output_tokens": 147,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0010",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 21915.79,
+        "output_tokens": 153,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0011",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 9455.88,
+        "output_tokens": 71,
+        "category": "feasibility",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0012",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 6913.436,
+        "output_tokens": 92,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0013",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 6017.0,
+        "output_tokens": 73,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0014",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 4772.94,
+        "output_tokens": 86,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0015",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 4841.692,
+        "output_tokens": 127,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0016",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 5429.956,
+        "output_tokens": 111,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0017",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 4943.857,
+        "output_tokens": 72,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0018",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 4421.893,
+        "output_tokens": 37,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0019",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 4209.038,
+        "output_tokens": 97,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0020",
+        "correct": true,
+        "predicted": "17:00",
+        "expected": "17:00",
+        "latency_ms": 4147.955,
+        "output_tokens": 160,
+        "category": "feasibility",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0021",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 4635.977,
+        "output_tokens": 110,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0022",
+        "correct": true,
+        "predicted": "11",
+        "expected": "11",
+        "latency_ms": 5030.66,
+        "output_tokens": 106,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0023",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 8614.26,
+        "output_tokens": 474,
+        "category": "feasibility",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0024",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 7851.167,
+        "output_tokens": 54,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0025",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 7440.953,
+        "output_tokens": 96,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0026",
+        "correct": true,
+        "predicted": "10",
+        "expected": "10",
+        "latency_ms": 8397.599,
+        "output_tokens": 163,
+        "category": "reversed_classics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0027",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4568.452,
+        "output_tokens": 38,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0028",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4825.552,
+        "output_tokens": 53,
+        "category": "feasibility",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0029",
+        "correct": true,
+        "predicted": "46",
+        "expected": "46",
+        "latency_ms": 4479.277,
+        "output_tokens": 49,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0030",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 3719.827,
+        "output_tokens": 85,
+        "category": "feasibility",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0031",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 5685.584,
+        "output_tokens": 189,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0032",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 7933.012,
+        "output_tokens": 334,
+        "category": "feasibility",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0033",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 8208.958,
+        "output_tokens": 70,
+        "category": "feasibility",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0034",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 11535.22,
+        "output_tokens": 319,
+        "category": "physical",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0035",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 9829.677,
+        "output_tokens": 56,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0036",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 7411.124,
+        "output_tokens": 41,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0037",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 7778.484,
+        "output_tokens": 126,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0038",
+        "correct": false,
+        "predicted": "reveled",
+        "expected": "reviled",
+        "latency_ms": 5983.166,
+        "output_tokens": 241,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0039",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 7456.706,
+        "output_tokens": 115,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0040",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 10327.925,
+        "output_tokens": 295,
+        "category": "physical",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0041",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 10700.445,
+        "output_tokens": 77,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0042",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 10036.329,
+        "output_tokens": 89,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0043",
+        "correct": true,
+        "predicted": "warts",
+        "expected": "warts",
+        "latency_ms": 9212.249,
+        "output_tokens": 152,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0044",
+        "correct": true,
+        "predicted": "repaid",
+        "expected": "repaid",
+        "latency_ms": 6677.516,
+        "output_tokens": 115,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0045",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 7970.533,
+        "output_tokens": 246,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0046",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 6633.549,
+        "output_tokens": 35,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0047",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 5877.423,
+        "output_tokens": 73,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0048",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 6181.297,
+        "output_tokens": 88,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0049",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 6267.715,
+        "output_tokens": 319,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0050",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 8944.64,
+        "output_tokens": 240,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0051",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 8931.911,
+        "output_tokens": 65,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0052",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 8640.625,
+        "output_tokens": 62,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0053",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 6338.389,
+        "output_tokens": 47,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0054",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 4282.927,
+        "output_tokens": 92,
+        "category": "physical",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0055",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 4403.594,
+        "output_tokens": 64,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0056",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4472.939,
+        "output_tokens": 93,
+        "category": "reversed_classics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0057",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 4794.089,
+        "output_tokens": 70,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0058",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 7658.074,
+        "output_tokens": 285,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0059",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 7787.453,
+        "output_tokens": 65,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0060",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 7232.921,
+        "output_tokens": 39,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0061",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 7005.469,
+        "output_tokens": 43,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0062",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 3906.825,
+        "output_tokens": 50,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0063",
+        "correct": true,
+        "predicted": "a",
+        "expected": "a",
+        "latency_ms": 4343.786,
+        "output_tokens": 174,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0064",
+        "correct": true,
+        "predicted": "12",
+        "expected": "12",
+        "latency_ms": 5937.075,
+        "output_tokens": 244,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0065",
+        "correct": false,
+        "predicted": "A",
+        "expected": "C",
+        "latency_ms": 39045.995,
+        "output_tokens": 2048,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0066",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 38478.969,
+        "output_tokens": 38,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0067",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 37495.23,
+        "output_tokens": 43,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0068",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 39406.55,
+        "output_tokens": 311,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0069",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 6759.646,
+        "output_tokens": 107,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0070",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 8691.231,
+        "output_tokens": 120,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0071",
+        "correct": true,
+        "predicted": "12",
+        "expected": "12",
+        "latency_ms": 8941.282,
+        "output_tokens": 99,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0072",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 5913.736,
+        "output_tokens": 72,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0073",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 5945.548,
+        "output_tokens": 129,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0074",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 7609.116,
+        "output_tokens": 335,
+        "category": "feasibility",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0075",
+        "correct": false,
+        "predicted": "5",
+        "expected": "4",
+        "latency_ms": 8607.785,
+        "output_tokens": 161,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0076",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 16987.265,
+        "output_tokens": 666,
+        "category": "physical",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0077",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 17785.125,
+        "output_tokens": 103,
+        "category": "physical",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0078",
+        "correct": true,
+        "predicted": "y",
+        "expected": "y",
+        "latency_ms": 14452.316,
+        "output_tokens": 70,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0079",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 13869.511,
+        "output_tokens": 111,
+        "category": "feasibility",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0080",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5491.354,
+        "output_tokens": 55,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0081",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4486.168,
+        "output_tokens": 51,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0082",
+        "correct": true,
+        "predicted": "m",
+        "expected": "m",
+        "latency_ms": 4620.979,
+        "output_tokens": 82,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0083",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 4789.356,
+        "output_tokens": 83,
+        "category": "feasibility",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0084",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 4275.939,
+        "output_tokens": 51,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0085",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 4452.58,
+        "output_tokens": 83,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0086",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 4847.039,
+        "output_tokens": 82,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0087",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 6783.099,
+        "output_tokens": 260,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0088",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 6530.599,
+        "output_tokens": 41,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0089",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 10242.763,
+        "output_tokens": 348,
+        "category": "physical",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0090",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 11560.379,
+        "output_tokens": 169,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0091",
+        "correct": true,
+        "predicted": "100",
+        "expected": "100",
+        "latency_ms": 12219.227,
+        "output_tokens": 407,
+        "category": "reversed_classics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0092",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 12711.127,
+        "output_tokens": 50,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0093",
+        "correct": true,
+        "predicted": "08:45",
+        "expected": "08:45",
+        "latency_ms": 9365.028,
+        "output_tokens": 151,
+        "category": "feasibility",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0094",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 9978.73,
+        "output_tokens": 258,
+        "category": "physical",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0095",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 8143.727,
+        "output_tokens": 179,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0096",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 8857.751,
+        "output_tokens": 148,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0097",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 13312.5,
+        "output_tokens": 354,
+        "category": "physical",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0098",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 11767.164,
+        "output_tokens": 79,
+        "category": "physical",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0099",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 10148.828,
+        "output_tokens": 27,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0100",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 15539.081,
+        "output_tokens": 549,
+        "category": "physical",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0101",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 11177.556,
+        "output_tokens": 98,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0102",
+        "correct": false,
+        "predicted": "6",
+        "expected": "4",
+        "latency_ms": 11130.871,
+        "output_tokens": 161,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0103",
+        "correct": true,
+        "predicted": "lager",
+        "expected": "lager",
+        "latency_ms": 12115.873,
+        "output_tokens": 152,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0104",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 5925.89,
+        "output_tokens": 49,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0105",
+        "correct": true,
+        "predicted": "p",
+        "expected": "p",
+        "latency_ms": 5183.19,
+        "output_tokens": 73,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0106",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 4099.509,
+        "output_tokens": 15,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0107",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 3890.566,
+        "output_tokens": 99,
+        "category": "reversed_classics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0108",
+        "correct": true,
+        "predicted": "11",
+        "expected": "11",
+        "latency_ms": 3922.468,
+        "output_tokens": 98,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0109",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 7153.282,
+        "output_tokens": 217,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0110",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 14925.292,
+        "output_tokens": 547,
+        "category": "physical",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0111",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 14824.453,
+        "output_tokens": 79,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0112",
+        "correct": true,
+        "predicted": "8",
+        "expected": "8",
+        "latency_ms": 14664.631,
+        "output_tokens": 58,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0113",
+        "correct": true,
+        "predicted": "i",
+        "expected": "i",
+        "latency_ms": 11491.049,
+        "output_tokens": 95,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0114",
+        "correct": true,
+        "predicted": "desserts",
+        "expected": "desserts",
+        "latency_ms": 5354.32,
+        "output_tokens": 175,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0115",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 8299.666,
+        "output_tokens": 272,
+        "category": "physical",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0116",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 8186.348,
+        "output_tokens": 38,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "c890e0f2e3b9c749882d02e5b05b7c253875f4971be90ba5d31132168cfe53be",
+    "payload_path": null,
+    "payload": {
+      "scorer": "mc",
+      "scorers_used": [
+        "exact",
+        "mc",
+        "numeric"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "ling-3.0-flash",
+        "advertised_models": [
+          "ling-3.0-flash"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-09-09T22:59:52Z",
+    "finished_at": "2026-09-09T23:04:38Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Served with the ling3-flash-dgx-spark recipe (49b6c9c), PROFILE=humming-dspark, thinking on (server default via --default-chat-template-kwargs): inclusionAI/Ling-3.0-flash-fp4 (MXFP4 routed experts, FP8 attention/shared/router) with --moe-runner-backend humming, online FP8 LM head (SGLANG_ENABLE_FP8_LM_HEAD=1), DSpark speculative decoding with inclusionAI/Ling-3.0-flash-dspark and the KDA ReplaySSM exact fold (--enable-linear-replayssm-spec, ring 32), context 262144 native (no YaRN), mem-fraction 0.75, max-running 1, page 64, decode cuda graph bs 1, prefill cuda graph disabled, FlashInfer autotune off with precompiled CUTLASS MXFP4 kernels. Single request at a time on every row."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-knowledge-v2--6cf80d.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-knowledge-v2--6cf80d.json
@@ -1,0 +1,1741 @@
+{
+  "schema_version": 1,
+  "run_id": "a3b46e9ee9b29ebc--eval-knowledge-v2--6cf80d",
+  "config_id": "a3b46e9ee9b29ebc",
+  "cell_id": "4ab17fea2273",
+  "workload_id": "eval-knowledge-v2",
+  "kind": "eval",
+  "engine": {
+    "id": "sglang",
+    "version": "0.0.0.dev1+g079d40460",
+    "commit": null,
+    "build": "github.com/inclusionAI/sglang@079d404",
+    "container": "lmsysorg/sglang:v0.0.0.dev1+g079d40460-cu126",
+    "install_method": "source"
+  },
+  "model": {
+    "id": "inclusionAI/Ling-3.0-flash",
+    "quant_id": "mxfp4",
+    "hf_id": "inclusionAI/Ling-3.0-flash",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "moe-runner-backend": "humming",
+    "speculative-algorithm": "DSPARK",
+    "speculative-draft-model-path": "inclusionAI/Ling-3.0-flash-dspark",
+    "enable-linear-replayssm-spec": true,
+    "linear-replayssm-cache-len": 32,
+    "mem-fraction-static": 0.75,
+    "max-running-requests": 1,
+    "max-mamba-cache-size": 64,
+    "chunked-prefill-size": 8192,
+    "max-prefill-tokens": 16384,
+    "page-size": 64,
+    "attention-backend": "flashinfer",
+    "fp8-gemm-backend": "cutlass",
+    "flashinfer-mxfp4-moe-precision": "default",
+    "disable-shared-experts-fusion": true,
+    "cuda-graph-backend-decode": "full",
+    "cuda-graph-max-bs-decode": 1,
+    "cuda-graph-backend-prefill": "disabled",
+    "reasoning-parser": "deepseek-r1",
+    "tool-call-parser": "qwen25",
+    "trust-remote-code": true,
+    "fp8-lm-head": "online",
+    "default-chat-template-kwargs": {
+      "enable_thinking": true
+    }
+  },
+  "args_canonical": "@build=github.com/inclusionai/sglang@079d404;@dtype=auto;@quant=mxfp4;attention-backend=flashinfer;chunked-prefill-size=8192;cuda-graph-backend-decode=full;cuda-graph-backend-prefill=disabled;cuda-graph-max-bs-decode=1;default-chat-template-kwargs={\"enable_thinking\":true};disable-shared-experts-fusion=true;enable-linear-replayssm-spec=true;fp8-gemm-backend=cutlass;fp8-lm-head=online;linear-replayssm-cache-len=32;max-mamba-cache-size=64;max-running-requests=1;mem-fraction-static=0.75;moe-runner-backend=humming;page-size=64;reasoning-parser=deepseek-r1;speculative-algorithm=DSPARK;speculative-draft-model-path=inclusionAI/Ling-3.0-flash-dspark;tool-call-parser=qwen25;trust-remote-code=true",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-knowledge-v2",
+    "resolved_params": {
+      "dataset_id": "eval-knowledge-v2",
+      "suite": "knowledge",
+      "scorer": "mc",
+      "items": 151,
+      "concurrency": 4,
+      "max_output_tokens": 1024,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 151,
+    "requests_ok": 151,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 196.862,
+    "input_tokens_total": 11072,
+    "output_tokens_total": 13078,
+    "e2e_ms": {
+      "mean": 5177.703,
+      "p50": 4934.036,
+      "p90": 8252.298,
+      "p95": 9172.823,
+      "p99": 10562.501,
+      "min": 1767.674,
+      "max": 11727.052
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 115.687,
+    "power_avg_w": 44.54,
+    "power_peak_w": 47.13,
+    "energy_wh": 2.4259,
+    "gpu_util_avg_pct": 95.66,
+    "temp_max_c": 69.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "knowledge",
+    "total": 151,
+    "correct": 151,
+    "accuracy": 1.0,
+    "success_rate": 1.0,
+    "by_category": {
+      "astronomy": {
+        "total": 25,
+        "correct": 25
+      },
+      "biology": {
+        "total": 25,
+        "correct": 25
+      },
+      "chemistry": {
+        "total": 25,
+        "correct": 25
+      },
+      "geography": {
+        "total": 25,
+        "correct": 25
+      },
+      "history_biography": {
+        "total": 25,
+        "correct": 25
+      },
+      "physics": {
+        "total": 26,
+        "correct": 26
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 5,
+        "correct": 5
+      },
+      "hard": {
+        "total": 42,
+        "correct": 42
+      },
+      "medium": {
+        "total": 104,
+        "correct": 104
+      }
+    },
+    "avg_output_tokens": 86.61,
+    "avg_latency_ms": 5177.7,
+    "failures": 0,
+    "items": [
+      {
+        "id": "know2-0001",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 3005.602,
+        "output_tokens": 244,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0002",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 5160.91,
+        "output_tokens": 164,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0003",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 6695.343,
+        "output_tokens": 96,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0004",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 7352.239,
+        "output_tokens": 30,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0005",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 5497.643,
+        "output_tokens": 104,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0006",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 3941.459,
+        "output_tokens": 33,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0007",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 2799.076,
+        "output_tokens": 25,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0008",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 2992.859,
+        "output_tokens": 48,
+        "category": "history_biography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0009",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 2431.972,
+        "output_tokens": 44,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0010",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 4179.822,
+        "output_tokens": 171,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0011",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 4758.161,
+        "output_tokens": 57,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0012",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4785.325,
+        "output_tokens": 54,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0013",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 5310.11,
+        "output_tokens": 60,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0014",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 4990.828,
+        "output_tokens": 153,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0015",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 4502.116,
+        "output_tokens": 31,
+        "category": "astronomy",
+        "difficulty": "easy"
+      },
+      {
+        "id": "know2-0016",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 7277.308,
+        "output_tokens": 277,
+        "category": "astronomy",
+        "difficulty": "easy"
+      },
+      {
+        "id": "know2-0017",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 7907.425,
+        "output_tokens": 81,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0018",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 6574.7,
+        "output_tokens": 31,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0019",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 6891.683,
+        "output_tokens": 45,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0020",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 3935.828,
+        "output_tokens": 34,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0021",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 2723.611,
+        "output_tokens": 35,
+        "category": "chemistry",
+        "difficulty": "easy"
+      },
+      {
+        "id": "know2-0022",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 2375.802,
+        "output_tokens": 19,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0023",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 2232.981,
+        "output_tokens": 27,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0024",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 2519.778,
+        "output_tokens": 54,
+        "category": "astronomy",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0025",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 2550.169,
+        "output_tokens": 35,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0026",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 2550.961,
+        "output_tokens": 17,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0027",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 2516.085,
+        "output_tokens": 41,
+        "category": "astronomy",
+        "difficulty": "easy"
+      },
+      {
+        "id": "know2-0028",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 2241.05,
+        "output_tokens": 42,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0029",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 2576.214,
+        "output_tokens": 66,
+        "category": "astronomy",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0030",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 3225.208,
+        "output_tokens": 49,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0031",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5704.136,
+        "output_tokens": 187,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0032",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 6358.106,
+        "output_tokens": 69,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0033",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 6336.145,
+        "output_tokens": 47,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0034",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 6408.054,
+        "output_tokens": 103,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0035",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 3586.765,
+        "output_tokens": 13,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0036",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 2680.613,
+        "output_tokens": 17,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0037",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 3342.386,
+        "output_tokens": 128,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0038",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 2675.433,
+        "output_tokens": 12,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0039",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 3298.112,
+        "output_tokens": 42,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0040",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4973.078,
+        "output_tokens": 138,
+        "category": "history_biography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0041",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 4015.124,
+        "output_tokens": 23,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0042",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 5625.402,
+        "output_tokens": 125,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0043",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5015.075,
+        "output_tokens": 13,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0044",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 3177.473,
+        "output_tokens": 14,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0045",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 6151.113,
+        "output_tokens": 275,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0046",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 4836.282,
+        "output_tokens": 34,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0047",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 6676.887,
+        "output_tokens": 114,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0048",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 7022.776,
+        "output_tokens": 48,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0049",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 9753.487,
+        "output_tokens": 493,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0050",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 9473.924,
+        "output_tokens": 17,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0051",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 7631.595,
+        "output_tokens": 17,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0052",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 7570.984,
+        "output_tokens": 36,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0053",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1786.905,
+        "output_tokens": 38,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0054",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1767.674,
+        "output_tokens": 20,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0055",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 2287.596,
+        "output_tokens": 36,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0056",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 2427.227,
+        "output_tokens": 33,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0057",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 3662.9,
+        "output_tokens": 97,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0058",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 3601.82,
+        "output_tokens": 16,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0059",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5105.415,
+        "output_tokens": 205,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0060",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4874.196,
+        "output_tokens": 27,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0061",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 3862.135,
+        "output_tokens": 43,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0062",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 4829.629,
+        "output_tokens": 89,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0063",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 3641.317,
+        "output_tokens": 42,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0064",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 3510.863,
+        "output_tokens": 15,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0065",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 5413.887,
+        "output_tokens": 202,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0066",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 4457.004,
+        "output_tokens": 16,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0067",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 4149.321,
+        "output_tokens": 52,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0068",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4560.916,
+        "output_tokens": 41,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0069",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 2979.999,
+        "output_tokens": 51,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0070",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 2934.272,
+        "output_tokens": 18,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0071",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 2935.753,
+        "output_tokens": 35,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0072",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 2906.734,
+        "output_tokens": 47,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0073",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 2556.01,
+        "output_tokens": 60,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0074",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 5908.086,
+        "output_tokens": 262,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0075",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5562.063,
+        "output_tokens": 19,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0076",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 5404.968,
+        "output_tokens": 38,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0077",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 5357.678,
+        "output_tokens": 25,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0078",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 9002.843,
+        "output_tokens": 348,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0079",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 8863.534,
+        "output_tokens": 13,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0080",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 8907.89,
+        "output_tokens": 39,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0081",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 9166.933,
+        "output_tokens": 71,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0082",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 3253.868,
+        "output_tokens": 96,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0083",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 3380.963,
+        "output_tokens": 22,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0084",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4046.369,
+        "output_tokens": 98,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0085",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 3795.971,
+        "output_tokens": 27,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0086",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 3040.014,
+        "output_tokens": 39,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0087",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 3210.561,
+        "output_tokens": 26,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0088",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 3720.508,
+        "output_tokens": 158,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0089",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 6100.052,
+        "output_tokens": 234,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0090",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 6522.568,
+        "output_tokens": 60,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0091",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 7688.837,
+        "output_tokens": 156,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0092",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 7685.364,
+        "output_tokens": 101,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0093",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 6852.237,
+        "output_tokens": 138,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0094",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 6439.742,
+        "output_tokens": 37,
+        "category": "biology",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0095",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5289.736,
+        "output_tokens": 32,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0096",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 6107.009,
+        "output_tokens": 219,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0097",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 4229.429,
+        "output_tokens": 14,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0098",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 5311.672,
+        "output_tokens": 143,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0099",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5532.634,
+        "output_tokens": 49,
+        "category": "history_biography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0100",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 8130.509,
+        "output_tokens": 443,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0101",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 10023.27,
+        "output_tokens": 198,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0102",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 8686.789,
+        "output_tokens": 15,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0103",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 8108.728,
+        "output_tokens": 12,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0104",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4655.257,
+        "output_tokens": 113,
+        "category": "history_biography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0105",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 3766.282,
+        "output_tokens": 75,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0106",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 4484.986,
+        "output_tokens": 90,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0107",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5506.689,
+        "output_tokens": 80,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0108",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 5576.787,
+        "output_tokens": 145,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0109",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 5059.027,
+        "output_tokens": 42,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0110",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 6666.803,
+        "output_tokens": 217,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0111",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 8170.231,
+        "output_tokens": 200,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0112",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 9397.781,
+        "output_tokens": 214,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0113",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 9178.712,
+        "output_tokens": 35,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0114",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 8111.06,
+        "output_tokens": 103,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0115",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 9060.473,
+        "output_tokens": 245,
+        "category": "history_biography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0116",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 9847.36,
+        "output_tokens": 279,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0117",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 11727.052,
+        "output_tokens": 199,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0118",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 11101.732,
+        "output_tokens": 47,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0119",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 8146.676,
+        "output_tokens": 38,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0120",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4934.036,
+        "output_tokens": 29,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0121",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 3147.973,
+        "output_tokens": 51,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0122",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 2658.452,
+        "output_tokens": 29,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0123",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 4138.531,
+        "output_tokens": 129,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0124",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 8264.57,
+        "output_tokens": 364,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0125",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 7925.906,
+        "output_tokens": 18,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0126",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 8252.298,
+        "output_tokens": 70,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0127",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 7036.001,
+        "output_tokens": 83,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0128",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 2754.259,
+        "output_tokens": 18,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0129",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 3000.024,
+        "output_tokens": 30,
+        "category": "astronomy",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0130",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 2486.915,
+        "output_tokens": 15,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0131",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 2507.447,
+        "output_tokens": 65,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0132",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 3130.79,
+        "output_tokens": 72,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0133",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 5372.191,
+        "output_tokens": 200,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0134",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 5309.569,
+        "output_tokens": 12,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0135",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 6259.211,
+        "output_tokens": 111,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0136",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 7969.644,
+        "output_tokens": 215,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0137",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 5401.132,
+        "output_tokens": 12,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0138",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 5465.163,
+        "output_tokens": 14,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0139",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 4056.376,
+        "output_tokens": 30,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0140",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 2227.691,
+        "output_tokens": 45,
+        "category": "physics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "know2-0141",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 3645.197,
+        "output_tokens": 89,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0142",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 5520.72,
+        "output_tokens": 164,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0143",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5516.558,
+        "output_tokens": 32,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0144",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 5924.545,
+        "output_tokens": 90,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0145",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 4622.846,
+        "output_tokens": 15,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0146",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 4794.439,
+        "output_tokens": 197,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0147",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5046.317,
+        "output_tokens": 78,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0148",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 4353.1,
+        "output_tokens": 41,
+        "category": "history_biography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0149",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 4441.805,
+        "output_tokens": 25,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0150",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 3468.422,
+        "output_tokens": 104,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0151",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 3346.53,
+        "output_tokens": 62,
+        "category": "history_biography",
+        "difficulty": "medium"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "cfd98883925866c7dff600b75b09d759d32b6d91f3c04d4af5f8c1872923a34b",
+    "payload_path": null,
+    "payload": {
+      "scorer": "mc",
+      "scorers_used": [
+        "mc"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "ling-3.0-flash",
+        "advertised_models": [
+          "ling-3.0-flash"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-09-09T22:45:03Z",
+    "finished_at": "2026-09-09T22:48:20Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Served with the ling3-flash-dgx-spark recipe (49b6c9c), PROFILE=humming-dspark, thinking on (server default via --default-chat-template-kwargs): inclusionAI/Ling-3.0-flash-fp4 (MXFP4 routed experts, FP8 attention/shared/router) with --moe-runner-backend humming, online FP8 LM head (SGLANG_ENABLE_FP8_LM_HEAD=1), DSpark speculative decoding with inclusionAI/Ling-3.0-flash-dspark and the KDA ReplaySSM exact fold (--enable-linear-replayssm-spec, ring 32), context 262144 native (no YaRN), mem-fraction 0.75, max-running 1, page 64, decode cuda graph bs 1, prefill cuda graph disabled, FlashInfer autotune off with precompiled CUTLASS MXFP4 kernels. Single request at a time on every row."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-knowledge-v2--6cf80d.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-knowledge-v2--6cf80d.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -93,7 +93,7 @@
       "items": 151,
       "concurrency": 4,
       "max_output_tokens": 1024,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -106,7 +106,7 @@
     "requests_total": 151,
     "requests_ok": 151,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 196.862,
     "input_tokens_total": 11072,
     "output_tokens_total": 13078,
@@ -125,15 +125,15 @@
     "power_peak_w": 47.13,
     "energy_wh": 2.4259,
     "gpu_util_avg_pct": 95.66,
-    "temp_max_c": 69.0,
+    "temp_max_c": 69,
     "thermal_throttle_detected": false
   },
   "scores": {
     "suite": "knowledge",
     "total": 151,
     "correct": 151,
-    "accuracy": 1.0,
-    "success_rate": 1.0,
+    "accuracy": 1,
+    "success_rate": 1,
     "by_category": {
       "astronomy": {
         "total": 25,
@@ -1723,7 +1723,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-09T22:45:03Z",
     "finished_at": "2026-09-09T22:48:20Z",
     "submitted_at": null,

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-reasoning-v2--5b458f.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-reasoning-v2--5b458f.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -93,7 +93,7 @@
       "items": 140,
       "concurrency": 4,
       "max_output_tokens": 4096,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -106,7 +106,7 @@
     "requests_total": 140,
     "requests_ok": 140,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 1626.48,
     "input_tokens_total": 17549,
     "output_tokens_total": 153684,
@@ -125,7 +125,7 @@
     "power_peak_w": 46.97,
     "energy_wh": 19.8676,
     "gpu_util_avg_pct": 95.96,
-    "temp_max_c": 70.0,
+    "temp_max_c": 70,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -133,7 +133,7 @@
     "total": 140,
     "correct": 133,
     "accuracy": 0.95,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "counting": {
         "total": 20,
@@ -1619,7 +1619,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-09T22:17:56Z",
     "finished_at": "2026-09-09T22:45:03Z",
     "submitted_at": null,

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-reasoning-v2--5b458f.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-reasoning-v2--5b458f.json
@@ -1,0 +1,1637 @@
+{
+  "schema_version": 1,
+  "run_id": "a3b46e9ee9b29ebc--eval-reasoning-v2--5b458f",
+  "config_id": "a3b46e9ee9b29ebc",
+  "cell_id": "4ab17fea2273",
+  "workload_id": "eval-reasoning-v2",
+  "kind": "eval",
+  "engine": {
+    "id": "sglang",
+    "version": "0.0.0.dev1+g079d40460",
+    "commit": null,
+    "build": "github.com/inclusionAI/sglang@079d404",
+    "container": "lmsysorg/sglang:v0.0.0.dev1+g079d40460-cu126",
+    "install_method": "source"
+  },
+  "model": {
+    "id": "inclusionAI/Ling-3.0-flash",
+    "quant_id": "mxfp4",
+    "hf_id": "inclusionAI/Ling-3.0-flash",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "moe-runner-backend": "humming",
+    "speculative-algorithm": "DSPARK",
+    "speculative-draft-model-path": "inclusionAI/Ling-3.0-flash-dspark",
+    "enable-linear-replayssm-spec": true,
+    "linear-replayssm-cache-len": 32,
+    "mem-fraction-static": 0.75,
+    "max-running-requests": 1,
+    "max-mamba-cache-size": 64,
+    "chunked-prefill-size": 8192,
+    "max-prefill-tokens": 16384,
+    "page-size": 64,
+    "attention-backend": "flashinfer",
+    "fp8-gemm-backend": "cutlass",
+    "flashinfer-mxfp4-moe-precision": "default",
+    "disable-shared-experts-fusion": true,
+    "cuda-graph-backend-decode": "full",
+    "cuda-graph-max-bs-decode": 1,
+    "cuda-graph-backend-prefill": "disabled",
+    "reasoning-parser": "deepseek-r1",
+    "tool-call-parser": "qwen25",
+    "trust-remote-code": true,
+    "fp8-lm-head": "online",
+    "default-chat-template-kwargs": {
+      "enable_thinking": true
+    }
+  },
+  "args_canonical": "@build=github.com/inclusionai/sglang@079d404;@dtype=auto;@quant=mxfp4;attention-backend=flashinfer;chunked-prefill-size=8192;cuda-graph-backend-decode=full;cuda-graph-backend-prefill=disabled;cuda-graph-max-bs-decode=1;default-chat-template-kwargs={\"enable_thinking\":true};disable-shared-experts-fusion=true;enable-linear-replayssm-spec=true;fp8-gemm-backend=cutlass;fp8-lm-head=online;linear-replayssm-cache-len=32;max-mamba-cache-size=64;max-running-requests=1;mem-fraction-static=0.75;moe-runner-backend=humming;page-size=64;reasoning-parser=deepseek-r1;speculative-algorithm=DSPARK;speculative-draft-model-path=inclusionAI/Ling-3.0-flash-dspark;tool-call-parser=qwen25;trust-remote-code=true",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-reasoning-v2",
+    "resolved_params": {
+      "dataset_id": "eval-reasoning-v2",
+      "suite": "reasoning",
+      "scorer": "exact",
+      "items": 140,
+      "concurrency": 4,
+      "max_output_tokens": 4096,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 140,
+    "requests_ok": 140,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 1626.48,
+    "input_tokens_total": 17549,
+    "output_tokens_total": 153684,
+    "e2e_ms": {
+      "mean": 46234.47,
+      "p50": 43192.046,
+      "p90": 79593.558,
+      "p95": 92240.996,
+      "p99": 105064.785,
+      "min": 2252.759,
+      "max": 134778.861
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 116.495,
+    "power_avg_w": 43.98,
+    "power_peak_w": 46.97,
+    "energy_wh": 19.8676,
+    "gpu_util_avg_pct": 95.96,
+    "temp_max_c": 70.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "reasoning",
+    "total": 140,
+    "correct": 133,
+    "accuracy": 0.95,
+    "success_rate": 1.0,
+    "by_category": {
+      "counting": {
+        "total": 20,
+        "correct": 20
+      },
+      "datetime": {
+        "total": 20,
+        "correct": 14
+      },
+      "deduction": {
+        "total": 20,
+        "correct": 20
+      },
+      "ordering": {
+        "total": 20,
+        "correct": 20
+      },
+      "spatial": {
+        "total": 20,
+        "correct": 19
+      },
+      "syllogism": {
+        "total": 20,
+        "correct": 20
+      },
+      "truth_liar": {
+        "total": 20,
+        "correct": 20
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 16,
+        "correct": 16
+      },
+      "hard": {
+        "total": 79,
+        "correct": 77
+      },
+      "medium": {
+        "total": 45,
+        "correct": 40
+      }
+    },
+    "avg_output_tokens": 1097.74,
+    "avg_latency_ms": 46234.47,
+    "failures": 0,
+    "items": [
+      {
+        "id": "reason2-0001",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 2252.759,
+        "output_tokens": 202,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0002",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 8866.966,
+        "output_tokens": 562,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0003",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 15838.407,
+        "output_tokens": 631,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0004",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 25032.272,
+        "output_tokens": 772,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0005",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 24908.795,
+        "output_tokens": 192,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0006",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 20409.419,
+        "output_tokens": 219,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0007",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 19307.797,
+        "output_tokens": 529,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0008",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 14330.972,
+        "output_tokens": 384,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0009",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 13366.143,
+        "output_tokens": 99,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0010",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 25267.024,
+        "output_tokens": 1116,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0011",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 21597.858,
+        "output_tokens": 181,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0012",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 19457.033,
+        "output_tokens": 182,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0013",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 19959.965,
+        "output_tokens": 147,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0014",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 7845.561,
+        "output_tokens": 180,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0015",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 18446.586,
+        "output_tokens": 1065,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0016",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 21438.647,
+        "output_tokens": 381,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0017",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 23026.184,
+        "output_tokens": 286,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0018",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 26859.287,
+        "output_tokens": 530,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0019",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 21858.932,
+        "output_tokens": 642,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0020",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 20280.973,
+        "output_tokens": 298,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0021",
+        "correct": true,
+        "predicted": "Gus",
+        "expected": "Gus",
+        "latency_ms": 33047.149,
+        "output_tokens": 1546,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0022",
+        "correct": true,
+        "predicted": "Ada",
+        "expected": "Ada",
+        "latency_ms": 46340.028,
+        "output_tokens": 1707,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0023",
+        "correct": true,
+        "predicted": "Juno",
+        "expected": "Juno",
+        "latency_ms": 54815.454,
+        "output_tokens": 1433,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0024",
+        "correct": true,
+        "predicted": "Juno",
+        "expected": "Juno",
+        "latency_ms": 60230.423,
+        "output_tokens": 881,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0025",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 63412.655,
+        "output_tokens": 1889,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0026",
+        "correct": true,
+        "predicted": "Juno",
+        "expected": "Juno",
+        "latency_ms": 68903.252,
+        "output_tokens": 2453,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0027",
+        "correct": true,
+        "predicted": "Cai",
+        "expected": "Cai",
+        "latency_ms": 68357.453,
+        "output_tokens": 1470,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0028",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 88044.791,
+        "output_tokens": 2555,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0029",
+        "correct": true,
+        "predicted": "Bo",
+        "expected": "Bo",
+        "latency_ms": 84866.708,
+        "output_tokens": 1581,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0030",
+        "correct": true,
+        "predicted": "Ada",
+        "expected": "Ada",
+        "latency_ms": 75829.219,
+        "output_tokens": 1521,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0031",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 78806.311,
+        "output_tokens": 1831,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0032",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 68179.973,
+        "output_tokens": 1611,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0033",
+        "correct": true,
+        "predicted": "Lars",
+        "expected": "Lars",
+        "latency_ms": 71155.659,
+        "output_tokens": 1824,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0034",
+        "correct": true,
+        "predicted": "Juno",
+        "expected": "Juno",
+        "latency_ms": 79670.48,
+        "output_tokens": 2187,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0035",
+        "correct": true,
+        "predicted": "Ada",
+        "expected": "Ada",
+        "latency_ms": 75026.011,
+        "output_tokens": 1279,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0036",
+        "correct": true,
+        "predicted": "Cai",
+        "expected": "Cai",
+        "latency_ms": 69539.176,
+        "output_tokens": 1164,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0037",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 71262.068,
+        "output_tokens": 1843,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0038",
+        "correct": true,
+        "predicted": "Kira",
+        "expected": "Kira",
+        "latency_ms": 61641.76,
+        "output_tokens": 1306,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0039",
+        "correct": true,
+        "predicted": "Hana",
+        "expected": "Hana",
+        "latency_ms": 58873.187,
+        "output_tokens": 980,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0040",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 58971.472,
+        "output_tokens": 1144,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0041",
+        "correct": true,
+        "predicted": "Juno, Kira",
+        "expected": "Juno, Kira",
+        "latency_ms": 49366.045,
+        "output_tokens": 1052,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0042",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 71671.937,
+        "output_tokens": 3109,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0043",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 81900.629,
+        "output_tokens": 2158,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0044",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 76664.952,
+        "output_tokens": 720,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0045",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 77944.759,
+        "output_tokens": 1205,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0046",
+        "correct": true,
+        "predicted": "Kira",
+        "expected": "Kira",
+        "latency_ms": 59323.516,
+        "output_tokens": 1713,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0047",
+        "correct": true,
+        "predicted": "Kira, Lars",
+        "expected": "Kira, Lars",
+        "latency_ms": 42723.023,
+        "output_tokens": 602,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0048",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 53000.644,
+        "output_tokens": 1709,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0049",
+        "correct": true,
+        "predicted": "Ada, Fenna, Hana",
+        "expected": "Ada, Fenna, Hana",
+        "latency_ms": 55113.479,
+        "output_tokens": 1368,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0050",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 55656.212,
+        "output_tokens": 1744,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0051",
+        "correct": true,
+        "predicted": "Bo, Cai",
+        "expected": "Bo, Cai",
+        "latency_ms": 61793.501,
+        "output_tokens": 1055,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0052",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 62729.998,
+        "output_tokens": 1660,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0053",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 79585.011,
+        "output_tokens": 2770,
+        "category": "truth_liar",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0054",
+        "correct": true,
+        "predicted": "Juno, Kira",
+        "expected": "Juno, Kira",
+        "latency_ms": 74562.885,
+        "output_tokens": 1361,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0055",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 67831.938,
+        "output_tokens": 384,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0056",
+        "correct": true,
+        "predicted": "Bo",
+        "expected": "Bo",
+        "latency_ms": 57438.76,
+        "output_tokens": 874,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0057",
+        "correct": true,
+        "predicted": "0",
+        "expected": "0",
+        "latency_ms": 64094.263,
+        "output_tokens": 3382,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0058",
+        "correct": true,
+        "predicted": "Ada, Cai, Juno",
+        "expected": "Ada, Cai, Juno",
+        "latency_ms": 79925.764,
+        "output_tokens": 2646,
+        "category": "truth_liar",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0059",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 93544.919,
+        "output_tokens": 1721,
+        "category": "truth_liar",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0060",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 95845.097,
+        "output_tokens": 1073,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0061",
+        "correct": true,
+        "predicted": "480",
+        "expected": "480",
+        "latency_ms": 67635.272,
+        "output_tokens": 973,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0062",
+        "correct": true,
+        "predicted": "104",
+        "expected": "104",
+        "latency_ms": 47869.014,
+        "output_tokens": 1037,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0063",
+        "correct": true,
+        "predicted": "41",
+        "expected": "41",
+        "latency_ms": 46764.715,
+        "output_tokens": 1811,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0064",
+        "correct": true,
+        "predicted": "3600",
+        "expected": "3600",
+        "latency_ms": 41287.443,
+        "output_tokens": 461,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0065",
+        "correct": true,
+        "predicted": "480",
+        "expected": "480",
+        "latency_ms": 35614.857,
+        "output_tokens": 422,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0066",
+        "correct": true,
+        "predicted": "230",
+        "expected": "230",
+        "latency_ms": 36703.833,
+        "output_tokens": 972,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0067",
+        "correct": true,
+        "predicted": "144",
+        "expected": "144",
+        "latency_ms": 27946.856,
+        "output_tokens": 1011,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0068",
+        "correct": true,
+        "predicted": "491",
+        "expected": "491",
+        "latency_ms": 34968.355,
+        "output_tokens": 1410,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0069",
+        "correct": true,
+        "predicted": "610",
+        "expected": "610",
+        "latency_ms": 39267.435,
+        "output_tokens": 1017,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0070",
+        "correct": true,
+        "predicted": "112",
+        "expected": "112",
+        "latency_ms": 49640.756,
+        "output_tokens": 2383,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0071",
+        "correct": true,
+        "predicted": "45",
+        "expected": "45",
+        "latency_ms": 52675.328,
+        "output_tokens": 1061,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0072",
+        "correct": true,
+        "predicted": "85",
+        "expected": "85",
+        "latency_ms": 51831.459,
+        "output_tokens": 1165,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0073",
+        "correct": true,
+        "predicted": "1401",
+        "expected": "1401",
+        "latency_ms": 52671.956,
+        "output_tokens": 908,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0074",
+        "correct": true,
+        "predicted": "3600",
+        "expected": "3600",
+        "latency_ms": 42183.306,
+        "output_tokens": 1024,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0075",
+        "correct": true,
+        "predicted": "14833",
+        "expected": "14833",
+        "latency_ms": 46464.497,
+        "output_tokens": 1939,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0076",
+        "correct": true,
+        "predicted": "166",
+        "expected": "166",
+        "latency_ms": 38681.076,
+        "output_tokens": 345,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0077",
+        "correct": true,
+        "predicted": "43",
+        "expected": "43",
+        "latency_ms": 39783.797,
+        "output_tokens": 1174,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0078",
+        "correct": true,
+        "predicted": "63",
+        "expected": "63",
+        "latency_ms": 33218.811,
+        "output_tokens": 418,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0079",
+        "correct": true,
+        "predicted": "104",
+        "expected": "104",
+        "latency_ms": 29537.786,
+        "output_tokens": 1188,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0080",
+        "correct": true,
+        "predicted": "3600",
+        "expected": "3600",
+        "latency_ms": 31438.278,
+        "output_tokens": 504,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0081",
+        "correct": true,
+        "predicted": "2032-12-09 22:15",
+        "expected": "2032-12-09 22:15",
+        "latency_ms": 27353.916,
+        "output_tokens": 588,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0082",
+        "correct": true,
+        "predicted": "1925-01-28",
+        "expected": "1925-01-28",
+        "latency_ms": 43495.28,
+        "output_tokens": 1825,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0083",
+        "correct": true,
+        "predicted": "1929-10-04",
+        "expected": "1929-10-04",
+        "latency_ms": 39213.435,
+        "output_tokens": 756,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0084",
+        "correct": true,
+        "predicted": "2028-06-30 23:10",
+        "expected": "2028-06-30 23:10",
+        "latency_ms": 39155.72,
+        "output_tokens": 527,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0085",
+        "correct": true,
+        "predicted": "07:40",
+        "expected": "07:40",
+        "latency_ms": 33314.501,
+        "output_tokens": 43,
+        "category": "datetime",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0086",
+        "correct": true,
+        "predicted": "2034-11-16",
+        "expected": "2034-11-16",
+        "latency_ms": 29291.807,
+        "output_tokens": 1593,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0087",
+        "correct": true,
+        "predicted": "19:35",
+        "expected": "19:35",
+        "latency_ms": 22590.667,
+        "output_tokens": 70,
+        "category": "datetime",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0088",
+        "correct": false,
+        "predicted": "We need to find the date of the second Monday of January 2028. The answer should be in YYYY-MM-DD form only.\n\nFirst, determine the day of the week for January 1, 2028.\nWe can use known anchor days or calculate.\n2028 is a leap year (divisible by 4, not by 100 unless by 400; 2028/4=507, so leap year).\nWe need the day of week for Jan 1, 2028.\nWe can use the fact that Jan 1, 2024 was a Monday? Let's check.\nActually, let's compute using a known reference.\nJan 1, 2000 was a Saturday.\nNumber of days fr",
+        "expected": "2028-01-10",
+        "latency_ms": 64794.397,
+        "output_tokens": 4096,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0089",
+        "correct": false,
+        "predicted": "1. The user wants to know the date that is 568 days before 1997-07-19.\n2. The target date is 1997-07-19.\n3. I need to subtract 568 days from this date.\n4. Let's do the subtraction step-by-step.\n   - Target: 1997-07-19\n   - Subtract 568 days.\n   - Let's convert 568 days into years, months, and days, or just subtract day by day / month by month.\n   - 1997 is not a leap year (1997 / 4 = 499.25).\n   - 1996 is a leap year.\n   - Let's go backwards from 1997-07-19.\n   - Days in July before 19th: 18 day",
+        "expected": "1995-12-29",
+        "latency_ms": 102057.75,
+        "output_tokens": 4096,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0090",
+        "correct": false,
+        "predicted": "1963-01-25",
+        "expected": "1963-01-22",
+        "latency_ms": 92264.764,
+        "output_tokens": 521,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0091",
+        "correct": false,
+        "predicted": "We need to compute the date that is 621 days before 2041-07-15. The answer should be in YYYY-MM-DD format only.\n\nWe need to subtract 621 days from 2041-07-15.\n\nFirst, let's understand the calendar. 2041 is not a leap year? Let's check: 2041 is not divisible by 4, so it's a common year. 2040 is a leap year.\n\nWe need to subtract 621 days. Let's do it step by step.\n\nWe can use the fact that 621 days is roughly 1 year and 256 days? Actually, 365 days is a year. 621 - 365 = 256. So 621 days before 20",
+        "expected": "2039-11-02",
+        "latency_ms": 134778.861,
+        "output_tokens": 4096,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0092",
+        "correct": true,
+        "predicted": "16:35",
+        "expected": "16:35",
+        "latency_ms": 92299.161,
+        "output_tokens": 421,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0093",
+        "correct": true,
+        "predicted": "2012-05-13 21:40",
+        "expected": "2012-05-13 21:40",
+        "latency_ms": 58657.571,
+        "output_tokens": 351,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0094",
+        "correct": true,
+        "predicted": "3777",
+        "expected": "3777",
+        "latency_ms": 62686.188,
+        "output_tokens": 1268,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0095",
+        "correct": false,
+        "predicted": "We need to find the day of the week for May 15, 2101 in the Gregorian calendar. The user asks: \"What day of the week is 2101-05-15 in the Gregorian calendar? Reply with the English name of the day only.\" So answer should be just the day name, e.g., \"Monday\". I need to compute it.\n\nWe need to compute day of week for 2101-05-15. We can use known algorithms like Zeller's congruence or the Doomsday algorithm. Let's do it carefully.\n\nFirst, note that the Gregorian calendar repeats every 400 years. Bu",
+        "expected": "Sunday",
+        "latency_ms": 65998.703,
+        "output_tokens": 4096,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0096",
+        "correct": true,
+        "predicted": "10:30",
+        "expected": "10:30",
+        "latency_ms": 66010.574,
+        "output_tokens": 413,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0097",
+        "correct": true,
+        "predicted": "11:05",
+        "expected": "11:05",
+        "latency_ms": 64450.867,
+        "output_tokens": 246,
+        "category": "datetime",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0098",
+        "correct": true,
+        "predicted": "2023-07-10",
+        "expected": "2023-07-10",
+        "latency_ms": 70650.121,
+        "output_tokens": 1512,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0099",
+        "correct": true,
+        "predicted": "2006-02-10 10:10",
+        "expected": "2006-02-10 10:10",
+        "latency_ms": 31257.792,
+        "output_tokens": 630,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0100",
+        "correct": false,
+        "predicted": "2007-11-06",
+        "expected": "2007-11-05",
+        "latency_ms": 45819.05,
+        "output_tokens": 1830,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0101",
+        "correct": true,
+        "predicted": "7",
+        "expected": "7",
+        "latency_ms": 47536.443,
+        "output_tokens": 489,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0102",
+        "correct": false,
+        "predicted": "5",
+        "expected": "2",
+        "latency_ms": 75661.918,
+        "output_tokens": 3730,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0103",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 106987.316,
+        "output_tokens": 3177,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0104",
+        "correct": true,
+        "predicted": "7",
+        "expected": "7",
+        "latency_ms": 91774.353,
+        "output_tokens": 413,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0105",
+        "correct": true,
+        "predicted": "17",
+        "expected": "17",
+        "latency_ms": 92239.745,
+        "output_tokens": 488,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0106",
+        "correct": true,
+        "predicted": "7",
+        "expected": "7",
+        "latency_ms": 51518.013,
+        "output_tokens": 373,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0107",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 42888.812,
+        "output_tokens": 2744,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0108",
+        "correct": true,
+        "predicted": "north",
+        "expected": "north",
+        "latency_ms": 39194.034,
+        "output_tokens": 28,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0109",
+        "correct": true,
+        "predicted": "20",
+        "expected": "20",
+        "latency_ms": 38984.369,
+        "output_tokens": 471,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0110",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 50925.592,
+        "output_tokens": 1662,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0111",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 51844.847,
+        "output_tokens": 3086,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0112",
+        "correct": true,
+        "predicted": "15",
+        "expected": "15",
+        "latency_ms": 55204.967,
+        "output_tokens": 410,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0113",
+        "correct": true,
+        "predicted": "east",
+        "expected": "east",
+        "latency_ms": 51362.229,
+        "output_tokens": 28,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0114",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 47735.882,
+        "output_tokens": 1219,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0115",
+        "correct": true,
+        "predicted": "20",
+        "expected": "20",
+        "latency_ms": 21921.5,
+        "output_tokens": 525,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0116",
+        "correct": true,
+        "predicted": "north",
+        "expected": "north",
+        "latency_ms": 19540.763,
+        "output_tokens": 162,
+        "category": "spatial",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0117",
+        "correct": true,
+        "predicted": "13",
+        "expected": "13",
+        "latency_ms": 22645.33,
+        "output_tokens": 420,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0118",
+        "correct": true,
+        "predicted": "south",
+        "expected": "south",
+        "latency_ms": 11872.575,
+        "output_tokens": 165,
+        "category": "spatial",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0119",
+        "correct": true,
+        "predicted": "south",
+        "expected": "south",
+        "latency_ms": 9421.461,
+        "output_tokens": 228,
+        "category": "spatial",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0120",
+        "correct": true,
+        "predicted": "West",
+        "expected": "west",
+        "latency_ms": 9464.737,
+        "output_tokens": 97,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0121",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 12081.893,
+        "output_tokens": 579,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0122",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 15381.219,
+        "output_tokens": 437,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0123",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 18382.393,
+        "output_tokens": 540,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0124",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 22118.936,
+        "output_tokens": 509,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0125",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 20326.933,
+        "output_tokens": 477,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0126",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 23426.528,
+        "output_tokens": 666,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0127",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 23513.525,
+        "output_tokens": 519,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0128",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 22684.123,
+        "output_tokens": 427,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0129",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 23879.18,
+        "output_tokens": 544,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0130",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 20760.026,
+        "output_tokens": 454,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0131",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 20311.954,
+        "output_tokens": 436,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0132",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 21599.852,
+        "output_tokens": 544,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0133",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 25623.814,
+        "output_tokens": 823,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0134",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 26369.879,
+        "output_tokens": 448,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0135",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 26755.301,
+        "output_tokens": 568,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0136",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 26526.911,
+        "output_tokens": 481,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0137",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 21334.531,
+        "output_tokens": 466,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0138",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 21420.795,
+        "output_tokens": 532,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0139",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 20340.73,
+        "output_tokens": 438,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0140",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 20894.337,
+        "output_tokens": 571,
+        "category": "deduction",
+        "difficulty": "hard"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "fab1929ab353901e5c7f829ecd140c22f2c6e7decc615789296826a20e3e5085",
+    "payload_path": null,
+    "payload": {
+      "scorer": "exact",
+      "scorers_used": [
+        "exact",
+        "mc",
+        "numeric"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "ling-3.0-flash",
+        "advertised_models": [
+          "ling-3.0-flash"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-09-09T22:17:56Z",
+    "finished_at": "2026-09-09T22:45:03Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Served with the ling3-flash-dgx-spark recipe (49b6c9c), PROFILE=humming-dspark, thinking on (server default via --default-chat-template-kwargs): inclusionAI/Ling-3.0-flash-fp4 (MXFP4 routed experts, FP8 attention/shared/router) with --moe-runner-backend humming, online FP8 LM head (SGLANG_ENABLE_FP8_LM_HEAD=1), DSpark speculative decoding with inclusionAI/Ling-3.0-flash-dspark and the KDA ReplaySSM exact fold (--enable-linear-replayssm-spec, ring 32), context 262144 native (no YaRN), mem-fraction 0.75, max-running 1, page 64, decode cuda graph bs 1, prefill cuda graph disabled, FlashInfer autotune off with precompiled CUTLASS MXFP4 kernels. Single request at a time on every row."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-science-v2--cd2424.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-science-v2--cd2424.json
@@ -1,0 +1,1431 @@
+{
+  "schema_version": 1,
+  "run_id": "a3b46e9ee9b29ebc--eval-science-v2--cd2424",
+  "config_id": "a3b46e9ee9b29ebc",
+  "cell_id": "4ab17fea2273",
+  "workload_id": "eval-science-v2",
+  "kind": "eval",
+  "engine": {
+    "id": "sglang",
+    "version": "0.0.0.dev1+g079d40460",
+    "commit": null,
+    "build": "github.com/inclusionAI/sglang@079d404",
+    "container": "lmsysorg/sglang:v0.0.0.dev1+g079d40460-cu126",
+    "install_method": "source"
+  },
+  "model": {
+    "id": "inclusionAI/Ling-3.0-flash",
+    "quant_id": "mxfp4",
+    "hf_id": "inclusionAI/Ling-3.0-flash",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "moe-runner-backend": "humming",
+    "speculative-algorithm": "DSPARK",
+    "speculative-draft-model-path": "inclusionAI/Ling-3.0-flash-dspark",
+    "enable-linear-replayssm-spec": true,
+    "linear-replayssm-cache-len": 32,
+    "mem-fraction-static": 0.75,
+    "max-running-requests": 1,
+    "max-mamba-cache-size": 64,
+    "chunked-prefill-size": 8192,
+    "max-prefill-tokens": 16384,
+    "page-size": 64,
+    "attention-backend": "flashinfer",
+    "fp8-gemm-backend": "cutlass",
+    "flashinfer-mxfp4-moe-precision": "default",
+    "disable-shared-experts-fusion": true,
+    "cuda-graph-backend-decode": "full",
+    "cuda-graph-max-bs-decode": 1,
+    "cuda-graph-backend-prefill": "disabled",
+    "reasoning-parser": "deepseek-r1",
+    "tool-call-parser": "qwen25",
+    "trust-remote-code": true,
+    "fp8-lm-head": "online",
+    "default-chat-template-kwargs": {
+      "enable_thinking": true
+    }
+  },
+  "args_canonical": "@build=github.com/inclusionai/sglang@079d404;@dtype=auto;@quant=mxfp4;attention-backend=flashinfer;chunked-prefill-size=8192;cuda-graph-backend-decode=full;cuda-graph-backend-prefill=disabled;cuda-graph-max-bs-decode=1;default-chat-template-kwargs={\"enable_thinking\":true};disable-shared-experts-fusion=true;enable-linear-replayssm-spec=true;fp8-gemm-backend=cutlass;fp8-lm-head=online;linear-replayssm-cache-len=32;max-mamba-cache-size=64;max-running-requests=1;mem-fraction-static=0.75;moe-runner-backend=humming;page-size=64;reasoning-parser=deepseek-r1;speculative-algorithm=DSPARK;speculative-draft-model-path=inclusionAI/Ling-3.0-flash-dspark;tool-call-parser=qwen25;trust-remote-code=true",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-science-v2",
+    "resolved_params": {
+      "dataset_id": "eval-science-v2",
+      "suite": "science",
+      "scorer": "numeric",
+      "items": 120,
+      "concurrency": 4,
+      "max_output_tokens": 4096,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 120,
+    "requests_ok": 120,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 690.412,
+    "input_tokens_total": 11345,
+    "output_tokens_total": 71813,
+    "e2e_ms": {
+      "mean": 22975.087,
+      "p50": 21607.47,
+      "p90": 33971.325,
+      "p95": 43316.293,
+      "p99": 58882.657,
+      "min": 1444.902,
+      "max": 66548.946
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 115.692,
+    "power_avg_w": 44.02,
+    "power_peak_w": 46.15,
+    "energy_wh": 8.4396,
+    "gpu_util_avg_pct": 95.65,
+    "temp_max_c": 69.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "science",
+    "total": 120,
+    "correct": 120,
+    "accuracy": 1.0,
+    "success_rate": 1.0,
+    "by_category": {
+      "chemistry": {
+        "total": 20,
+        "correct": 20
+      },
+      "electricity": {
+        "total": 20,
+        "correct": 20
+      },
+      "mechanics": {
+        "total": 20,
+        "correct": 20
+      },
+      "radioactivity_units": {
+        "total": 20,
+        "correct": 20
+      },
+      "thermodynamics": {
+        "total": 20,
+        "correct": 20
+      },
+      "waves_optics": {
+        "total": 20,
+        "correct": 20
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 22,
+        "correct": 22
+      },
+      "hard": {
+        "total": 51,
+        "correct": 51
+      },
+      "medium": {
+        "total": 47,
+        "correct": 47
+      }
+    },
+    "avg_output_tokens": 598.44,
+    "avg_latency_ms": 22975.09,
+    "failures": 0,
+    "items": [
+      {
+        "id": "sci-0001",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 1444.902,
+        "output_tokens": 113,
+        "category": "mechanics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0002",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 2753.797,
+        "output_tokens": 100,
+        "category": "mechanics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0003",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 4027.571,
+        "output_tokens": 124,
+        "category": "mechanics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0004",
+        "correct": true,
+        "predicted": "120",
+        "expected": "120",
+        "latency_ms": 9108.508,
+        "output_tokens": 452,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0005",
+        "correct": true,
+        "predicted": "96",
+        "expected": "96",
+        "latency_ms": 14472.677,
+        "output_tokens": 575,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0006",
+        "correct": true,
+        "predicted": "32",
+        "expected": "32",
+        "latency_ms": 18346.649,
+        "output_tokens": 444,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0007",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 28280.804,
+        "output_tokens": 1132,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0008",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 32221.244,
+        "output_tokens": 927,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0009",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 31976.207,
+        "output_tokens": 665,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0010",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 33871.283,
+        "output_tokens": 712,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0011",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 29421.369,
+        "output_tokens": 743,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0012",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 29099.867,
+        "output_tokens": 931,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0013",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 25435.047,
+        "output_tokens": 306,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0014",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 26304.756,
+        "output_tokens": 832,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0015",
+        "correct": true,
+        "predicted": "108",
+        "expected": "108",
+        "latency_ms": 22114.722,
+        "output_tokens": 252,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0016",
+        "correct": true,
+        "predicted": "72",
+        "expected": "72",
+        "latency_ms": 15310.109,
+        "output_tokens": 165,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0017",
+        "correct": true,
+        "predicted": "28.8",
+        "expected": "28.8",
+        "latency_ms": 14863.191,
+        "output_tokens": 198,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0018",
+        "correct": true,
+        "predicted": "8",
+        "expected": "8",
+        "latency_ms": 19019.991,
+        "output_tokens": 1204,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0019",
+        "correct": true,
+        "predicted": "16",
+        "expected": "16",
+        "latency_ms": 26342.783,
+        "output_tokens": 938,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0020",
+        "correct": true,
+        "predicted": "10",
+        "expected": "10",
+        "latency_ms": 35562.173,
+        "output_tokens": 1109,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0021",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 39065.782,
+        "output_tokens": 597,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0022",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 32485.673,
+        "output_tokens": 533,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0023",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 31273.794,
+        "output_tokens": 888,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0024",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 27826.468,
+        "output_tokens": 819,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0025",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 28161.16,
+        "output_tokens": 723,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0026",
+        "correct": true,
+        "predicted": "72",
+        "expected": "72",
+        "latency_ms": 28005.419,
+        "output_tokens": 597,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0027",
+        "correct": true,
+        "predicted": "27",
+        "expected": "27",
+        "latency_ms": 25414.271,
+        "output_tokens": 648,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0028",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 22997.321,
+        "output_tokens": 579,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0029",
+        "correct": true,
+        "predicted": "27",
+        "expected": "27",
+        "latency_ms": 23062.935,
+        "output_tokens": 644,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0030",
+        "correct": true,
+        "predicted": "4.11",
+        "expected": "4.11",
+        "latency_ms": 20882.756,
+        "output_tokens": 256,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0031",
+        "correct": true,
+        "predicted": "4.12",
+        "expected": "4.12",
+        "latency_ms": 16930.893,
+        "output_tokens": 181,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0032",
+        "correct": true,
+        "predicted": "6.86",
+        "expected": "6.86",
+        "latency_ms": 13340.335,
+        "output_tokens": 145,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0033",
+        "correct": true,
+        "predicted": "5.74",
+        "expected": "5.74",
+        "latency_ms": 12377.177,
+        "output_tokens": 496,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0034",
+        "correct": true,
+        "predicted": "14.4",
+        "expected": "14.4",
+        "latency_ms": 18644.979,
+        "output_tokens": 978,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0035",
+        "correct": true,
+        "predicted": "8",
+        "expected": "8",
+        "latency_ms": 22311.325,
+        "output_tokens": 572,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0036",
+        "correct": true,
+        "predicted": "10",
+        "expected": "10",
+        "latency_ms": 26338.103,
+        "output_tokens": 553,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0037",
+        "correct": true,
+        "predicted": "67.5",
+        "expected": "67.5",
+        "latency_ms": 25547.068,
+        "output_tokens": 467,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0038",
+        "correct": true,
+        "predicted": "8",
+        "expected": "8",
+        "latency_ms": 17209.751,
+        "output_tokens": 87,
+        "category": "electricity",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0039",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 13064.88,
+        "output_tokens": 154,
+        "category": "electricity",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0040",
+        "correct": true,
+        "predicted": "10",
+        "expected": "10",
+        "latency_ms": 8514.396,
+        "output_tokens": 87,
+        "category": "electricity",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0041",
+        "correct": true,
+        "predicted": "43",
+        "expected": "43",
+        "latency_ms": 12286.174,
+        "output_tokens": 914,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0042",
+        "correct": true,
+        "predicted": "32",
+        "expected": "32",
+        "latency_ms": 19027.105,
+        "output_tokens": 834,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0043",
+        "correct": true,
+        "predicted": "44",
+        "expected": "44",
+        "latency_ms": 25232.976,
+        "output_tokens": 823,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0044",
+        "correct": true,
+        "predicted": "34",
+        "expected": "34",
+        "latency_ms": 30500.474,
+        "output_tokens": 710,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0045",
+        "correct": true,
+        "predicted": "30",
+        "expected": "30",
+        "latency_ms": 33010.167,
+        "output_tokens": 1323,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0046",
+        "correct": true,
+        "predicted": "30",
+        "expected": "30",
+        "latency_ms": 32306.223,
+        "output_tokens": 839,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0047",
+        "correct": true,
+        "predicted": "30",
+        "expected": "30",
+        "latency_ms": 31265.143,
+        "output_tokens": 805,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0048",
+        "correct": true,
+        "predicted": "80",
+        "expected": "80",
+        "latency_ms": 33994.302,
+        "output_tokens": 1101,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0049",
+        "correct": true,
+        "predicted": "1995",
+        "expected": "1995",
+        "latency_ms": 29575.8,
+        "output_tokens": 764,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0050",
+        "correct": true,
+        "predicted": "2310",
+        "expected": "2310",
+        "latency_ms": 33844.13,
+        "output_tokens": 1322,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0051",
+        "correct": true,
+        "predicted": "2835",
+        "expected": "2835",
+        "latency_ms": 41922.434,
+        "output_tokens": 1664,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0052",
+        "correct": true,
+        "predicted": "1050",
+        "expected": "1050",
+        "latency_ms": 41940.898,
+        "output_tokens": 1099,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0053",
+        "correct": true,
+        "predicted": "0.17",
+        "expected": "0.17",
+        "latency_ms": 56724.664,
+        "output_tokens": 2228,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0054",
+        "correct": true,
+        "predicted": "0.55",
+        "expected": "0.55",
+        "latency_ms": 56002.727,
+        "output_tokens": 1151,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0055",
+        "correct": true,
+        "predicted": "0.56",
+        "expected": "0.56",
+        "latency_ms": 59388.853,
+        "output_tokens": 1871,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0056",
+        "correct": true,
+        "predicted": "1.13",
+        "expected": "1.13",
+        "latency_ms": 66548.946,
+        "output_tokens": 1750,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0057",
+        "correct": true,
+        "predicted": "180",
+        "expected": "180",
+        "latency_ms": 56411.468,
+        "output_tokens": 1062,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0058",
+        "correct": true,
+        "predicted": "300",
+        "expected": "300",
+        "latency_ms": 52935.461,
+        "output_tokens": 722,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0059",
+        "correct": true,
+        "predicted": "180",
+        "expected": "180",
+        "latency_ms": 42810.021,
+        "output_tokens": 837,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0060",
+        "correct": true,
+        "predicted": "200",
+        "expected": "200",
+        "latency_ms": 33362.099,
+        "output_tokens": 720,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0061",
+        "correct": true,
+        "predicted": "36",
+        "expected": "36",
+        "latency_ms": 29356.741,
+        "output_tokens": 681,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0062",
+        "correct": true,
+        "predicted": "72",
+        "expected": "72",
+        "latency_ms": 32714.758,
+        "output_tokens": 1076,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0063",
+        "correct": true,
+        "predicted": "72",
+        "expected": "72",
+        "latency_ms": 32334.871,
+        "output_tokens": 793,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0064",
+        "correct": true,
+        "predicted": "36",
+        "expected": "36",
+        "latency_ms": 33928.204,
+        "output_tokens": 884,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0065",
+        "correct": true,
+        "predicted": "85",
+        "expected": "85",
+        "latency_ms": 33968.772,
+        "output_tokens": 815,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0066",
+        "correct": true,
+        "predicted": "51",
+        "expected": "51",
+        "latency_ms": 31183.15,
+        "output_tokens": 866,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0067",
+        "correct": true,
+        "predicted": "102",
+        "expected": "102",
+        "latency_ms": 30429.762,
+        "output_tokens": 764,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0068",
+        "correct": true,
+        "predicted": "51",
+        "expected": "51",
+        "latency_ms": 29328.011,
+        "output_tokens": 799,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0069",
+        "correct": true,
+        "predicted": "0.02",
+        "expected": "0.02",
+        "latency_ms": 30535.505,
+        "output_tokens": 865,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0070",
+        "correct": true,
+        "predicted": "0.005",
+        "expected": "0.005",
+        "latency_ms": 30750.711,
+        "output_tokens": 817,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0071",
+        "correct": true,
+        "predicted": "0.04",
+        "expected": "0.04",
+        "latency_ms": 31574.471,
+        "output_tokens": 754,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0072",
+        "correct": true,
+        "predicted": "0.01",
+        "expected": "0.01",
+        "latency_ms": 32556.588,
+        "output_tokens": 851,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0073",
+        "correct": true,
+        "predicted": "90",
+        "expected": "90",
+        "latency_ms": 25649.513,
+        "output_tokens": 108,
+        "category": "chemistry",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0074",
+        "correct": true,
+        "predicted": "60",
+        "expected": "60",
+        "latency_ms": 18540.656,
+        "output_tokens": 91,
+        "category": "chemistry",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0075",
+        "correct": true,
+        "predicted": "65",
+        "expected": "65",
+        "latency_ms": 11528.797,
+        "output_tokens": 77,
+        "category": "chemistry",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0076",
+        "correct": true,
+        "predicted": "70",
+        "expected": "70",
+        "latency_ms": 5439.022,
+        "output_tokens": 213,
+        "category": "chemistry",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0077",
+        "correct": true,
+        "predicted": "24",
+        "expected": "24",
+        "latency_ms": 9957.041,
+        "output_tokens": 637,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0078",
+        "correct": true,
+        "predicted": "120",
+        "expected": "120",
+        "latency_ms": 13715.925,
+        "output_tokens": 536,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0079",
+        "correct": true,
+        "predicted": "72",
+        "expected": "72",
+        "latency_ms": 16347.496,
+        "output_tokens": 343,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0080",
+        "correct": true,
+        "predicted": "48",
+        "expected": "48",
+        "latency_ms": 21169.25,
+        "output_tokens": 774,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0081",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 16388.91,
+        "output_tokens": 108,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0082",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 12785.388,
+        "output_tokens": 102,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0083",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 11441.223,
+        "output_tokens": 185,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0084",
+        "correct": true,
+        "predicted": "1.5",
+        "expected": "1.5",
+        "latency_ms": 5379.191,
+        "output_tokens": 95,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0085",
+        "correct": true,
+        "predicted": "50",
+        "expected": "50",
+        "latency_ms": 9350.422,
+        "output_tokens": 567,
+        "category": "waves_optics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0086",
+        "correct": true,
+        "predicted": "120",
+        "expected": "120",
+        "latency_ms": 12844.091,
+        "output_tokens": 517,
+        "category": "waves_optics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0087",
+        "correct": true,
+        "predicted": "120",
+        "expected": "120",
+        "latency_ms": 15000.86,
+        "output_tokens": 465,
+        "category": "waves_optics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0088",
+        "correct": true,
+        "predicted": "60",
+        "expected": "60",
+        "latency_ms": 19450.584,
+        "output_tokens": 586,
+        "category": "waves_optics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0089",
+        "correct": true,
+        "predicted": "0.72",
+        "expected": "0.72",
+        "latency_ms": 16054.366,
+        "output_tokens": 151,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0090",
+        "correct": true,
+        "predicted": "0.38",
+        "expected": "0.38",
+        "latency_ms": 15729.827,
+        "output_tokens": 362,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0091",
+        "correct": true,
+        "predicted": "0.84",
+        "expected": "0.84",
+        "latency_ms": 13194.612,
+        "output_tokens": 150,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0092",
+        "correct": true,
+        "predicted": "0.7",
+        "expected": "0.7",
+        "latency_ms": 10066.023,
+        "output_tokens": 194,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0093",
+        "correct": true,
+        "predicted": "50",
+        "expected": "50",
+        "latency_ms": 8874.249,
+        "output_tokens": 42,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0094",
+        "correct": true,
+        "predicted": "100",
+        "expected": "100",
+        "latency_ms": 5211.584,
+        "output_tokens": 33,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0095",
+        "correct": true,
+        "predicted": "25",
+        "expected": "25",
+        "latency_ms": 3980.357,
+        "output_tokens": 42,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0096",
+        "correct": true,
+        "predicted": "200",
+        "expected": "200",
+        "latency_ms": 2273.58,
+        "output_tokens": 33,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0097",
+        "correct": true,
+        "predicted": "1020",
+        "expected": "1020",
+        "latency_ms": 6313.626,
+        "output_tokens": 452,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0098",
+        "correct": true,
+        "predicted": "680",
+        "expected": "680",
+        "latency_ms": 8312.808,
+        "output_tokens": 228,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0099",
+        "correct": true,
+        "predicted": "340",
+        "expected": "340",
+        "latency_ms": 11567.637,
+        "output_tokens": 365,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0100",
+        "correct": true,
+        "predicted": "510",
+        "expected": "510",
+        "latency_ms": 13318.08,
+        "output_tokens": 219,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0101",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 13423.51,
+        "output_tokens": 494,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0102",
+        "correct": true,
+        "predicted": "12",
+        "expected": "12",
+        "latency_ms": 15077.786,
+        "output_tokens": 453,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0103",
+        "correct": true,
+        "predicted": "10",
+        "expected": "10",
+        "latency_ms": 16399.388,
+        "output_tokens": 560,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0104",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 21262.734,
+        "output_tokens": 749,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0105",
+        "correct": true,
+        "predicted": "36",
+        "expected": "36",
+        "latency_ms": 20976.002,
+        "output_tokens": 413,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0106",
+        "correct": true,
+        "predicted": "75",
+        "expected": "75",
+        "latency_ms": 20674.146,
+        "output_tokens": 356,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0107",
+        "correct": true,
+        "predicted": "24",
+        "expected": "24",
+        "latency_ms": 19905.985,
+        "output_tokens": 408,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0108",
+        "correct": true,
+        "predicted": "125",
+        "expected": "125",
+        "latency_ms": 17205.477,
+        "output_tokens": 433,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0109",
+        "correct": true,
+        "predicted": "3600",
+        "expected": "3600",
+        "latency_ms": 21952.206,
+        "output_tokens": 1022,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0110",
+        "correct": true,
+        "predicted": "6000",
+        "expected": "6000",
+        "latency_ms": 21173.543,
+        "output_tokens": 371,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0111",
+        "correct": true,
+        "predicted": "18000",
+        "expected": "18000",
+        "latency_ms": 25980.162,
+        "output_tokens": 1011,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0112",
+        "correct": true,
+        "predicted": "30000",
+        "expected": "30000",
+        "latency_ms": 27940.021,
+        "output_tokens": 768,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0113",
+        "correct": true,
+        "predicted": "360",
+        "expected": "360",
+        "latency_ms": 24791.118,
+        "output_tokens": 674,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0114",
+        "correct": true,
+        "predicted": "450",
+        "expected": "450",
+        "latency_ms": 26799.763,
+        "output_tokens": 596,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0115",
+        "correct": true,
+        "predicted": "240",
+        "expected": "240",
+        "latency_ms": 22359.856,
+        "output_tokens": 542,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0116",
+        "correct": true,
+        "predicted": "1000",
+        "expected": "1000",
+        "latency_ms": 20986.189,
+        "output_tokens": 594,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0117",
+        "correct": true,
+        "predicted": "35",
+        "expected": "35",
+        "latency_ms": 15846.651,
+        "output_tokens": 48,
+        "category": "radioactivity_units",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0118",
+        "correct": true,
+        "predicted": "25",
+        "expected": "25",
+        "latency_ms": 11918.737,
+        "output_tokens": 120,
+        "category": "radioactivity_units",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0119",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 7830.621,
+        "output_tokens": 43,
+        "category": "radioactivity_units",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0120",
+        "correct": true,
+        "predicted": "15",
+        "expected": "15",
+        "latency_ms": 3437.709,
+        "output_tokens": 53,
+        "category": "radioactivity_units",
+        "difficulty": "easy"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "a31b99c24e94de4c9f2e04edc64d3512c5c6af345973c36613dd66faf68db0e2",
+    "payload_path": null,
+    "payload": {
+      "scorer": "numeric",
+      "scorers_used": [
+        "numeric"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "ling-3.0-flash",
+        "advertised_models": [
+          "ling-3.0-flash"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-09-09T22:48:21Z",
+    "finished_at": "2026-09-09T22:59:51Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Served with the ling3-flash-dgx-spark recipe (49b6c9c), PROFILE=humming-dspark, thinking on (server default via --default-chat-template-kwargs): inclusionAI/Ling-3.0-flash-fp4 (MXFP4 routed experts, FP8 attention/shared/router) with --moe-runner-backend humming, online FP8 LM head (SGLANG_ENABLE_FP8_LM_HEAD=1), DSpark speculative decoding with inclusionAI/Ling-3.0-flash-dspark and the KDA ReplaySSM exact fold (--enable-linear-replayssm-spec, ring 32), context 262144 native (no YaRN), mem-fraction 0.75, max-running 1, page 64, decode cuda graph bs 1, prefill cuda graph disabled, FlashInfer autotune off with precompiled CUTLASS MXFP4 kernels. Single request at a time on every row."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-science-v2--cd2424.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-science-v2--cd2424.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -93,7 +93,7 @@
       "items": 120,
       "concurrency": 4,
       "max_output_tokens": 4096,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -106,7 +106,7 @@
     "requests_total": 120,
     "requests_ok": 120,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 690.412,
     "input_tokens_total": 11345,
     "output_tokens_total": 71813,
@@ -125,15 +125,15 @@
     "power_peak_w": 46.15,
     "energy_wh": 8.4396,
     "gpu_util_avg_pct": 95.65,
-    "temp_max_c": 69.0,
+    "temp_max_c": 69,
     "thermal_throttle_detected": false
   },
   "scores": {
     "suite": "science",
     "total": 120,
     "correct": 120,
-    "accuracy": 1.0,
-    "success_rate": 1.0,
+    "accuracy": 1,
+    "success_rate": 1,
     "by_category": {
       "chemistry": {
         "total": 20,
@@ -1413,7 +1413,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-09T22:48:21Z",
     "finished_at": "2026-09-09T22:59:51Z",
     "submitted_at": null,

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-security-v2--80b156.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-security-v2--80b156.json
@@ -1,0 +1,1343 @@
+{
+  "schema_version": 1,
+  "run_id": "a3b46e9ee9b29ebc--eval-security-v2--80b156",
+  "config_id": "a3b46e9ee9b29ebc",
+  "cell_id": "4ab17fea2273",
+  "workload_id": "eval-security-v2",
+  "kind": "eval",
+  "engine": {
+    "id": "sglang",
+    "version": "0.0.0.dev1+g079d40460",
+    "commit": null,
+    "build": "github.com/inclusionAI/sglang@079d404",
+    "container": "lmsysorg/sglang:v0.0.0.dev1+g079d40460-cu126",
+    "install_method": "source"
+  },
+  "model": {
+    "id": "inclusionAI/Ling-3.0-flash",
+    "quant_id": "mxfp4",
+    "hf_id": "inclusionAI/Ling-3.0-flash",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "moe-runner-backend": "humming",
+    "speculative-algorithm": "DSPARK",
+    "speculative-draft-model-path": "inclusionAI/Ling-3.0-flash-dspark",
+    "enable-linear-replayssm-spec": true,
+    "linear-replayssm-cache-len": 32,
+    "mem-fraction-static": 0.75,
+    "max-running-requests": 1,
+    "max-mamba-cache-size": 64,
+    "chunked-prefill-size": 8192,
+    "max-prefill-tokens": 16384,
+    "page-size": 64,
+    "attention-backend": "flashinfer",
+    "fp8-gemm-backend": "cutlass",
+    "flashinfer-mxfp4-moe-precision": "default",
+    "disable-shared-experts-fusion": true,
+    "cuda-graph-backend-decode": "full",
+    "cuda-graph-max-bs-decode": 1,
+    "cuda-graph-backend-prefill": "disabled",
+    "reasoning-parser": "deepseek-r1",
+    "tool-call-parser": "qwen25",
+    "trust-remote-code": true,
+    "fp8-lm-head": "online",
+    "default-chat-template-kwargs": {
+      "enable_thinking": true
+    }
+  },
+  "args_canonical": "@build=github.com/inclusionai/sglang@079d404;@dtype=auto;@quant=mxfp4;attention-backend=flashinfer;chunked-prefill-size=8192;cuda-graph-backend-decode=full;cuda-graph-backend-prefill=disabled;cuda-graph-max-bs-decode=1;default-chat-template-kwargs={\"enable_thinking\":true};disable-shared-experts-fusion=true;enable-linear-replayssm-spec=true;fp8-gemm-backend=cutlass;fp8-lm-head=online;linear-replayssm-cache-len=32;max-mamba-cache-size=64;max-running-requests=1;mem-fraction-static=0.75;moe-runner-backend=humming;page-size=64;reasoning-parser=deepseek-r1;speculative-algorithm=DSPARK;speculative-draft-model-path=inclusionAI/Ling-3.0-flash-dspark;tool-call-parser=qwen25;trust-remote-code=true",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-security-v2",
+    "resolved_params": {
+      "dataset_id": "eval-security-v2",
+      "suite": "security",
+      "scorer": "mc",
+      "items": 111,
+      "concurrency": 4,
+      "max_output_tokens": 4096,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 111,
+    "requests_ok": 111,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 388.372,
+    "input_tokens_total": 12852,
+    "output_tokens_total": 34686,
+    "e2e_ms": {
+      "mean": 13785.858,
+      "p50": 10160.469,
+      "p90": 34783.536,
+      "p95": 41113.969,
+      "p99": 46069.434,
+      "min": 4826.749,
+      "max": 46180.303
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 115.775,
+    "power_avg_w": 44.22,
+    "power_peak_w": 51.66,
+    "energy_wh": 4.7694,
+    "gpu_util_avg_pct": 95.88,
+    "temp_max_c": 70.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "security",
+    "total": 111,
+    "correct": 108,
+    "accuracy": 0.972973,
+    "success_rate": 1.0,
+    "by_category": {
+      "concepts": {
+        "total": 19,
+        "correct": 19
+      },
+      "crypto": {
+        "total": 21,
+        "correct": 20
+      },
+      "forensics": {
+        "total": 17,
+        "correct": 15
+      },
+      "incident_judgment": {
+        "total": 12,
+        "correct": 12
+      },
+      "network": {
+        "total": 22,
+        "correct": 22
+      },
+      "web_security": {
+        "total": 20,
+        "correct": 20
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 15,
+        "correct": 15
+      },
+      "hard": {
+        "total": 31,
+        "correct": 29
+      },
+      "medium": {
+        "total": 65,
+        "correct": 64
+      }
+    },
+    "avg_output_tokens": 312.49,
+    "avg_latency_ms": 13785.86,
+    "failures": 0,
+    "items": [
+      {
+        "id": "sec2-0001",
+        "correct": true,
+        "predicted": "sandbox",
+        "expected": "sandbox",
+        "latency_ms": 4826.749,
+        "output_tokens": 447,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0002",
+        "correct": true,
+        "predicted": "142",
+        "expected": "142",
+        "latency_ms": 8265.096,
+        "output_tokens": 332,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0003",
+        "correct": true,
+        "predicted": "10.45.120.0",
+        "expected": "10.45.120.0",
+        "latency_ms": 15206.253,
+        "output_tokens": 710,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0004",
+        "correct": true,
+        "predicted": "68",
+        "expected": "68",
+        "latency_ms": 16689.685,
+        "output_tokens": 131,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0005",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 14774.954,
+        "output_tokens": 181,
+        "category": "web_security",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0006",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 12344.392,
+        "output_tokens": 53,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0007",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 9673.749,
+        "output_tokens": 218,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0008",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 10246.932,
+        "output_tokens": 91,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0009",
+        "correct": true,
+        "predicted": "10.25.55.255",
+        "expected": "10.25.55.255",
+        "latency_ms": 15489.433,
+        "output_tokens": 691,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0010",
+        "correct": true,
+        "predicted": "11",
+        "expected": "11",
+        "latency_ms": 29126.301,
+        "output_tokens": 1546,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0011",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 25806.141,
+        "output_tokens": 54,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0012",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 25071.493,
+        "output_tokens": 67,
+        "category": "incident_judgment",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0013",
+        "correct": true,
+        "predicted": "30",
+        "expected": "30",
+        "latency_ms": 17978.58,
+        "output_tokens": 55,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0014",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 10343.618,
+        "output_tokens": 398,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0015",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 11185.967,
+        "output_tokens": 127,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0016",
+        "correct": true,
+        "predicted": "126",
+        "expected": "126",
+        "latency_ms": 10945.987,
+        "output_tokens": 60,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0017",
+        "correct": true,
+        "predicted": "phishing",
+        "expected": "phishing",
+        "latency_ms": 13415.705,
+        "output_tokens": 381,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0018",
+        "correct": true,
+        "predicted": "230",
+        "expected": "230",
+        "latency_ms": 9858.996,
+        "output_tokens": 369,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0019",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 10668.15,
+        "output_tokens": 170,
+        "category": "web_security",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0020",
+        "correct": true,
+        "predicted": "firewall",
+        "expected": "firewall",
+        "latency_ms": 14680.793,
+        "output_tokens": 478,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0021",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 12957.529,
+        "output_tokens": 112,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0022",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 12037.39,
+        "output_tokens": 141,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0023",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 10929.435,
+        "output_tokens": 106,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0024",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 8143.173,
+        "output_tokens": 157,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0025",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 7512.154,
+        "output_tokens": 79,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0026",
+        "correct": true,
+        "predicted": "02:37:04",
+        "expected": "02:37:04",
+        "latency_ms": 6318.366,
+        "output_tokens": 121,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0027",
+        "correct": true,
+        "predicted": "2022-06-28 14:45:38",
+        "expected": "2022-06-28 14:45:38",
+        "latency_ms": 36133.204,
+        "output_tokens": 3280,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0028",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 34783.536,
+        "output_tokens": 56,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0029",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 36268.687,
+        "output_tokens": 148,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0030",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 36492.179,
+        "output_tokens": 81,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0031",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 6542.831,
+        "output_tokens": 88,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0032",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 6898.448,
+        "output_tokens": 103,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0033",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 5220.765,
+        "output_tokens": 52,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0034",
+        "correct": false,
+        "predicted": "1. The Unix timestamp is 1691146295 seconds.\n2. Unix time starts from 1970-01-01 00:00:00 UTC.\n3. I need to convert 1691146295 seconds to a UTC date and time.\n4. Let's calculate the number of days: 1691146295 / 86400 = 19573.452488... days.\n5. 19573 days from 1970-01-01.\n6. Let's find the year.\n   - 1970 to 2022 is 52 years.\n   - Leap years between 1970 and 2022: 1972, 1976, 1980, 1984, 1988, 1992, 1996, 2000, 2004, 2008, 2012, 2016, 2020. (13 leap years)\n   - Total days from 1970 to 2022: 52 * ",
+        "expected": "2023-08-04 10:51:35",
+        "latency_ms": 38970.569,
+        "output_tokens": 4096,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0035",
+        "correct": true,
+        "predicted": "235",
+        "expected": "235",
+        "latency_ms": 46119.648,
+        "output_tokens": 932,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0036",
+        "correct": true,
+        "predicted": "02:38:57",
+        "expected": "02:38:57",
+        "latency_ms": 46180.303,
+        "output_tokens": 121,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0037",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 45617.508,
+        "output_tokens": 21,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0038",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 12587.782,
+        "output_tokens": 209,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0039",
+        "correct": true,
+        "predicted": "28",
+        "expected": "28",
+        "latency_ms": 5185.558,
+        "output_tokens": 89,
+        "category": "concepts",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0040",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5004.373,
+        "output_tokens": 93,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0041",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 7438.843,
+        "output_tokens": 289,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0042",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 6329.265,
+        "output_tokens": 65,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0043",
+        "correct": false,
+        "predicted": "1. The Unix timestamp is 1694679636 seconds.\n2. Unix time starts from 1970-01-01 00:00:00 UTC.\n3. Let's calculate the date.\n   - 1694679636 seconds.\n   - Days = 1694679636 / 86400 = 19614.3476...\n   - 19614 days from 1970-01-01.\n   - Let's use known reference points or calculate step by step.\n   - 1970 to 2023:\n     - 1970-2022 is 53 years.\n     - Leap years between 1970 and 2022: 1972, 1976, 1980, 1984, 1988, 1992, 1996, 2000, 2004, 2008, 2012, 2016, 2020. (13 leap years)\n     - Total days from",
+        "expected": "2023-09-14 08:20:36",
+        "latency_ms": 43485.49,
+        "output_tokens": 4096,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0044",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 42783.318,
+        "output_tokens": 22,
+        "category": "concepts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0045",
+        "correct": true,
+        "predicted": "118",
+        "expected": "118",
+        "latency_ms": 40887.18,
+        "output_tokens": 83,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0046",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 41340.759,
+        "output_tokens": 108,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0047",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 6572.209,
+        "output_tokens": 256,
+        "category": "crypto",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0048",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 6787.545,
+        "output_tokens": 48,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0049",
+        "correct": false,
+        "predicted": "fierce",
+        "expected": "firewall",
+        "latency_ms": 11840.397,
+        "output_tokens": 632,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0050",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 12303.923,
+        "output_tokens": 158,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0051",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 9832.109,
+        "output_tokens": 38,
+        "category": "incident_judgment",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0052",
+        "correct": true,
+        "predicted": "352",
+        "expected": "352",
+        "latency_ms": 10408.215,
+        "output_tokens": 96,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0053",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 8008.827,
+        "output_tokens": 251,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0054",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 7621.673,
+        "output_tokens": 89,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0055",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 7904.119,
+        "output_tokens": 112,
+        "category": "concepts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0056",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 7889.938,
+        "output_tokens": 80,
+        "category": "concepts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0057",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 8371.937,
+        "output_tokens": 213,
+        "category": "web_security",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0058",
+        "correct": true,
+        "predicted": "cipher",
+        "expected": "cipher",
+        "latency_ms": 9770.182,
+        "output_tokens": 361,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0059",
+        "correct": true,
+        "predicted": "308915776",
+        "expected": "308915776",
+        "latency_ms": 10840.139,
+        "output_tokens": 194,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0060",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 11457.805,
+        "output_tokens": 123,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0061",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 10404.446,
+        "output_tokens": 307,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0062",
+        "correct": true,
+        "predicted": "1083",
+        "expected": "1083",
+        "latency_ms": 17468.291,
+        "output_tokens": 1075,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0063",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 16151.221,
+        "output_tokens": 57,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0064",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 15962.532,
+        "output_tokens": 147,
+        "category": "concepts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0065",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 13605.832,
+        "output_tokens": 50,
+        "category": "web_security",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0066",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5482.389,
+        "output_tokens": 114,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0067",
+        "correct": true,
+        "predicted": "malware",
+        "expected": "malware",
+        "latency_ms": 7428.127,
+        "output_tokens": 279,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0068",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 6440.664,
+        "output_tokens": 42,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0069",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 9141.878,
+        "output_tokens": 234,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0070",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 8116.155,
+        "output_tokens": 65,
+        "category": "network",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0071",
+        "correct": true,
+        "predicted": "7",
+        "expected": "7",
+        "latency_ms": 17207.086,
+        "output_tokens": 1461,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0072",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 20240.178,
+        "output_tokens": 229,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0073",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 19729.059,
+        "output_tokens": 175,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0074",
+        "correct": true,
+        "predicted": "66",
+        "expected": "66",
+        "latency_ms": 19830.523,
+        "output_tokens": 95,
+        "category": "concepts",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0075",
+        "correct": true,
+        "predicted": "510",
+        "expected": "510",
+        "latency_ms": 8546.622,
+        "output_tokens": 59,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0076",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 8161.479,
+        "output_tokens": 224,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0077",
+        "correct": true,
+        "predicted": "malware",
+        "expected": "malware",
+        "latency_ms": 10174.962,
+        "output_tokens": 496,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0078",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 9743.001,
+        "output_tokens": 50,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0079",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 10149.325,
+        "output_tokens": 89,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0080",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 10392.198,
+        "output_tokens": 201,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0081",
+        "correct": true,
+        "predicted": "105",
+        "expected": "105",
+        "latency_ms": 7345.026,
+        "output_tokens": 148,
+        "category": "concepts",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0082",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 9313.948,
+        "output_tokens": 277,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0083",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 10160.469,
+        "output_tokens": 123,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0084",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 7264.523,
+        "output_tokens": 49,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0085",
+        "correct": true,
+        "predicted": "1022",
+        "expected": "1022",
+        "latency_ms": 6289.585,
+        "output_tokens": 62,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0086",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 7630.181,
+        "output_tokens": 244,
+        "category": "concepts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0087",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 6332.504,
+        "output_tokens": 45,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0088",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 6687.896,
+        "output_tokens": 79,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0089",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 7596.586,
+        "output_tokens": 87,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0090",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5484.452,
+        "output_tokens": 171,
+        "category": "concepts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0091",
+        "correct": true,
+        "predicted": "10.169.14.0",
+        "expected": "10.169.14.0",
+        "latency_ms": 6173.089,
+        "output_tokens": 110,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0092",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 8578.826,
+        "output_tokens": 210,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0093",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 8003.803,
+        "output_tokens": 64,
+        "category": "incident_judgment",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0094",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 9871.14,
+        "output_tokens": 263,
+        "category": "incident_judgment",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0095",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 10431.233,
+        "output_tokens": 139,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0096",
+        "correct": true,
+        "predicted": "8",
+        "expected": "8",
+        "latency_ms": 10295.055,
+        "output_tokens": 344,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0097",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 9691.019,
+        "output_tokens": 28,
+        "category": "crypto",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0098",
+        "correct": true,
+        "predicted": "1656",
+        "expected": "1656",
+        "latency_ms": 8344.773,
+        "output_tokens": 252,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0099",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 8264.804,
+        "output_tokens": 128,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0100",
+        "correct": true,
+        "predicted": "7",
+        "expected": "7",
+        "latency_ms": 7716.54,
+        "output_tokens": 298,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0101",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 8133.946,
+        "output_tokens": 66,
+        "category": "web_security",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0102",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 6549.146,
+        "output_tokens": 49,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0103",
+        "correct": true,
+        "predicted": "10.7.189.255",
+        "expected": "10.7.189.255",
+        "latency_ms": 11951.924,
+        "output_tokens": 668,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0104",
+        "correct": true,
+        "predicted": "10000",
+        "expected": "10000",
+        "latency_ms": 11812.926,
+        "output_tokens": 246,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0105",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 13051.513,
+        "output_tokens": 147,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0106",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 13387.7,
+        "output_tokens": 74,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0107",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 7054.794,
+        "output_tokens": 56,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0108",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 5324.077,
+        "output_tokens": 42,
+        "category": "incident_judgment",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0109",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 6233.934,
+        "output_tokens": 179,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0110",
+        "correct": true,
+        "predicted": "backdoor",
+        "expected": "backdoor",
+        "latency_ms": 10071.091,
+        "output_tokens": 448,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0111",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 12431.478,
+        "output_tokens": 183,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "c890e0f2e3b9c749882d02e5b05b7c253875f4971be90ba5d31132168cfe53be",
+    "payload_path": null,
+    "payload": {
+      "scorer": "mc",
+      "scorers_used": [
+        "exact",
+        "mc",
+        "numeric"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "ling-3.0-flash",
+        "advertised_models": [
+          "ling-3.0-flash"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-09-09T23:04:39Z",
+    "finished_at": "2026-09-09T23:11:07Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Served with the ling3-flash-dgx-spark recipe (49b6c9c), PROFILE=humming-dspark, thinking on (server default via --default-chat-template-kwargs): inclusionAI/Ling-3.0-flash-fp4 (MXFP4 routed experts, FP8 attention/shared/router) with --moe-runner-backend humming, online FP8 LM head (SGLANG_ENABLE_FP8_LM_HEAD=1), DSpark speculative decoding with inclusionAI/Ling-3.0-flash-dspark and the KDA ReplaySSM exact fold (--enable-linear-replayssm-spec, ring 32), context 262144 native (no YaRN), mem-fraction 0.75, max-running 1, page 64, decode cuda graph bs 1, prefill cuda graph disabled, FlashInfer autotune off with precompiled CUTLASS MXFP4 kernels. Single request at a time on every row."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-security-v2--80b156.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a3b46e9ee9b29ebc--eval-security-v2--80b156.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -93,7 +93,7 @@
       "items": 111,
       "concurrency": 4,
       "max_output_tokens": 4096,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -106,7 +106,7 @@
     "requests_total": 111,
     "requests_ok": 111,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 388.372,
     "input_tokens_total": 12852,
     "output_tokens_total": 34686,
@@ -125,7 +125,7 @@
     "power_peak_w": 51.66,
     "energy_wh": 4.7694,
     "gpu_util_avg_pct": 95.88,
-    "temp_max_c": 70.0,
+    "temp_max_c": 70,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -133,7 +133,7 @@
     "total": 111,
     "correct": 108,
     "accuracy": 0.972973,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "concepts": {
         "total": 19,
@@ -1325,7 +1325,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-09T23:04:39Z",
     "finished_at": "2026-09-09T23:11:07Z",
     "submitted_at": null,

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--longctx-depth-sweep-v1--6a38d7.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--longctx-depth-sweep-v1--6a38d7.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -91,35 +91,35 @@
       "points": [
         [
           1024,
-          90.0
+          90
         ],
         [
           4096,
-          90.0
+          90
         ],
         [
           8192,
-          90.0
+          90
         ],
         [
           16384,
-          90.0
+          90
         ],
         [
           32768,
-          90.0
+          90
         ],
         [
           65536,
-          90.0
+          90
         ],
         [
           131072,
-          90.0
+          90
         ],
         [
           262144,
-          90.0
+          90
         ]
       ],
       "output_tokens": 256,
@@ -130,7 +130,7 @@
       "needles_total": 6,
       "dataset_categories": null,
       "dataset_target_tokens": null,
-      "timeout_s": 1800.0,
+      "timeout_s": 1800,
       "seed": 42
     }
   },
@@ -138,7 +138,7 @@
     "requests_total": 1,
     "requests_ok": 1,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 25.199,
     "input_tokens_total": 80765,
     "output_tokens_total": 6,
@@ -197,8 +197,8 @@
     "power_avg_w": 76.04,
     "power_peak_w": 85.82,
     "energy_wh": 0.5206,
-    "gpu_util_avg_pct": 96.0,
-    "temp_max_c": 72.0,
+    "gpu_util_avg_pct": 96,
+    "temp_max_c": 72,
     "thermal_throttle_detected": false
   },
   "sweep": [
@@ -210,7 +210,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 0.58,
         "input_tokens_total": 1371,
         "output_tokens_total": 6,
@@ -268,9 +268,9 @@
         "kv_cache_tokens": null,
         "power_avg_w": 12.75,
         "power_peak_w": 12.75,
-        "energy_wh": 0.0,
-        "gpu_util_avg_pct": 0.0,
-        "temp_max_c": 46.0,
+        "energy_wh": 0,
+        "gpu_util_avg_pct": 0,
+        "temp_max_c": 46,
         "thermal_throttle_detected": false
       }
     },
@@ -282,7 +282,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 1.48,
         "input_tokens_total": 5176,
         "output_tokens_total": 6,
@@ -341,8 +341,8 @@
         "power_avg_w": 53.59,
         "power_peak_w": 69.08,
         "energy_wh": 0.0157,
-        "gpu_util_avg_pct": 48.0,
-        "temp_max_c": 57.0,
+        "gpu_util_avg_pct": 48,
+        "temp_max_c": 57,
         "thermal_throttle_detected": false
       }
     },
@@ -354,7 +354,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 2.801,
         "input_tokens_total": 10169,
         "output_tokens_total": 6,
@@ -413,8 +413,8 @@
         "power_avg_w": 63.3,
         "power_peak_w": 66.49,
         "energy_wh": 0.0369,
-        "gpu_util_avg_pct": 96.0,
-        "temp_max_c": 57.0,
+        "gpu_util_avg_pct": 96,
+        "temp_max_c": 57,
         "thermal_throttle_detected": false
       }
     },
@@ -426,7 +426,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 5.133,
         "input_tokens_total": 20064,
         "output_tokens_total": 6,
@@ -486,7 +486,7 @@
         "power_peak_w": 71.31,
         "energy_wh": 0.0798,
         "gpu_util_avg_pct": 95.4,
-        "temp_max_c": 60.0,
+        "temp_max_c": 60,
         "thermal_throttle_detected": false
       }
     },
@@ -498,7 +498,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 10.96,
         "input_tokens_total": 40486,
         "output_tokens_total": 6,
@@ -557,8 +557,8 @@
         "power_avg_w": 71.91,
         "power_peak_w": 77.02,
         "energy_wh": 0.2115,
-        "gpu_util_avg_pct": 96.0,
-        "temp_max_c": 67.0,
+        "gpu_util_avg_pct": 96,
+        "temp_max_c": 67,
         "thermal_throttle_detected": false
       }
     },
@@ -570,7 +570,7 @@
         "requests_total": 1,
         "requests_ok": 1,
         "requests_failed": 0,
-        "success_rate": 1.0,
+        "success_rate": 1,
         "duration_s": 25.199,
         "input_tokens_total": 80765,
         "output_tokens_total": 6,
@@ -629,8 +629,8 @@
         "power_avg_w": 76.04,
         "power_peak_w": 85.82,
         "energy_wh": 0.5206,
-        "gpu_util_avg_pct": 96.0,
-        "temp_max_c": 72.0,
+        "gpu_util_avg_pct": 96,
+        "temp_max_c": 72,
         "thermal_throttle_detected": false
       }
     },
@@ -642,13 +642,13 @@
         "requests_total": 1,
         "requests_ok": 0,
         "requests_failed": 1,
-        "success_rate": 0.0,
+        "success_rate": 0,
         "duration_s": 0.303,
         "input_tokens_total": 0,
         "output_tokens_total": 0,
-        "output_tok_s": 0.0,
-        "total_tok_s": 0.0,
-        "req_s": 0.0,
+        "output_tok_s": 0,
+        "total_tok_s": 0,
+        "req_s": 0,
         "prefill_tok_s": null,
         "ttft_ms": null,
         "tpot_ms": null,
@@ -660,9 +660,9 @@
         "kv_cache_tokens": null,
         "power_avg_w": 78.47,
         "power_peak_w": 78.47,
-        "energy_wh": 0.0,
-        "gpu_util_avg_pct": 96.0,
-        "temp_max_c": 74.0,
+        "energy_wh": 0,
+        "gpu_util_avg_pct": 96,
+        "temp_max_c": 74,
         "thermal_throttle_detected": false
       }
     },
@@ -674,13 +674,13 @@
         "requests_total": 1,
         "requests_ok": 0,
         "requests_failed": 1,
-        "success_rate": 0.0,
+        "success_rate": 0,
         "duration_s": 0.956,
         "input_tokens_total": 0,
         "output_tokens_total": 0,
-        "output_tok_s": 0.0,
-        "total_tok_s": 0.0,
-        "req_s": 0.0,
+        "output_tok_s": 0,
+        "total_tok_s": 0,
+        "req_s": 0,
         "prefill_tok_s": null,
         "ttft_ms": null,
         "tpot_ms": null,
@@ -692,9 +692,9 @@
         "kv_cache_tokens": null,
         "power_avg_w": 63.75,
         "power_peak_w": 63.75,
-        "energy_wh": 0.0,
-        "gpu_util_avg_pct": 96.0,
-        "temp_max_c": 61.0,
+        "energy_wh": 0,
+        "gpu_util_avg_pct": 96,
+        "temp_max_c": 61,
         "thermal_throttle_detected": false
       }
     }
@@ -739,82 +739,82 @@
         {
           "id": "hay-1k-d90",
           "input_tokens": 1024,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 10.351,
           "decode_tok_s": 86.013,
           "ttft_ms": 521.358,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "hay-4k-d90",
           "input_tokens": 4096,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 4.053,
           "decode_tok_s": 83.741,
           "ttft_ms": 1420.331,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "hay-8k-d90",
           "input_tokens": 8192,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 2.142,
           "decode_tok_s": 77.488,
           "ttft_ms": 2736.068,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "hay-16k-d90",
           "input_tokens": 16384,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 1.169,
           "decode_tok_s": 72.796,
           "ttft_ms": 5063.831,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "hay-32k-d90",
           "input_tokens": 32768,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 0.547,
           "decode_tok_s": 64.114,
           "ttft_ms": 10881.407,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "hay-64k-d90",
           "input_tokens": 65536,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": true,
           "output_tok_s": 0.238,
           "decode_tok_s": 52.709,
           "ttft_ms": 25103.821,
-          "success_rate": 1.0
+          "success_rate": 1
         },
         {
           "id": "hay-128k-d90",
           "input_tokens": 131072,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": null,
-          "output_tok_s": 0.0,
+          "output_tok_s": 0,
           "decode_tok_s": null,
           "ttft_ms": null,
-          "success_rate": 0.0
+          "success_rate": 0
         },
         {
           "id": "hay-256k-d90",
           "input_tokens": 262144,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": null,
-          "output_tok_s": 0.0,
+          "output_tok_s": 0,
           "decode_tok_s": null,
           "ttft_ms": null,
-          "success_rate": 0.0
+          "success_rate": 0
         }
       ],
       "requests": [
@@ -936,7 +936,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-09T23:17:48Z",
     "finished_at": "2026-09-09T23:18:36Z",
     "submitted_at": null,

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--longctx-depth-sweep-v1--6a38d7.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--longctx-depth-sweep-v1--6a38d7.json
@@ -1,0 +1,954 @@
+{
+  "schema_version": 1,
+  "run_id": "a9e5da49f0c2bba3--longctx-depth-sweep-v1--6a38d7",
+  "config_id": "a9e5da49f0c2bba3",
+  "cell_id": "4ab17fea2273",
+  "workload_id": "longctx-depth-sweep-v1",
+  "kind": "longctx",
+  "engine": {
+    "id": "sglang",
+    "version": "0.0.0.dev1+g079d40460",
+    "commit": null,
+    "build": "github.com/inclusionAI/sglang@079d404",
+    "container": "lmsysorg/sglang:v0.0.0.dev1+g079d40460-cu126",
+    "install_method": "source"
+  },
+  "model": {
+    "id": "inclusionAI/Ling-3.0-flash",
+    "quant_id": "mxfp4",
+    "hf_id": "inclusionAI/Ling-3.0-flash",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "moe-runner-backend": "humming",
+    "speculative-algorithm": "DSPARK",
+    "speculative-draft-model-path": "inclusionAI/Ling-3.0-flash-dspark",
+    "enable-linear-replayssm-spec": true,
+    "linear-replayssm-cache-len": 32,
+    "mem-fraction-static": 0.75,
+    "max-running-requests": 1,
+    "max-mamba-cache-size": 64,
+    "chunked-prefill-size": 8192,
+    "max-prefill-tokens": 16384,
+    "page-size": 64,
+    "attention-backend": "flashinfer",
+    "fp8-gemm-backend": "cutlass",
+    "flashinfer-mxfp4-moe-precision": "default",
+    "disable-shared-experts-fusion": true,
+    "cuda-graph-backend-decode": "full",
+    "cuda-graph-max-bs-decode": 1,
+    "cuda-graph-backend-prefill": "disabled",
+    "reasoning-parser": "deepseek-r1",
+    "tool-call-parser": "qwen25",
+    "trust-remote-code": true,
+    "fp8-lm-head": "online",
+    "default-chat-template-kwargs": {
+      "enable_thinking": false
+    }
+  },
+  "args_canonical": "@build=github.com/inclusionai/sglang@079d404;@dtype=auto;@quant=mxfp4;attention-backend=flashinfer;chunked-prefill-size=8192;cuda-graph-backend-decode=full;cuda-graph-backend-prefill=disabled;cuda-graph-max-bs-decode=1;default-chat-template-kwargs={\"enable_thinking\":false};disable-shared-experts-fusion=true;enable-linear-replayssm-spec=true;fp8-gemm-backend=cutlass;fp8-lm-head=online;linear-replayssm-cache-len=32;max-mamba-cache-size=64;max-running-requests=1;mem-fraction-static=0.75;moe-runner-backend=humming;page-size=64;reasoning-parser=deepseek-r1;speculative-algorithm=DSPARK;speculative-draft-model-path=inclusionAI/Ling-3.0-flash-dspark;tool-call-parser=qwen25;trust-remote-code=true",
+  "serve_command": null,
+  "workload": {
+    "id": "longctx-depth-sweep-v1",
+    "resolved_params": {
+      "axis": "input_tokens",
+      "points": [
+        [
+          1024,
+          90.0
+        ],
+        [
+          4096,
+          90.0
+        ],
+        [
+          8192,
+          90.0
+        ],
+        [
+          16384,
+          90.0
+        ],
+        [
+          32768,
+          90.0
+        ],
+        [
+          65536,
+          90.0
+        ],
+        [
+          131072,
+          90.0
+        ],
+        [
+          262144,
+          90.0
+        ]
+      ],
+      "output_tokens": 256,
+      "needle_check": true,
+      "needle_depth": 0.9,
+      "headline_input_tokens": 65536,
+      "needles_found": 6,
+      "needles_total": 6,
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "timeout_s": 1800.0,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 1,
+    "requests_ok": 1,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 25.199,
+    "input_tokens_total": 80765,
+    "output_tokens_total": 6,
+    "output_tok_s": 0.238,
+    "total_tok_s": 3205.344,
+    "req_s": 0.04,
+    "prefill_tok_s": 3217.239,
+    "ttft_ms": {
+      "mean": 25103.821,
+      "p50": 25103.821,
+      "p90": 25103.821,
+      "p95": 25103.821,
+      "p99": 25103.821,
+      "min": 25103.821,
+      "max": 25103.821
+    },
+    "tpot_ms": {
+      "mean": 18.972,
+      "p50": 18.972,
+      "p90": 18.972,
+      "p95": 18.972,
+      "p99": 18.972,
+      "min": 18.972,
+      "max": 18.972
+    },
+    "itl_ms": {
+      "mean": 94.167,
+      "p50": 94.167,
+      "p90": 94.167,
+      "p95": 94.167,
+      "p99": 94.167,
+      "min": 94.167,
+      "max": 94.167
+    },
+    "e2e_ms": {
+      "mean": 25198.683,
+      "p50": 25198.683,
+      "p90": 25198.683,
+      "p95": 25198.683,
+      "p99": 25198.683,
+      "min": 25198.683,
+      "max": 25198.683
+    },
+    "decode_tok_s_per_request": {
+      "mean": 52.709,
+      "p50": 52.709,
+      "p90": 52.709,
+      "p95": 52.709,
+      "p99": 52.709,
+      "min": 52.709,
+      "max": 52.709
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 104.098,
+    "kv_cache_tokens": null,
+    "power_avg_w": 76.04,
+    "power_peak_w": 85.82,
+    "energy_wh": 0.5206,
+    "gpu_util_avg_pct": 96.0,
+    "temp_max_c": 72.0,
+    "thermal_throttle_detected": false
+  },
+  "sweep": [
+    {
+      "input_tokens": 1024,
+      "output_tokens": 256,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 0.58,
+        "input_tokens_total": 1371,
+        "output_tokens_total": 6,
+        "output_tok_s": 10.351,
+        "total_tok_s": 2375.669,
+        "req_s": 1.725,
+        "prefill_tok_s": 2629.673,
+        "ttft_ms": {
+          "mean": 521.358,
+          "p50": 521.358,
+          "p90": 521.358,
+          "p95": 521.358,
+          "p99": 521.358,
+          "min": 521.358,
+          "max": 521.358
+        },
+        "tpot_ms": {
+          "mean": 11.626,
+          "p50": 11.626,
+          "p90": 11.626,
+          "p95": 11.626,
+          "p99": 11.626,
+          "min": 11.626,
+          "max": 11.626
+        },
+        "itl_ms": {
+          "mean": 57.14,
+          "p50": 57.14,
+          "p90": 57.14,
+          "p95": 57.14,
+          "p99": 57.14,
+          "min": 57.14,
+          "max": 57.14
+        },
+        "e2e_ms": {
+          "mean": 579.488,
+          "p50": 579.488,
+          "p90": 579.488,
+          "p95": 579.488,
+          "p99": 579.488,
+          "min": 579.488,
+          "max": 579.488
+        },
+        "decode_tok_s_per_request": {
+          "mean": 86.013,
+          "p50": 86.013,
+          "p90": 86.013,
+          "p95": 86.013,
+          "p99": 86.013,
+          "min": 86.013,
+          "max": 86.013
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 95.268,
+        "kv_cache_tokens": null,
+        "power_avg_w": 12.75,
+        "power_peak_w": 12.75,
+        "energy_wh": 0.0,
+        "gpu_util_avg_pct": 0.0,
+        "temp_max_c": 46.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 4096,
+      "output_tokens": 256,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 1.48,
+        "input_tokens_total": 5176,
+        "output_tokens_total": 6,
+        "output_tok_s": 4.053,
+        "total_tok_s": 3500.8,
+        "req_s": 0.676,
+        "prefill_tok_s": 3644.221,
+        "ttft_ms": {
+          "mean": 1420.331,
+          "p50": 1420.331,
+          "p90": 1420.331,
+          "p95": 1420.331,
+          "p99": 1420.331,
+          "min": 1420.331,
+          "max": 1420.331
+        },
+        "tpot_ms": {
+          "mean": 11.942,
+          "p50": 11.942,
+          "p90": 11.942,
+          "p95": 11.942,
+          "p99": 11.942,
+          "min": 11.942,
+          "max": 11.942
+        },
+        "itl_ms": {
+          "mean": 58.867,
+          "p50": 58.867,
+          "p90": 58.867,
+          "p95": 58.867,
+          "p99": 58.867,
+          "min": 58.867,
+          "max": 58.867
+        },
+        "e2e_ms": {
+          "mean": 1480.039,
+          "p50": 1480.039,
+          "p90": 1480.039,
+          "p95": 1480.039,
+          "p99": 1480.039,
+          "min": 1480.039,
+          "max": 1480.039
+        },
+        "decode_tok_s_per_request": {
+          "mean": 83.741,
+          "p50": 83.741,
+          "p90": 83.741,
+          "p95": 83.741,
+          "p99": 83.741,
+          "min": 83.741,
+          "max": 83.741
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 96.208,
+        "kv_cache_tokens": null,
+        "power_avg_w": 53.59,
+        "power_peak_w": 69.08,
+        "energy_wh": 0.0157,
+        "gpu_util_avg_pct": 48.0,
+        "temp_max_c": 57.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 8192,
+      "output_tokens": 256,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 2.801,
+        "input_tokens_total": 10169,
+        "output_tokens_total": 6,
+        "output_tok_s": 2.142,
+        "total_tok_s": 3632.947,
+        "req_s": 0.357,
+        "prefill_tok_s": 3716.647,
+        "ttft_ms": {
+          "mean": 2736.068,
+          "p50": 2736.068,
+          "p90": 2736.068,
+          "p95": 2736.068,
+          "p99": 2736.068,
+          "min": 2736.068,
+          "max": 2736.068
+        },
+        "tpot_ms": {
+          "mean": 12.905,
+          "p50": 12.905,
+          "p90": 12.905,
+          "p95": 12.905,
+          "p99": 12.905,
+          "min": 12.905,
+          "max": 12.905
+        },
+        "itl_ms": {
+          "mean": 63.712,
+          "p50": 63.712,
+          "p90": 63.712,
+          "p95": 63.712,
+          "p99": 63.712,
+          "min": 63.712,
+          "max": 63.712
+        },
+        "e2e_ms": {
+          "mean": 2800.594,
+          "p50": 2800.594,
+          "p90": 2800.594,
+          "p95": 2800.594,
+          "p99": 2800.594,
+          "min": 2800.594,
+          "max": 2800.594
+        },
+        "decode_tok_s_per_request": {
+          "mean": 77.488,
+          "p50": 77.488,
+          "p90": 77.488,
+          "p95": 77.488,
+          "p99": 77.488,
+          "min": 77.488,
+          "max": 77.488
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 97.628,
+        "kv_cache_tokens": null,
+        "power_avg_w": 63.3,
+        "power_peak_w": 66.49,
+        "energy_wh": 0.0369,
+        "gpu_util_avg_pct": 96.0,
+        "temp_max_c": 57.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 16384,
+      "output_tokens": 256,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 5.133,
+        "input_tokens_total": 20064,
+        "output_tokens_total": 6,
+        "output_tok_s": 1.169,
+        "total_tok_s": 3910.246,
+        "req_s": 0.195,
+        "prefill_tok_s": 3962.217,
+        "ttft_ms": {
+          "mean": 5063.831,
+          "p50": 5063.831,
+          "p90": 5063.831,
+          "p95": 5063.831,
+          "p99": 5063.831,
+          "min": 5063.831,
+          "max": 5063.831
+        },
+        "tpot_ms": {
+          "mean": 13.737,
+          "p50": 13.737,
+          "p90": 13.737,
+          "p95": 13.737,
+          "p99": 13.737,
+          "min": 13.737,
+          "max": 13.737
+        },
+        "itl_ms": {
+          "mean": 67.345,
+          "p50": 67.345,
+          "p90": 67.345,
+          "p95": 67.345,
+          "p99": 67.345,
+          "min": 67.345,
+          "max": 67.345
+        },
+        "e2e_ms": {
+          "mean": 5132.517,
+          "p50": 5132.517,
+          "p90": 5132.517,
+          "p95": 5132.517,
+          "p99": 5132.517,
+          "min": 5132.517,
+          "max": 5132.517
+        },
+        "decode_tok_s_per_request": {
+          "mean": 72.796,
+          "p50": 72.796,
+          "p90": 72.796,
+          "p95": 72.796,
+          "p99": 72.796,
+          "min": 72.796,
+          "max": 72.796
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 97.675,
+        "kv_cache_tokens": null,
+        "power_avg_w": 67.87,
+        "power_peak_w": 71.31,
+        "energy_wh": 0.0798,
+        "gpu_util_avg_pct": 95.4,
+        "temp_max_c": 60.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 32768,
+      "output_tokens": 256,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 10.96,
+        "input_tokens_total": 40486,
+        "output_tokens_total": 6,
+        "output_tok_s": 0.547,
+        "total_tok_s": 3694.671,
+        "req_s": 0.091,
+        "prefill_tok_s": 3720.659,
+        "ttft_ms": {
+          "mean": 10881.407,
+          "p50": 10881.407,
+          "p90": 10881.407,
+          "p95": 10881.407,
+          "p99": 10881.407,
+          "min": 10881.407,
+          "max": 10881.407
+        },
+        "tpot_ms": {
+          "mean": 15.597,
+          "p50": 15.597,
+          "p90": 15.597,
+          "p95": 15.597,
+          "p99": 15.597,
+          "min": 15.597,
+          "max": 15.597
+        },
+        "itl_ms": {
+          "mean": 77.074,
+          "p50": 77.074,
+          "p90": 77.074,
+          "p95": 77.074,
+          "p99": 77.074,
+          "min": 77.074,
+          "max": 77.074
+        },
+        "e2e_ms": {
+          "mean": 10959.393,
+          "p50": 10959.393,
+          "p90": 10959.393,
+          "p95": 10959.393,
+          "p99": 10959.393,
+          "min": 10959.393,
+          "max": 10959.393
+        },
+        "decode_tok_s_per_request": {
+          "mean": 64.114,
+          "p50": 64.114,
+          "p90": 64.114,
+          "p95": 64.114,
+          "p99": 64.114,
+          "min": 64.114,
+          "max": 64.114
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 98.126,
+        "kv_cache_tokens": null,
+        "power_avg_w": 71.91,
+        "power_peak_w": 77.02,
+        "energy_wh": 0.2115,
+        "gpu_util_avg_pct": 96.0,
+        "temp_max_c": 67.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 65536,
+      "output_tokens": 256,
+      "label": "depth 90% · needle found",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 1,
+        "requests_failed": 0,
+        "success_rate": 1.0,
+        "duration_s": 25.199,
+        "input_tokens_total": 80765,
+        "output_tokens_total": 6,
+        "output_tok_s": 0.238,
+        "total_tok_s": 3205.344,
+        "req_s": 0.04,
+        "prefill_tok_s": 3217.239,
+        "ttft_ms": {
+          "mean": 25103.821,
+          "p50": 25103.821,
+          "p90": 25103.821,
+          "p95": 25103.821,
+          "p99": 25103.821,
+          "min": 25103.821,
+          "max": 25103.821
+        },
+        "tpot_ms": {
+          "mean": 18.972,
+          "p50": 18.972,
+          "p90": 18.972,
+          "p95": 18.972,
+          "p99": 18.972,
+          "min": 18.972,
+          "max": 18.972
+        },
+        "itl_ms": {
+          "mean": 94.167,
+          "p50": 94.167,
+          "p90": 94.167,
+          "p95": 94.167,
+          "p99": 94.167,
+          "min": 94.167,
+          "max": 94.167
+        },
+        "e2e_ms": {
+          "mean": 25198.683,
+          "p50": 25198.683,
+          "p90": 25198.683,
+          "p95": 25198.683,
+          "p99": 25198.683,
+          "min": 25198.683,
+          "max": 25198.683
+        },
+        "decode_tok_s_per_request": {
+          "mean": 52.709,
+          "p50": 52.709,
+          "p90": 52.709,
+          "p95": 52.709,
+          "p99": 52.709,
+          "min": 52.709,
+          "max": 52.709
+        },
+        "vram_peak_gb": null,
+        "ram_peak_gb": 104.098,
+        "kv_cache_tokens": null,
+        "power_avg_w": 76.04,
+        "power_peak_w": 85.82,
+        "energy_wh": 0.5206,
+        "gpu_util_avg_pct": 96.0,
+        "temp_max_c": 72.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 131072,
+      "output_tokens": 256,
+      "label": "depth 90% · needle n/a",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 0,
+        "requests_failed": 1,
+        "success_rate": 0.0,
+        "duration_s": 0.303,
+        "input_tokens_total": 0,
+        "output_tokens_total": 0,
+        "output_tok_s": 0.0,
+        "total_tok_s": 0.0,
+        "req_s": 0.0,
+        "prefill_tok_s": null,
+        "ttft_ms": null,
+        "tpot_ms": null,
+        "itl_ms": null,
+        "e2e_ms": null,
+        "decode_tok_s_per_request": null,
+        "vram_peak_gb": null,
+        "ram_peak_gb": 104.118,
+        "kv_cache_tokens": null,
+        "power_avg_w": 78.47,
+        "power_peak_w": 78.47,
+        "energy_wh": 0.0,
+        "gpu_util_avg_pct": 96.0,
+        "temp_max_c": 74.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 262144,
+      "output_tokens": 256,
+      "label": "depth 90% · needle n/a",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 0,
+        "requests_failed": 1,
+        "success_rate": 0.0,
+        "duration_s": 0.956,
+        "input_tokens_total": 0,
+        "output_tokens_total": 0,
+        "output_tok_s": 0.0,
+        "total_tok_s": 0.0,
+        "req_s": 0.0,
+        "prefill_tok_s": null,
+        "ttft_ms": null,
+        "tpot_ms": null,
+        "itl_ms": null,
+        "e2e_ms": null,
+        "decode_tok_s_per_request": null,
+        "vram_peak_gb": null,
+        "ram_peak_gb": 104.14,
+        "kv_cache_tokens": null,
+        "power_avg_w": 63.75,
+        "power_peak_w": 63.75,
+        "energy_wh": 0.0,
+        "gpu_util_avg_pct": 96.0,
+        "temp_max_c": 61.0,
+        "thermal_throttle_detected": false
+      }
+    }
+  ],
+  "failures": [
+    {
+      "at": "request",
+      "count": 1,
+      "category": "context-overflow",
+      "message": "Input length (161400 tokens) exceeds the maximum allowed length (140474 tokens). Use a shorter input or enable --allow-auto-truncate.",
+      "sample_request_id": "ctx131072-r00000"
+    },
+    {
+      "at": "request",
+      "count": 1,
+      "category": "http-4xx",
+      "message": "{\"object\":\"error\",\"message\":\"The input (322473 tokens) is longer than the model's context length (262144 tokens).\",\"type\":\"BadRequestError\",\"param\":null,\"code\":400}",
+      "sample_request_id": "ctx262144-r00000"
+    }
+  ],
+  "conditions": null,
+  "gotchas": [
+    {
+      "severity": "warn",
+      "text": "Requests exceeded the model's context window; the workload's input length does not fit this configuration."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": 0.0031,
+    "tok_s_per_gb_bandwidth": 0.193073,
+    "bandwidth_efficiency": 0.5241,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "4986a3b8d4b99c11d63e9c89f8cdd49ac0eef72e89753a4114be20c7c84136a0",
+    "payload_path": null,
+    "payload": {
+      "points": [
+        {
+          "id": "hay-1k-d90",
+          "input_tokens": 1024,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 10.351,
+          "decode_tok_s": 86.013,
+          "ttft_ms": 521.358,
+          "success_rate": 1.0
+        },
+        {
+          "id": "hay-4k-d90",
+          "input_tokens": 4096,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 4.053,
+          "decode_tok_s": 83.741,
+          "ttft_ms": 1420.331,
+          "success_rate": 1.0
+        },
+        {
+          "id": "hay-8k-d90",
+          "input_tokens": 8192,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 2.142,
+          "decode_tok_s": 77.488,
+          "ttft_ms": 2736.068,
+          "success_rate": 1.0
+        },
+        {
+          "id": "hay-16k-d90",
+          "input_tokens": 16384,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 1.169,
+          "decode_tok_s": 72.796,
+          "ttft_ms": 5063.831,
+          "success_rate": 1.0
+        },
+        {
+          "id": "hay-32k-d90",
+          "input_tokens": 32768,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 0.547,
+          "decode_tok_s": 64.114,
+          "ttft_ms": 10881.407,
+          "success_rate": 1.0
+        },
+        {
+          "id": "hay-64k-d90",
+          "input_tokens": 65536,
+          "depth_pct": 90.0,
+          "needle_correct": true,
+          "output_tok_s": 0.238,
+          "decode_tok_s": 52.709,
+          "ttft_ms": 25103.821,
+          "success_rate": 1.0
+        },
+        {
+          "id": "hay-128k-d90",
+          "input_tokens": 131072,
+          "depth_pct": 90.0,
+          "needle_correct": null,
+          "output_tok_s": 0.0,
+          "decode_tok_s": null,
+          "ttft_ms": null,
+          "success_rate": 0.0
+        },
+        {
+          "id": "hay-256k-d90",
+          "input_tokens": 262144,
+          "depth_pct": 90.0,
+          "needle_correct": null,
+          "output_tok_s": 0.0,
+          "decode_tok_s": null,
+          "ttft_ms": null,
+          "success_rate": 0.0
+        }
+      ],
+      "requests": [
+        {
+          "id": "ctx1024-r00000",
+          "prompt_id": "hay-1k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 521.358,
+          "e2e_ms": 579.488,
+          "prompt_tokens": 1371,
+          "completion_tokens": 6,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx4096-r00000",
+          "prompt_id": "hay-4k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 1420.331,
+          "e2e_ms": 1480.039,
+          "prompt_tokens": 5176,
+          "completion_tokens": 6,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx8192-r00000",
+          "prompt_id": "hay-8k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 2736.068,
+          "e2e_ms": 2800.594,
+          "prompt_tokens": 10169,
+          "completion_tokens": 6,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx16384-r00000",
+          "prompt_id": "hay-16k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 5063.831,
+          "e2e_ms": 5132.517,
+          "prompt_tokens": 20064,
+          "completion_tokens": 6,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx32768-r00000",
+          "prompt_id": "hay-32k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 10881.407,
+          "e2e_ms": 10959.393,
+          "prompt_tokens": 40486,
+          "completion_tokens": 6,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx65536-r00000",
+          "prompt_id": "hay-64k-d90",
+          "warmup": false,
+          "status": "ok",
+          "ttft_ms": 25103.821,
+          "e2e_ms": 25198.683,
+          "prompt_tokens": 80765,
+          "completion_tokens": 6,
+          "token_source": "usage",
+          "finish_reason": "stop",
+          "error_category": null
+        },
+        {
+          "id": "ctx131072-r00000",
+          "prompt_id": "hay-128k-d90",
+          "warmup": false,
+          "status": "error",
+          "ttft_ms": null,
+          "e2e_ms": 302.22,
+          "prompt_tokens": null,
+          "completion_tokens": null,
+          "token_source": "usage",
+          "finish_reason": null,
+          "error_category": "context-overflow"
+        },
+        {
+          "id": "ctx262144-r00000",
+          "prompt_id": "hay-256k-d90",
+          "warmup": false,
+          "status": "error",
+          "ttft_ms": null,
+          "e2e_ms": 464.191,
+          "prompt_tokens": null,
+          "completion_tokens": null,
+          "token_source": "usage",
+          "finish_reason": null,
+          "error_category": "http-4xx"
+        }
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "ling-3.0-flash",
+        "advertised_models": [
+          "ling-3.0-flash"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-09-09T23:17:48Z",
+    "finished_at": "2026-09-09T23:18:36Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Served with the ling3-flash-dgx-spark recipe (49b6c9c), PROFILE=humming-dspark, thinking off (server default via --default-chat-template-kwargs): inclusionAI/Ling-3.0-flash-fp4 (MXFP4 routed experts, FP8 attention/shared/router) with --moe-runner-backend humming, online FP8 LM head (SGLANG_ENABLE_FP8_LM_HEAD=1), DSpark speculative decoding with inclusionAI/Ling-3.0-flash-dspark and the KDA ReplaySSM exact fold (--enable-linear-replayssm-spec, ring 32), context 262144 native (no YaRN), mem-fraction 0.75, max-running 1, page 64, decode cuda graph bs 1, prefill cuda graph disabled, FlashInfer autotune off with precompiled CUTLASS MXFP4 kernels. Single request at a time on every row."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--longctx-needle-128k-v1--b6f8b1.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--longctx-needle-128k-v1--b6f8b1.json
@@ -1,0 +1,524 @@
+{
+  "schema_version": 1,
+  "run_id": "a9e5da49f0c2bba3--longctx-needle-128k-v1--b6f8b1",
+  "config_id": "a9e5da49f0c2bba3",
+  "cell_id": "4ab17fea2273",
+  "workload_id": "longctx-needle-128k-v1",
+  "kind": "longctx",
+  "engine": {
+    "id": "sglang",
+    "version": "0.0.0.dev1+g079d40460",
+    "commit": null,
+    "build": "github.com/inclusionAI/sglang@079d404",
+    "container": "lmsysorg/sglang:v0.0.0.dev1+g079d40460-cu126",
+    "install_method": "source"
+  },
+  "model": {
+    "id": "inclusionAI/Ling-3.0-flash",
+    "quant_id": "mxfp4",
+    "hf_id": "inclusionAI/Ling-3.0-flash",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "moe-runner-backend": "humming",
+    "speculative-algorithm": "DSPARK",
+    "speculative-draft-model-path": "inclusionAI/Ling-3.0-flash-dspark",
+    "enable-linear-replayssm-spec": true,
+    "linear-replayssm-cache-len": 32,
+    "mem-fraction-static": 0.75,
+    "max-running-requests": 1,
+    "max-mamba-cache-size": 64,
+    "chunked-prefill-size": 8192,
+    "max-prefill-tokens": 16384,
+    "page-size": 64,
+    "attention-backend": "flashinfer",
+    "fp8-gemm-backend": "cutlass",
+    "flashinfer-mxfp4-moe-precision": "default",
+    "disable-shared-experts-fusion": true,
+    "cuda-graph-backend-decode": "full",
+    "cuda-graph-max-bs-decode": 1,
+    "cuda-graph-backend-prefill": "disabled",
+    "reasoning-parser": "deepseek-r1",
+    "tool-call-parser": "qwen25",
+    "trust-remote-code": true,
+    "fp8-lm-head": "online",
+    "default-chat-template-kwargs": {
+      "enable_thinking": false
+    }
+  },
+  "args_canonical": "@build=github.com/inclusionai/sglang@079d404;@dtype=auto;@quant=mxfp4;attention-backend=flashinfer;chunked-prefill-size=8192;cuda-graph-backend-decode=full;cuda-graph-backend-prefill=disabled;cuda-graph-max-bs-decode=1;default-chat-template-kwargs={\"enable_thinking\":false};disable-shared-experts-fusion=true;enable-linear-replayssm-spec=true;fp8-gemm-backend=cutlass;fp8-lm-head=online;linear-replayssm-cache-len=32;max-mamba-cache-size=64;max-running-requests=1;mem-fraction-static=0.75;moe-runner-backend=humming;page-size=64;reasoning-parser=deepseek-r1;speculative-algorithm=DSPARK;speculative-draft-model-path=inclusionAI/Ling-3.0-flash-dspark;tool-call-parser=qwen25;trust-remote-code=true",
+  "serve_command": null,
+  "workload": {
+    "id": "longctx-needle-128k-v1",
+    "resolved_params": {
+      "axis": "input_tokens",
+      "points": [
+        [
+          131072,
+          10.0
+        ],
+        [
+          131072,
+          10.0
+        ],
+        [
+          131072,
+          50.0
+        ],
+        [
+          131072,
+          50.0
+        ],
+        [
+          131072,
+          90.0
+        ],
+        [
+          131072,
+          90.0
+        ]
+      ],
+      "output_tokens": 128,
+      "needle_check": true,
+      "needle_depth": null,
+      "headline_input_tokens": null,
+      "needles_found": 0,
+      "needles_total": 0,
+      "dataset_categories": [
+        "needle"
+      ],
+      "dataset_target_tokens": 131072,
+      "timeout_s": 1800.0,
+      "seed": 42
+    }
+  },
+  "sweep": [
+    {
+      "input_tokens": 131072,
+      "output_tokens": 128,
+      "label": "depth 10% · needle n/a",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 0,
+        "requests_failed": 1,
+        "success_rate": 0.0,
+        "duration_s": 0.315,
+        "input_tokens_total": 0,
+        "output_tokens_total": 0,
+        "output_tok_s": 0.0,
+        "total_tok_s": 0.0,
+        "req_s": 0.0,
+        "prefill_tok_s": null,
+        "ttft_ms": null,
+        "tpot_ms": null,
+        "itl_ms": null,
+        "e2e_ms": null,
+        "decode_tok_s_per_request": null,
+        "vram_peak_gb": null,
+        "ram_peak_gb": 95.189,
+        "kv_cache_tokens": null,
+        "power_avg_w": 10.08,
+        "power_peak_w": 10.08,
+        "energy_wh": 0.0,
+        "gpu_util_avg_pct": 0.0,
+        "temp_max_c": 46.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 131072,
+      "output_tokens": 128,
+      "label": "depth 10% · needle n/a",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 0,
+        "requests_failed": 1,
+        "success_rate": 0.0,
+        "duration_s": 0.283,
+        "input_tokens_total": 0,
+        "output_tokens_total": 0,
+        "output_tok_s": 0.0,
+        "total_tok_s": 0.0,
+        "req_s": 0.0,
+        "prefill_tok_s": null,
+        "ttft_ms": null,
+        "tpot_ms": null,
+        "itl_ms": null,
+        "e2e_ms": null,
+        "decode_tok_s_per_request": null,
+        "vram_peak_gb": null,
+        "ram_peak_gb": 95.215,
+        "kv_cache_tokens": null,
+        "power_avg_w": 12.41,
+        "power_peak_w": 12.41,
+        "energy_wh": 0.0,
+        "gpu_util_avg_pct": 0.0,
+        "temp_max_c": 46.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 131072,
+      "output_tokens": 128,
+      "label": "depth 50% · needle n/a",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 0,
+        "requests_failed": 1,
+        "success_rate": 0.0,
+        "duration_s": 0.286,
+        "input_tokens_total": 0,
+        "output_tokens_total": 0,
+        "output_tok_s": 0.0,
+        "total_tok_s": 0.0,
+        "req_s": 0.0,
+        "prefill_tok_s": null,
+        "ttft_ms": null,
+        "tpot_ms": null,
+        "itl_ms": null,
+        "e2e_ms": null,
+        "decode_tok_s_per_request": null,
+        "vram_peak_gb": null,
+        "ram_peak_gb": 95.202,
+        "kv_cache_tokens": null,
+        "power_avg_w": 14.42,
+        "power_peak_w": 14.42,
+        "energy_wh": 0.0,
+        "gpu_util_avg_pct": 0.0,
+        "temp_max_c": 46.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 131072,
+      "output_tokens": 128,
+      "label": "depth 50% · needle n/a",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 0,
+        "requests_failed": 1,
+        "success_rate": 0.0,
+        "duration_s": 0.288,
+        "input_tokens_total": 0,
+        "output_tokens_total": 0,
+        "output_tok_s": 0.0,
+        "total_tok_s": 0.0,
+        "req_s": 0.0,
+        "prefill_tok_s": null,
+        "ttft_ms": null,
+        "tpot_ms": null,
+        "itl_ms": null,
+        "e2e_ms": null,
+        "decode_tok_s_per_request": null,
+        "vram_peak_gb": null,
+        "ram_peak_gb": 95.199,
+        "kv_cache_tokens": null,
+        "power_avg_w": 17.29,
+        "power_peak_w": 17.29,
+        "energy_wh": 0.0,
+        "gpu_util_avg_pct": 0.0,
+        "temp_max_c": 46.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 131072,
+      "output_tokens": 128,
+      "label": "depth 90% · needle n/a",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 0,
+        "requests_failed": 1,
+        "success_rate": 0.0,
+        "duration_s": 0.285,
+        "input_tokens_total": 0,
+        "output_tokens_total": 0,
+        "output_tok_s": 0.0,
+        "total_tok_s": 0.0,
+        "req_s": 0.0,
+        "prefill_tok_s": null,
+        "ttft_ms": null,
+        "tpot_ms": null,
+        "itl_ms": null,
+        "e2e_ms": null,
+        "decode_tok_s_per_request": null,
+        "vram_peak_gb": null,
+        "ram_peak_gb": 95.197,
+        "kv_cache_tokens": null,
+        "power_avg_w": 20.0,
+        "power_peak_w": 20.0,
+        "energy_wh": 0.0,
+        "gpu_util_avg_pct": 0.0,
+        "temp_max_c": 47.0,
+        "thermal_throttle_detected": false
+      }
+    },
+    {
+      "input_tokens": 131072,
+      "output_tokens": 128,
+      "label": "depth 90% · needle n/a",
+      "metrics": {
+        "requests_total": 1,
+        "requests_ok": 0,
+        "requests_failed": 1,
+        "success_rate": 0.0,
+        "duration_s": 0.284,
+        "input_tokens_total": 0,
+        "output_tokens_total": 0,
+        "output_tok_s": 0.0,
+        "total_tok_s": 0.0,
+        "req_s": 0.0,
+        "prefill_tok_s": null,
+        "ttft_ms": null,
+        "tpot_ms": null,
+        "itl_ms": null,
+        "e2e_ms": null,
+        "decode_tok_s_per_request": null,
+        "vram_peak_gb": null,
+        "ram_peak_gb": 95.194,
+        "kv_cache_tokens": null,
+        "power_avg_w": 19.95,
+        "power_peak_w": 19.95,
+        "energy_wh": 0.0,
+        "gpu_util_avg_pct": 0.0,
+        "temp_max_c": 47.0,
+        "thermal_throttle_detected": false
+      }
+    }
+  ],
+  "failures": [
+    {
+      "at": "request",
+      "count": 6,
+      "category": "context-overflow",
+      "message": "Input length (161293 tokens) exceeds the maximum allowed length (140474 tokens). Use a shorter input or enable --allow-auto-truncate.",
+      "sample_request_id": "ctx131072-r00000"
+    }
+  ],
+  "conditions": null,
+  "gotchas": [
+    {
+      "severity": "warn",
+      "text": "Requests exceeded the model's context window; the workload's input length does not fit this configuration."
+    }
+  ],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "d448b2d50f976cbd07f4a001ee93d0d97ee24977f6cf5ac22e02066b8d29b509",
+    "payload_path": null,
+    "payload": {
+      "points": [
+        {
+          "id": "lctx-0049",
+          "input_tokens": 131072,
+          "depth_pct": 10.0,
+          "needle_correct": null,
+          "output_tok_s": 0.0,
+          "decode_tok_s": null,
+          "ttft_ms": null,
+          "success_rate": 0.0
+        },
+        {
+          "id": "lctx-0050",
+          "input_tokens": 131072,
+          "depth_pct": 10.0,
+          "needle_correct": null,
+          "output_tok_s": 0.0,
+          "decode_tok_s": null,
+          "ttft_ms": null,
+          "success_rate": 0.0
+        },
+        {
+          "id": "lctx-0051",
+          "input_tokens": 131072,
+          "depth_pct": 50.0,
+          "needle_correct": null,
+          "output_tok_s": 0.0,
+          "decode_tok_s": null,
+          "ttft_ms": null,
+          "success_rate": 0.0
+        },
+        {
+          "id": "lctx-0052",
+          "input_tokens": 131072,
+          "depth_pct": 50.0,
+          "needle_correct": null,
+          "output_tok_s": 0.0,
+          "decode_tok_s": null,
+          "ttft_ms": null,
+          "success_rate": 0.0
+        },
+        {
+          "id": "lctx-0053",
+          "input_tokens": 131072,
+          "depth_pct": 90.0,
+          "needle_correct": null,
+          "output_tok_s": 0.0,
+          "decode_tok_s": null,
+          "ttft_ms": null,
+          "success_rate": 0.0
+        },
+        {
+          "id": "lctx-0054",
+          "input_tokens": 131072,
+          "depth_pct": 90.0,
+          "needle_correct": null,
+          "output_tok_s": 0.0,
+          "decode_tok_s": null,
+          "ttft_ms": null,
+          "success_rate": 0.0
+        }
+      ],
+      "requests": [
+        {
+          "id": "ctx131072-r00000",
+          "prompt_id": "lctx-0049",
+          "warmup": false,
+          "status": "error",
+          "ttft_ms": null,
+          "e2e_ms": 313.977,
+          "prompt_tokens": null,
+          "completion_tokens": null,
+          "token_source": "usage",
+          "finish_reason": null,
+          "error_category": "context-overflow"
+        },
+        {
+          "id": "ctx131072-r00000",
+          "prompt_id": "lctx-0050",
+          "warmup": false,
+          "status": "error",
+          "ttft_ms": null,
+          "e2e_ms": 281.597,
+          "prompt_tokens": null,
+          "completion_tokens": null,
+          "token_source": "usage",
+          "finish_reason": null,
+          "error_category": "context-overflow"
+        },
+        {
+          "id": "ctx131072-r00000",
+          "prompt_id": "lctx-0051",
+          "warmup": false,
+          "status": "error",
+          "ttft_ms": null,
+          "e2e_ms": 285.022,
+          "prompt_tokens": null,
+          "completion_tokens": null,
+          "token_source": "usage",
+          "finish_reason": null,
+          "error_category": "context-overflow"
+        },
+        {
+          "id": "ctx131072-r00000",
+          "prompt_id": "lctx-0052",
+          "warmup": false,
+          "status": "error",
+          "ttft_ms": null,
+          "e2e_ms": 286.762,
+          "prompt_tokens": null,
+          "completion_tokens": null,
+          "token_source": "usage",
+          "finish_reason": null,
+          "error_category": "context-overflow"
+        },
+        {
+          "id": "ctx131072-r00000",
+          "prompt_id": "lctx-0053",
+          "warmup": false,
+          "status": "error",
+          "ttft_ms": null,
+          "e2e_ms": 284.084,
+          "prompt_tokens": null,
+          "completion_tokens": null,
+          "token_source": "usage",
+          "finish_reason": null,
+          "error_category": "context-overflow"
+        },
+        {
+          "id": "ctx131072-r00000",
+          "prompt_id": "lctx-0054",
+          "warmup": false,
+          "status": "error",
+          "ttft_ms": null,
+          "e2e_ms": 283.055,
+          "prompt_tokens": null,
+          "completion_tokens": null,
+          "token_source": "usage",
+          "finish_reason": null,
+          "error_category": "context-overflow"
+        }
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "ling-3.0-flash",
+        "advertised_models": [
+          "ling-3.0-flash"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-09-09T23:17:46Z",
+    "finished_at": "2026-09-09T23:17:47Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Served with the ling3-flash-dgx-spark recipe (49b6c9c), PROFILE=humming-dspark, thinking off (server default via --default-chat-template-kwargs): inclusionAI/Ling-3.0-flash-fp4 (MXFP4 routed experts, FP8 attention/shared/router) with --moe-runner-backend humming, online FP8 LM head (SGLANG_ENABLE_FP8_LM_HEAD=1), DSpark speculative decoding with inclusionAI/Ling-3.0-flash-dspark and the KDA ReplaySSM exact fold (--enable-linear-replayssm-spec, ring 32), context 262144 native (no YaRN), mem-fraction 0.75, max-running 1, page 64, decode cuda graph bs 1, prefill cuda graph disabled, FlashInfer autotune off with precompiled CUTLASS MXFP4 kernels. Single request at a time on every row."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--longctx-needle-128k-v1--b6f8b1.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--longctx-needle-128k-v1--b6f8b1.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -91,27 +91,27 @@
       "points": [
         [
           131072,
-          10.0
+          10
         ],
         [
           131072,
-          10.0
+          10
         ],
         [
           131072,
-          50.0
+          50
         ],
         [
           131072,
-          50.0
+          50
         ],
         [
           131072,
-          90.0
+          90
         ],
         [
           131072,
-          90.0
+          90
         ]
       ],
       "output_tokens": 128,
@@ -124,7 +124,7 @@
         "needle"
       ],
       "dataset_target_tokens": 131072,
-      "timeout_s": 1800.0,
+      "timeout_s": 1800,
       "seed": 42
     }
   },
@@ -137,13 +137,13 @@
         "requests_total": 1,
         "requests_ok": 0,
         "requests_failed": 1,
-        "success_rate": 0.0,
+        "success_rate": 0,
         "duration_s": 0.315,
         "input_tokens_total": 0,
         "output_tokens_total": 0,
-        "output_tok_s": 0.0,
-        "total_tok_s": 0.0,
-        "req_s": 0.0,
+        "output_tok_s": 0,
+        "total_tok_s": 0,
+        "req_s": 0,
         "prefill_tok_s": null,
         "ttft_ms": null,
         "tpot_ms": null,
@@ -155,9 +155,9 @@
         "kv_cache_tokens": null,
         "power_avg_w": 10.08,
         "power_peak_w": 10.08,
-        "energy_wh": 0.0,
-        "gpu_util_avg_pct": 0.0,
-        "temp_max_c": 46.0,
+        "energy_wh": 0,
+        "gpu_util_avg_pct": 0,
+        "temp_max_c": 46,
         "thermal_throttle_detected": false
       }
     },
@@ -169,13 +169,13 @@
         "requests_total": 1,
         "requests_ok": 0,
         "requests_failed": 1,
-        "success_rate": 0.0,
+        "success_rate": 0,
         "duration_s": 0.283,
         "input_tokens_total": 0,
         "output_tokens_total": 0,
-        "output_tok_s": 0.0,
-        "total_tok_s": 0.0,
-        "req_s": 0.0,
+        "output_tok_s": 0,
+        "total_tok_s": 0,
+        "req_s": 0,
         "prefill_tok_s": null,
         "ttft_ms": null,
         "tpot_ms": null,
@@ -187,9 +187,9 @@
         "kv_cache_tokens": null,
         "power_avg_w": 12.41,
         "power_peak_w": 12.41,
-        "energy_wh": 0.0,
-        "gpu_util_avg_pct": 0.0,
-        "temp_max_c": 46.0,
+        "energy_wh": 0,
+        "gpu_util_avg_pct": 0,
+        "temp_max_c": 46,
         "thermal_throttle_detected": false
       }
     },
@@ -201,13 +201,13 @@
         "requests_total": 1,
         "requests_ok": 0,
         "requests_failed": 1,
-        "success_rate": 0.0,
+        "success_rate": 0,
         "duration_s": 0.286,
         "input_tokens_total": 0,
         "output_tokens_total": 0,
-        "output_tok_s": 0.0,
-        "total_tok_s": 0.0,
-        "req_s": 0.0,
+        "output_tok_s": 0,
+        "total_tok_s": 0,
+        "req_s": 0,
         "prefill_tok_s": null,
         "ttft_ms": null,
         "tpot_ms": null,
@@ -219,9 +219,9 @@
         "kv_cache_tokens": null,
         "power_avg_w": 14.42,
         "power_peak_w": 14.42,
-        "energy_wh": 0.0,
-        "gpu_util_avg_pct": 0.0,
-        "temp_max_c": 46.0,
+        "energy_wh": 0,
+        "gpu_util_avg_pct": 0,
+        "temp_max_c": 46,
         "thermal_throttle_detected": false
       }
     },
@@ -233,13 +233,13 @@
         "requests_total": 1,
         "requests_ok": 0,
         "requests_failed": 1,
-        "success_rate": 0.0,
+        "success_rate": 0,
         "duration_s": 0.288,
         "input_tokens_total": 0,
         "output_tokens_total": 0,
-        "output_tok_s": 0.0,
-        "total_tok_s": 0.0,
-        "req_s": 0.0,
+        "output_tok_s": 0,
+        "total_tok_s": 0,
+        "req_s": 0,
         "prefill_tok_s": null,
         "ttft_ms": null,
         "tpot_ms": null,
@@ -251,9 +251,9 @@
         "kv_cache_tokens": null,
         "power_avg_w": 17.29,
         "power_peak_w": 17.29,
-        "energy_wh": 0.0,
-        "gpu_util_avg_pct": 0.0,
-        "temp_max_c": 46.0,
+        "energy_wh": 0,
+        "gpu_util_avg_pct": 0,
+        "temp_max_c": 46,
         "thermal_throttle_detected": false
       }
     },
@@ -265,13 +265,13 @@
         "requests_total": 1,
         "requests_ok": 0,
         "requests_failed": 1,
-        "success_rate": 0.0,
+        "success_rate": 0,
         "duration_s": 0.285,
         "input_tokens_total": 0,
         "output_tokens_total": 0,
-        "output_tok_s": 0.0,
-        "total_tok_s": 0.0,
-        "req_s": 0.0,
+        "output_tok_s": 0,
+        "total_tok_s": 0,
+        "req_s": 0,
         "prefill_tok_s": null,
         "ttft_ms": null,
         "tpot_ms": null,
@@ -281,11 +281,11 @@
         "vram_peak_gb": null,
         "ram_peak_gb": 95.197,
         "kv_cache_tokens": null,
-        "power_avg_w": 20.0,
-        "power_peak_w": 20.0,
-        "energy_wh": 0.0,
-        "gpu_util_avg_pct": 0.0,
-        "temp_max_c": 47.0,
+        "power_avg_w": 20,
+        "power_peak_w": 20,
+        "energy_wh": 0,
+        "gpu_util_avg_pct": 0,
+        "temp_max_c": 47,
         "thermal_throttle_detected": false
       }
     },
@@ -297,13 +297,13 @@
         "requests_total": 1,
         "requests_ok": 0,
         "requests_failed": 1,
-        "success_rate": 0.0,
+        "success_rate": 0,
         "duration_s": 0.284,
         "input_tokens_total": 0,
         "output_tokens_total": 0,
-        "output_tok_s": 0.0,
-        "total_tok_s": 0.0,
-        "req_s": 0.0,
+        "output_tok_s": 0,
+        "total_tok_s": 0,
+        "req_s": 0,
         "prefill_tok_s": null,
         "ttft_ms": null,
         "tpot_ms": null,
@@ -315,9 +315,9 @@
         "kv_cache_tokens": null,
         "power_avg_w": 19.95,
         "power_peak_w": 19.95,
-        "energy_wh": 0.0,
-        "gpu_util_avg_pct": 0.0,
-        "temp_max_c": 47.0,
+        "energy_wh": 0,
+        "gpu_util_avg_pct": 0,
+        "temp_max_c": 47,
         "thermal_throttle_detected": false
       }
     }
@@ -355,62 +355,62 @@
         {
           "id": "lctx-0049",
           "input_tokens": 131072,
-          "depth_pct": 10.0,
+          "depth_pct": 10,
           "needle_correct": null,
-          "output_tok_s": 0.0,
+          "output_tok_s": 0,
           "decode_tok_s": null,
           "ttft_ms": null,
-          "success_rate": 0.0
+          "success_rate": 0
         },
         {
           "id": "lctx-0050",
           "input_tokens": 131072,
-          "depth_pct": 10.0,
+          "depth_pct": 10,
           "needle_correct": null,
-          "output_tok_s": 0.0,
+          "output_tok_s": 0,
           "decode_tok_s": null,
           "ttft_ms": null,
-          "success_rate": 0.0
+          "success_rate": 0
         },
         {
           "id": "lctx-0051",
           "input_tokens": 131072,
-          "depth_pct": 50.0,
+          "depth_pct": 50,
           "needle_correct": null,
-          "output_tok_s": 0.0,
+          "output_tok_s": 0,
           "decode_tok_s": null,
           "ttft_ms": null,
-          "success_rate": 0.0
+          "success_rate": 0
         },
         {
           "id": "lctx-0052",
           "input_tokens": 131072,
-          "depth_pct": 50.0,
+          "depth_pct": 50,
           "needle_correct": null,
-          "output_tok_s": 0.0,
+          "output_tok_s": 0,
           "decode_tok_s": null,
           "ttft_ms": null,
-          "success_rate": 0.0
+          "success_rate": 0
         },
         {
           "id": "lctx-0053",
           "input_tokens": 131072,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": null,
-          "output_tok_s": 0.0,
+          "output_tok_s": 0,
           "decode_tok_s": null,
           "ttft_ms": null,
-          "success_rate": 0.0
+          "success_rate": 0
         },
         {
           "id": "lctx-0054",
           "input_tokens": 131072,
-          "depth_pct": 90.0,
+          "depth_pct": 90,
           "needle_correct": null,
-          "output_tok_s": 0.0,
+          "output_tok_s": 0,
           "decode_tok_s": null,
           "ttft_ms": null,
-          "success_rate": 0.0
+          "success_rate": 0
         }
       ],
       "requests": [
@@ -506,7 +506,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-09T23:17:46Z",
     "finished_at": "2026-09-09T23:17:47Z",
     "submitted_at": null,


### PR DESCRIPTION
Follows #206 with the eval half of the same measurement session.

**Six v2 suites, 778 items, config `a3b46e9e`** — MXFP4 + Humming MoE + online FP8 LM head + DSpark, thinking on (the model's default mode, set as a server default via `--default-chat-template-kwargs`):

| suite | accuracy | items |
|---|---:|---:|
| eval-knowledge-v2 | 1.000 | 151 |
| eval-science-v2 | 1.000 | 120 |
| eval-math-v2 | 0.993 | 140 |
| eval-security-v2 | 0.973 | 111 |
| eval-reasoning-v2 | 0.950 | 140 |
| eval-commonsense-v2 | 0.948 | 116 |

Worth stating plainly: these are the *quantized* pack. Ant publishes BF16 vs FP4 on the model card for a different set of suites, and the gap there is under a point; nothing here contradicts that. The v2 suites were built because v1 saturated, so two perfect scores are a statement about this model on these suites, not about the suites being easy — `eval-commonsense-v2`, which is the one with the deliberate goal-tracking traps, is the lowest of the six.

Also adds `longctx-needle-128k-v1` and `longctx-depth-sweep-v1` under `a9e5da49`, an explicit thinking-off server. Those two rows were lost earlier in the session to a memory guard I had set above the server's healthy steady state, and are re-taken here.

`validate.ts`: 0 errors, no new warning families.

Recipe: https://github.com/0xBakeer/ling3-flash-spark

🤖 Generated with [Claude Code](https://claude.com/claude-code)