### PR TITLE
Ling-3.0-flash: v2 evals with thinking off, completing the matrix

### DIFF
--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-commonsense-v2--2aac46.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-commonsense-v2--2aac46.json
@@ -1,0 +1,1393 @@
+{
+  "schema_version": 1,
+  "run_id": "a9e5da49f0c2bba3--eval-commonsense-v2--2aac46",
+  "config_id": "a9e5da49f0c2bba3",
+  "cell_id": "4ab17fea2273",
+  "workload_id": "eval-commonsense-v2",
+  "kind": "eval",
+  "engine": {
+    "id": "sglang",
+    "version": "0.0.0.dev1+g079d40460",
+    "commit": null,
+    "build": "github.com/inclusionAI/sglang@079d404",
+    "container": "lmsysorg/sglang:v0.0.0.dev1+g079d40460-cu126",
+    "install_method": "source"
+  },
+  "model": {
+    "id": "inclusionAI/Ling-3.0-flash",
+    "quant_id": "mxfp4",
+    "hf_id": "inclusionAI/Ling-3.0-flash",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "moe-runner-backend": "humming",
+    "speculative-algorithm": "DSPARK",
+    "speculative-draft-model-path": "inclusionAI/Ling-3.0-flash-dspark",
+    "enable-linear-replayssm-spec": true,
+    "linear-replayssm-cache-len": 32,
+    "mem-fraction-static": 0.75,
+    "max-running-requests": 1,
+    "max-mamba-cache-size": 64,
+    "chunked-prefill-size": 8192,
+    "max-prefill-tokens": 16384,
+    "page-size": 64,
+    "attention-backend": "flashinfer",
+    "fp8-gemm-backend": "cutlass",
+    "flashinfer-mxfp4-moe-precision": "default",
+    "disable-shared-experts-fusion": true,
+    "cuda-graph-backend-decode": "full",
+    "cuda-graph-max-bs-decode": 1,
+    "cuda-graph-backend-prefill": "disabled",
+    "reasoning-parser": "deepseek-r1",
+    "tool-call-parser": "qwen25",
+    "trust-remote-code": true,
+    "fp8-lm-head": "online",
+    "default-chat-template-kwargs": {
+      "enable_thinking": false
+    }
+  },
+  "args_canonical": "@build=github.com/inclusionai/sglang@079d404;@dtype=auto;@quant=mxfp4;attention-backend=flashinfer;chunked-prefill-size=8192;cuda-graph-backend-decode=full;cuda-graph-backend-prefill=disabled;cuda-graph-max-bs-decode=1;default-chat-template-kwargs={\"enable_thinking\":false};disable-shared-experts-fusion=true;enable-linear-replayssm-spec=true;fp8-gemm-backend=cutlass;fp8-lm-head=online;linear-replayssm-cache-len=32;max-mamba-cache-size=64;max-running-requests=1;mem-fraction-static=0.75;moe-runner-backend=humming;page-size=64;reasoning-parser=deepseek-r1;speculative-algorithm=DSPARK;speculative-draft-model-path=inclusionAI/Ling-3.0-flash-dspark;tool-call-parser=qwen25;trust-remote-code=true",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-commonsense-v2",
+    "resolved_params": {
+      "dataset_id": "eval-commonsense-v2",
+      "suite": "commonsense",
+      "scorer": "mc",
+      "items": 116,
+      "concurrency": 4,
+      "max_output_tokens": 2048,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 116,
+    "requests_ok": 116,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 28.795,
+    "input_tokens_total": 10976,
+    "output_tokens_total": 256,
+    "e2e_ms": {
+      "mean": 980.16,
+      "p50": 994.636,
+      "p90": 1061.101,
+      "p95": 1072.974,
+      "p99": 1096.073,
+      "min": 220.68,
+      "max": 1104.505
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 103.872,
+    "power_avg_w": 50.26,
+    "power_peak_w": 52.58,
+    "energy_wh": 0.4034,
+    "gpu_util_avg_pct": 91.57,
+    "temp_max_c": 73.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "commonsense",
+    "total": 116,
+    "correct": 99,
+    "accuracy": 0.853448,
+    "success_rate": 1.0,
+    "by_category": {
+      "false_presupposition": {
+        "total": 16,
+        "correct": 16
+      },
+      "feasibility": {
+        "total": 12,
+        "correct": 10
+      },
+      "goal_tracking": {
+        "total": 22,
+        "correct": 21
+      },
+      "physical": {
+        "total": 20,
+        "correct": 20
+      },
+      "reversed_classics": {
+        "total": 14,
+        "correct": 11
+      },
+      "text_selfref": {
+        "total": 32,
+        "correct": 21
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 27,
+        "correct": 26
+      },
+      "hard": {
+        "total": 31,
+        "correct": 22
+      },
+      "medium": {
+        "total": 58,
+        "correct": 51
+      }
+    },
+    "avg_output_tokens": 2.21,
+    "avg_latency_ms": 980.16,
+    "failures": 0,
+    "items": [
+      {
+        "id": "common-0001",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 220.68,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0002",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 492.873,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0003",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 748.421,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0004",
+        "correct": false,
+        "predicted": "D",
+        "expected": "B",
+        "latency_ms": 1025.564,
+        "output_tokens": 2,
+        "category": "feasibility",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0005",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1075.377,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0006",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1072.173,
+        "output_tokens": 2,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0007",
+        "correct": true,
+        "predicted": "reward",
+        "expected": "reward",
+        "latency_ms": 1061.07,
+        "output_tokens": 3,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0008",
+        "correct": true,
+        "predicted": "45",
+        "expected": "45",
+        "latency_ms": 995.579,
+        "output_tokens": 3,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0009",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 991.871,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0010",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 999.06,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0011",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1026.243,
+        "output_tokens": 2,
+        "category": "feasibility",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0012",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 1035.275,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0013",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1017.92,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0014",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 989.112,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0015",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 937.115,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0016",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 952.135,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0017",
+        "correct": false,
+        "predicted": "6",
+        "expected": "4",
+        "latency_ms": 926.685,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0018",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 897.783,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0019",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 920.048,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0020",
+        "correct": false,
+        "predicted": "16:00",
+        "expected": "17:00",
+        "latency_ms": 989.981,
+        "output_tokens": 6,
+        "category": "feasibility",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0021",
+        "correct": false,
+        "predicted": "5",
+        "expected": "3",
+        "latency_ms": 977.14,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0022",
+        "correct": true,
+        "predicted": "11",
+        "expected": "11",
+        "latency_ms": 975.893,
+        "output_tokens": 3,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0023",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1002.177,
+        "output_tokens": 2,
+        "category": "feasibility",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0024",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 944.11,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0025",
+        "correct": false,
+        "predicted": "3",
+        "expected": "2",
+        "latency_ms": 945.123,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0026",
+        "correct": true,
+        "predicted": "10",
+        "expected": "10",
+        "latency_ms": 939.875,
+        "output_tokens": 3,
+        "category": "reversed_classics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0027",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 920.955,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0028",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 938.265,
+        "output_tokens": 2,
+        "category": "feasibility",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0029",
+        "correct": true,
+        "predicted": "46",
+        "expected": "46",
+        "latency_ms": 956.694,
+        "output_tokens": 3,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0030",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1005.404,
+        "output_tokens": 2,
+        "category": "feasibility",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0031",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1035.925,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0032",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1055.014,
+        "output_tokens": 2,
+        "category": "feasibility",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0033",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1092.068,
+        "output_tokens": 2,
+        "category": "feasibility",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0034",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1104.505,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0035",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1096.664,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0036",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1077.163,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0037",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 1029.51,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0038",
+        "correct": true,
+        "predicted": "reviled",
+        "expected": "reviled",
+        "latency_ms": 999.584,
+        "output_tokens": 3,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0039",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 980.007,
+        "output_tokens": 2,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0040",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 975.958,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0041",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1032.513,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0042",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1049.803,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0043",
+        "correct": true,
+        "predicted": "warts",
+        "expected": "warts",
+        "latency_ms": 993.692,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0044",
+        "correct": true,
+        "predicted": "repaid",
+        "expected": "repaid",
+        "latency_ms": 974.948,
+        "output_tokens": 3,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0045",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 976.079,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0046",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 990.52,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0047",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 1015.658,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0048",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1034.258,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0049",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 977.708,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0050",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 958.878,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0051",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 955.068,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0052",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 944.625,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0053",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 980.011,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0054",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1000.084,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0055",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1045.848,
+        "output_tokens": 2,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0056",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1066.784,
+        "output_tokens": 2,
+        "category": "reversed_classics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0057",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1056.91,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0058",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1048.528,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0059",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1035.48,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0060",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1043.147,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0061",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1037.033,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0062",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1020.912,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0063",
+        "correct": false,
+        "predicted": "r",
+        "expected": "a",
+        "latency_ms": 982.024,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0064",
+        "correct": false,
+        "predicted": "11",
+        "expected": "12",
+        "latency_ms": 910.696,
+        "output_tokens": 3,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0065",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 929.024,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0066",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 928.972,
+        "output_tokens": 2,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0067",
+        "correct": false,
+        "predicted": "5",
+        "expected": "4",
+        "latency_ms": 938.796,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0068",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 982.308,
+        "output_tokens": 2,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0069",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 944.035,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0070",
+        "correct": false,
+        "predicted": "Two",
+        "expected": "2",
+        "latency_ms": 903.982,
+        "output_tokens": 2,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0071",
+        "correct": false,
+        "predicted": "11",
+        "expected": "12",
+        "latency_ms": 908.635,
+        "output_tokens": 3,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0072",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 911.143,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0073",
+        "correct": false,
+        "predicted": "7",
+        "expected": "6",
+        "latency_ms": 901.053,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0074",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 965.579,
+        "output_tokens": 2,
+        "category": "feasibility",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0075",
+        "correct": false,
+        "predicted": "5",
+        "expected": "4",
+        "latency_ms": 961.377,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0076",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 963.969,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0077",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1008.287,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0078",
+        "correct": true,
+        "predicted": "y",
+        "expected": "y",
+        "latency_ms": 956.58,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0079",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1005.092,
+        "output_tokens": 2,
+        "category": "feasibility",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0080",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1019.85,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0081",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1012.089,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0082",
+        "correct": true,
+        "predicted": "m",
+        "expected": "m",
+        "latency_ms": 1010.987,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0083",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1007.572,
+        "output_tokens": 2,
+        "category": "feasibility",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0084",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1016.203,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0085",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1009.678,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0086",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1061.132,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0087",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1063.728,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0088",
+        "correct": false,
+        "predicted": "11",
+        "expected": "4",
+        "latency_ms": 988.628,
+        "output_tokens": 3,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0089",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1007.937,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0090",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1009.863,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0091",
+        "correct": true,
+        "predicted": "100",
+        "expected": "100",
+        "latency_ms": 977.938,
+        "output_tokens": 4,
+        "category": "reversed_classics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0092",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1025.591,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0093",
+        "correct": true,
+        "predicted": "08:45",
+        "expected": "08:45",
+        "latency_ms": 1070.634,
+        "output_tokens": 6,
+        "category": "feasibility",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0094",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1062.855,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0095",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1092.721,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0096",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 1056.297,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0097",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1012.132,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0098",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1000.268,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0099",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 987.697,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0100",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1025.476,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0101",
+        "correct": false,
+        "predicted": "B",
+        "expected": "C",
+        "latency_ms": 1030.505,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0102",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 993.674,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0103",
+        "correct": true,
+        "predicted": "lager",
+        "expected": "lager",
+        "latency_ms": 932.751,
+        "output_tokens": 3,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0104",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 930.632,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "easy"
+      },
+      {
+        "id": "common-0105",
+        "correct": false,
+        "predicted": "o",
+        "expected": "p",
+        "latency_ms": 883.223,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0106",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 922.692,
+        "output_tokens": 2,
+        "category": "false_presupposition",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0107",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1000.279,
+        "output_tokens": 2,
+        "category": "reversed_classics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0108",
+        "correct": true,
+        "predicted": "11",
+        "expected": "11",
+        "latency_ms": 972.981,
+        "output_tokens": 3,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0109",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1022.252,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0110",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1023.84,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0111",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1023.614,
+        "output_tokens": 2,
+        "category": "goal_tracking",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0112",
+        "correct": false,
+        "predicted": "6",
+        "expected": "8",
+        "latency_ms": 1025.935,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0113",
+        "correct": true,
+        "predicted": "i",
+        "expected": "i",
+        "latency_ms": 966.091,
+        "output_tokens": 2,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0114",
+        "correct": true,
+        "predicted": "desserts",
+        "expected": "desserts",
+        "latency_ms": 896.634,
+        "output_tokens": 4,
+        "category": "text_selfref",
+        "difficulty": "medium"
+      },
+      {
+        "id": "common-0115",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 879.234,
+        "output_tokens": 2,
+        "category": "physical",
+        "difficulty": "hard"
+      },
+      {
+        "id": "common-0116",
+        "correct": false,
+        "predicted": "C",
+        "expected": "B",
+        "latency_ms": 907.953,
+        "output_tokens": 2,
+        "category": "reversed_classics",
+        "difficulty": "medium"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "c890e0f2e3b9c749882d02e5b05b7c253875f4971be90ba5d31132168cfe53be",
+    "payload_path": null,
+    "payload": {
+      "scorer": "mc",
+      "scorers_used": [
+        "exact",
+        "mc",
+        "numeric"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "ling-3.0-flash",
+        "advertised_models": [
+          "ling-3.0-flash"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-09-10T00:36:58Z",
+    "finished_at": "2026-09-10T00:37:26Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Served with the ling3-flash-dgx-spark recipe (49b6c9c), PROFILE=humming-dspark, thinking off (server default via --default-chat-template-kwargs): inclusionAI/Ling-3.0-flash-fp4 (MXFP4 routed experts, FP8 attention/shared/router) with --moe-runner-backend humming, online FP8 LM head (SGLANG_ENABLE_FP8_LM_HEAD=1), DSpark speculative decoding with inclusionAI/Ling-3.0-flash-dspark and the KDA ReplaySSM exact fold (--enable-linear-replayssm-spec, ring 32), context 262144 native (no YaRN), mem-fraction 0.75, max-running 1, page 64, decode cuda graph bs 1, prefill cuda graph disabled, FlashInfer autotune off with precompiled CUTLASS MXFP4 kernels. Single request at a time on every row."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-commonsense-v2--2aac46.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-commonsense-v2--2aac46.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -93,7 +93,7 @@
       "items": 116,
       "concurrency": 4,
       "max_output_tokens": 2048,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -106,7 +106,7 @@
     "requests_total": 116,
     "requests_ok": 116,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 28.795,
     "input_tokens_total": 10976,
     "output_tokens_total": 256,
@@ -125,7 +125,7 @@
     "power_peak_w": 52.58,
     "energy_wh": 0.4034,
     "gpu_util_avg_pct": 91.57,
-    "temp_max_c": 73.0,
+    "temp_max_c": 73,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -133,7 +133,7 @@
     "total": 116,
     "correct": 99,
     "accuracy": 0.853448,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "false_presupposition": {
         "total": 16,
@@ -1375,7 +1375,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-10T00:36:58Z",
     "finished_at": "2026-09-10T00:37:26Z",
     "submitted_at": null,

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-knowledge-v2--df9cf0.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-knowledge-v2--df9cf0.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -93,7 +93,7 @@
       "items": 151,
       "concurrency": 4,
       "max_output_tokens": 1024,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -106,7 +106,7 @@
     "requests_total": 151,
     "requests_ok": 151,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 35.033,
     "input_tokens_total": 11223,
     "output_tokens_total": 302,
@@ -125,15 +125,15 @@
     "power_peak_w": 51.29,
     "energy_wh": 0.4836,
     "gpu_util_avg_pct": 92.15,
-    "temp_max_c": 72.0,
+    "temp_max_c": 72,
     "thermal_throttle_detected": false
   },
   "scores": {
     "suite": "knowledge",
     "total": 151,
     "correct": 151,
-    "accuracy": 1.0,
-    "success_rate": 1.0,
+    "accuracy": 1,
+    "success_rate": 1,
     "by_category": {
       "astronomy": {
         "total": 25,
@@ -174,7 +174,7 @@
         "correct": 104
       }
     },
-    "avg_output_tokens": 2.0,
+    "avg_output_tokens": 2,
     "avg_latency_ms": 918.8,
     "failures": 0,
     "items": [
@@ -893,7 +893,7 @@
         "correct": true,
         "predicted": "D",
         "expected": "D",
-        "latency_ms": 917.0,
+        "latency_ms": 917,
         "output_tokens": 2,
         "category": "biology",
         "difficulty": "medium"
@@ -1723,7 +1723,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-10T00:31:46Z",
     "finished_at": "2026-09-10T00:32:21Z",
     "submitted_at": null,

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-knowledge-v2--df9cf0.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-knowledge-v2--df9cf0.json
@@ -1,0 +1,1741 @@
+{
+  "schema_version": 1,
+  "run_id": "a9e5da49f0c2bba3--eval-knowledge-v2--df9cf0",
+  "config_id": "a9e5da49f0c2bba3",
+  "cell_id": "4ab17fea2273",
+  "workload_id": "eval-knowledge-v2",
+  "kind": "eval",
+  "engine": {
+    "id": "sglang",
+    "version": "0.0.0.dev1+g079d40460",
+    "commit": null,
+    "build": "github.com/inclusionAI/sglang@079d404",
+    "container": "lmsysorg/sglang:v0.0.0.dev1+g079d40460-cu126",
+    "install_method": "source"
+  },
+  "model": {
+    "id": "inclusionAI/Ling-3.0-flash",
+    "quant_id": "mxfp4",
+    "hf_id": "inclusionAI/Ling-3.0-flash",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "moe-runner-backend": "humming",
+    "speculative-algorithm": "DSPARK",
+    "speculative-draft-model-path": "inclusionAI/Ling-3.0-flash-dspark",
+    "enable-linear-replayssm-spec": true,
+    "linear-replayssm-cache-len": 32,
+    "mem-fraction-static": 0.75,
+    "max-running-requests": 1,
+    "max-mamba-cache-size": 64,
+    "chunked-prefill-size": 8192,
+    "max-prefill-tokens": 16384,
+    "page-size": 64,
+    "attention-backend": "flashinfer",
+    "fp8-gemm-backend": "cutlass",
+    "flashinfer-mxfp4-moe-precision": "default",
+    "disable-shared-experts-fusion": true,
+    "cuda-graph-backend-decode": "full",
+    "cuda-graph-max-bs-decode": 1,
+    "cuda-graph-backend-prefill": "disabled",
+    "reasoning-parser": "deepseek-r1",
+    "tool-call-parser": "qwen25",
+    "trust-remote-code": true,
+    "fp8-lm-head": "online",
+    "default-chat-template-kwargs": {
+      "enable_thinking": false
+    }
+  },
+  "args_canonical": "@build=github.com/inclusionai/sglang@079d404;@dtype=auto;@quant=mxfp4;attention-backend=flashinfer;chunked-prefill-size=8192;cuda-graph-backend-decode=full;cuda-graph-backend-prefill=disabled;cuda-graph-max-bs-decode=1;default-chat-template-kwargs={\"enable_thinking\":false};disable-shared-experts-fusion=true;enable-linear-replayssm-spec=true;fp8-gemm-backend=cutlass;fp8-lm-head=online;linear-replayssm-cache-len=32;max-mamba-cache-size=64;max-running-requests=1;mem-fraction-static=0.75;moe-runner-backend=humming;page-size=64;reasoning-parser=deepseek-r1;speculative-algorithm=DSPARK;speculative-draft-model-path=inclusionAI/Ling-3.0-flash-dspark;tool-call-parser=qwen25;trust-remote-code=true",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-knowledge-v2",
+    "resolved_params": {
+      "dataset_id": "eval-knowledge-v2",
+      "suite": "knowledge",
+      "scorer": "mc",
+      "items": 151,
+      "concurrency": 4,
+      "max_output_tokens": 1024,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 151,
+    "requests_ok": 151,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 35.033,
+    "input_tokens_total": 11223,
+    "output_tokens_total": 302,
+    "e2e_ms": {
+      "mean": 918.797,
+      "p50": 925.177,
+      "p90": 959.928,
+      "p95": 968.299,
+      "p99": 990.445,
+      "min": 192.446,
+      "max": 992.986
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 103.879,
+    "power_avg_w": 49.64,
+    "power_peak_w": 51.29,
+    "energy_wh": 0.4836,
+    "gpu_util_avg_pct": 92.15,
+    "temp_max_c": 72.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "knowledge",
+    "total": 151,
+    "correct": 151,
+    "accuracy": 1.0,
+    "success_rate": 1.0,
+    "by_category": {
+      "astronomy": {
+        "total": 25,
+        "correct": 25
+      },
+      "biology": {
+        "total": 25,
+        "correct": 25
+      },
+      "chemistry": {
+        "total": 25,
+        "correct": 25
+      },
+      "geography": {
+        "total": 25,
+        "correct": 25
+      },
+      "history_biography": {
+        "total": 25,
+        "correct": 25
+      },
+      "physics": {
+        "total": 26,
+        "correct": 26
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 5,
+        "correct": 5
+      },
+      "hard": {
+        "total": 42,
+        "correct": 42
+      },
+      "medium": {
+        "total": 104,
+        "correct": 104
+      }
+    },
+    "avg_output_tokens": 2.0,
+    "avg_latency_ms": 918.8,
+    "failures": 0,
+    "items": [
+      {
+        "id": "know2-0001",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 192.446,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0002",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 428.965,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0003",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 663.872,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0004",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 877.857,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0005",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 917.149,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0006",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 909.308,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0007",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 904.61,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0008",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 907.667,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0009",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 899.536,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0010",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 905.723,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0011",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 911.786,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0012",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 925.975,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0013",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 953.832,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0014",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 962.579,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0015",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 981.919,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "easy"
+      },
+      {
+        "id": "know2-0016",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 988.909,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "easy"
+      },
+      {
+        "id": "know2-0017",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 962.569,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0018",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 946.565,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0019",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 925.58,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0020",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 921.66,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0021",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 935.85,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "easy"
+      },
+      {
+        "id": "know2-0022",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 937.576,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0023",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 938.4,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0024",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 946.449,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0025",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 935.429,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0026",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 934.111,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0027",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 910.982,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "easy"
+      },
+      {
+        "id": "know2-0028",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 905.423,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0029",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 911.693,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0030",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 904.257,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0031",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 907.508,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0032",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 902.529,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0033",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 913.551,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0034",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 922.715,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0035",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 934.074,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0036",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 924.633,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0037",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 912.248,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0038",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 913.951,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0039",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 931.255,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0040",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 939.351,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0041",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 924.835,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0042",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 931.573,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0043",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 909.798,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0044",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 908.958,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0045",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 944.541,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0046",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 936.281,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0047",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 950.772,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0048",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 946.973,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0049",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 944.926,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0050",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 959.656,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0051",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 949.047,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0052",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 940.99,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0053",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 912.505,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0054",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 881.641,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0055",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 868.704,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0056",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 900.872,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0057",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 913.524,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0058",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 915.723,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0059",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 928.871,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0060",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 907.55,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0061",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 919.834,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0062",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 916.358,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0063",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 927.742,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0064",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 927.526,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0065",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 936.393,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0066",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 949.347,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0067",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 953.196,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0068",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 978.851,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0069",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 947.561,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0070",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 959.928,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0071",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 943.433,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0072",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 917.0,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0073",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 908.256,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0074",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 930.549,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0075",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 939.093,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0076",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 933.904,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0077",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 943.42,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0078",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 908.272,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0079",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 906.614,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0080",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 912.921,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0081",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 905.195,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0082",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 907.318,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0083",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 912.988,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0084",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 898.45,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0085",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 905.499,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0086",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 919.674,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0087",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 902.087,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0088",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 913.924,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0089",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 923.175,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0090",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 912.654,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0091",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 915.922,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0092",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 915.042,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0093",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 912.113,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0094",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 900.999,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0095",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 901.054,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0096",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 906.833,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0097",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 906.163,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0098",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 913.229,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0099",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 922.911,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0100",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 950.942,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0101",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 953.186,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0102",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 961.225,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0103",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 957.634,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0104",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 919.416,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0105",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 911.37,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0106",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 905.178,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0107",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 898.456,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0108",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 921.163,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0109",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 915.66,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0110",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 937.631,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0111",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 965.769,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0112",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 947.068,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0113",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 977.334,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0114",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 953.803,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0115",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 925.177,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0116",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 950.612,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0117",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 943.901,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0118",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 960.111,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0119",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 970.828,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0120",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 951.626,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0121",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 933.924,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0122",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 938.856,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0123",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 956.383,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0124",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 991.981,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0125",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 992.986,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0126",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 974.333,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0127",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 943.302,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0128",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 906.228,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0129",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 911.377,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0130",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 897.08,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0131",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 898.978,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0132",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 897.627,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0133",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 907.987,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0134",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 923.726,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0135",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 948.075,
+        "output_tokens": 2,
+        "category": "biology",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0136",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 956.256,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0137",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 935.776,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0138",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 932.039,
+        "output_tokens": 2,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0139",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 909.844,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0140",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 894.554,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "know2-0141",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 899.746,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0142",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 929.726,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0143",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 931.021,
+        "output_tokens": 2,
+        "category": "geography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0144",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 942.062,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0145",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 940.43,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0146",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 941.244,
+        "output_tokens": 2,
+        "category": "physics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0147",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 953.041,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0148",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 962.022,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "hard"
+      },
+      {
+        "id": "know2-0149",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 965.264,
+        "output_tokens": 2,
+        "category": "astronomy",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0150",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 934.275,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      },
+      {
+        "id": "know2-0151",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 926.377,
+        "output_tokens": 2,
+        "category": "history_biography",
+        "difficulty": "medium"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "cfd98883925866c7dff600b75b09d759d32b6d91f3c04d4af5f8c1872923a34b",
+    "payload_path": null,
+    "payload": {
+      "scorer": "mc",
+      "scorers_used": [
+        "mc"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "ling-3.0-flash",
+        "advertised_models": [
+          "ling-3.0-flash"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-09-10T00:31:46Z",
+    "finished_at": "2026-09-10T00:32:21Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Served with the ling3-flash-dgx-spark recipe (49b6c9c), PROFILE=humming-dspark, thinking off (server default via --default-chat-template-kwargs): inclusionAI/Ling-3.0-flash-fp4 (MXFP4 routed experts, FP8 attention/shared/router) with --moe-runner-backend humming, online FP8 LM head (SGLANG_ENABLE_FP8_LM_HEAD=1), DSpark speculative decoding with inclusionAI/Ling-3.0-flash-dspark and the KDA ReplaySSM exact fold (--enable-linear-replayssm-spec, ring 32), context 262144 native (no YaRN), mem-fraction 0.75, max-running 1, page 64, decode cuda graph bs 1, prefill cuda graph disabled, FlashInfer autotune off with precompiled CUTLASS MXFP4 kernels. Single request at a time on every row."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-math-v2--3701f2.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-math-v2--3701f2.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -93,7 +93,7 @@
       "items": 140,
       "concurrency": 4,
       "max_output_tokens": 4096,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -106,7 +106,7 @@
     "requests_total": 140,
     "requests_ok": 140,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 631.847,
     "input_tokens_total": 12151,
     "output_tokens_total": 68602,
@@ -125,7 +125,7 @@
     "power_peak_w": 49.72,
     "energy_wh": 7.6497,
     "gpu_util_avg_pct": 95.75,
-    "temp_max_c": 71.0,
+    "temp_max_c": 71,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -133,7 +133,7 @@
     "total": 140,
     "correct": 115,
     "accuracy": 0.821429,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "algebra": {
         "total": 20,
@@ -1618,7 +1618,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-10T00:17:57Z",
     "finished_at": "2026-09-10T00:28:28Z",
     "submitted_at": null,

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-math-v2--3701f2.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-math-v2--3701f2.json
@@ -1,0 +1,1636 @@
+{
+  "schema_version": 1,
+  "run_id": "a9e5da49f0c2bba3--eval-math-v2--3701f2",
+  "config_id": "a9e5da49f0c2bba3",
+  "cell_id": "4ab17fea2273",
+  "workload_id": "eval-math-v2",
+  "kind": "eval",
+  "engine": {
+    "id": "sglang",
+    "version": "0.0.0.dev1+g079d40460",
+    "commit": null,
+    "build": "github.com/inclusionAI/sglang@079d404",
+    "container": "lmsysorg/sglang:v0.0.0.dev1+g079d40460-cu126",
+    "install_method": "source"
+  },
+  "model": {
+    "id": "inclusionAI/Ling-3.0-flash",
+    "quant_id": "mxfp4",
+    "hf_id": "inclusionAI/Ling-3.0-flash",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "moe-runner-backend": "humming",
+    "speculative-algorithm": "DSPARK",
+    "speculative-draft-model-path": "inclusionAI/Ling-3.0-flash-dspark",
+    "enable-linear-replayssm-spec": true,
+    "linear-replayssm-cache-len": 32,
+    "mem-fraction-static": 0.75,
+    "max-running-requests": 1,
+    "max-mamba-cache-size": 64,
+    "chunked-prefill-size": 8192,
+    "max-prefill-tokens": 16384,
+    "page-size": 64,
+    "attention-backend": "flashinfer",
+    "fp8-gemm-backend": "cutlass",
+    "flashinfer-mxfp4-moe-precision": "default",
+    "disable-shared-experts-fusion": true,
+    "cuda-graph-backend-decode": "full",
+    "cuda-graph-max-bs-decode": 1,
+    "cuda-graph-backend-prefill": "disabled",
+    "reasoning-parser": "deepseek-r1",
+    "tool-call-parser": "qwen25",
+    "trust-remote-code": true,
+    "fp8-lm-head": "online",
+    "default-chat-template-kwargs": {
+      "enable_thinking": false
+    }
+  },
+  "args_canonical": "@build=github.com/inclusionai/sglang@079d404;@dtype=auto;@quant=mxfp4;attention-backend=flashinfer;chunked-prefill-size=8192;cuda-graph-backend-decode=full;cuda-graph-backend-prefill=disabled;cuda-graph-max-bs-decode=1;default-chat-template-kwargs={\"enable_thinking\":false};disable-shared-experts-fusion=true;enable-linear-replayssm-spec=true;fp8-gemm-backend=cutlass;fp8-lm-head=online;linear-replayssm-cache-len=32;max-mamba-cache-size=64;max-running-requests=1;mem-fraction-static=0.75;moe-runner-backend=humming;page-size=64;reasoning-parser=deepseek-r1;speculative-algorithm=DSPARK;speculative-draft-model-path=inclusionAI/Ling-3.0-flash-dspark;tool-call-parser=qwen25;trust-remote-code=true",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-math-v2",
+    "resolved_params": {
+      "dataset_id": "eval-math-v2",
+      "suite": "math",
+      "scorer": "numeric",
+      "items": 140,
+      "concurrency": 4,
+      "max_output_tokens": 4096,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 140,
+    "requests_ok": 140,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 631.847,
+    "input_tokens_total": 12151,
+    "output_tokens_total": 68602,
+    "e2e_ms": {
+      "mean": 17787.061,
+      "p50": 19161.205,
+      "p90": 28229.238,
+      "p95": 31174.508,
+      "p99": 39005.645,
+      "min": 404.041,
+      "max": 39188.509
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 103.889,
+    "power_avg_w": 43.56,
+    "power_peak_w": 49.72,
+    "energy_wh": 7.6497,
+    "gpu_util_avg_pct": 95.75,
+    "temp_max_c": 71.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "math",
+    "total": 140,
+    "correct": 115,
+    "accuracy": 0.821429,
+    "success_rate": 1.0,
+    "by_category": {
+      "algebra": {
+        "total": 20,
+        "correct": 12
+      },
+      "arithmetic": {
+        "total": 20,
+        "correct": 16
+      },
+      "claims": {
+        "total": 20,
+        "correct": 14
+      },
+      "combinatorics_probability": {
+        "total": 20,
+        "correct": 19
+      },
+      "number_theory": {
+        "total": 22,
+        "correct": 22
+      },
+      "sequences": {
+        "total": 18,
+        "correct": 18
+      },
+      "word_problems": {
+        "total": 20,
+        "correct": 14
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 10,
+        "correct": 5
+      },
+      "hard": {
+        "total": 77,
+        "correct": 66
+      },
+      "medium": {
+        "total": 53,
+        "correct": 44
+      }
+    },
+    "avg_output_tokens": 490.01,
+    "avg_latency_ms": 17787.06,
+    "failures": 0,
+    "items": [
+      {
+        "id": "math2-0001",
+        "correct": false,
+        "predicted": "794.09",
+        "expected": "730.96",
+        "latency_ms": 404.041,
+        "output_tokens": 7,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0002",
+        "correct": false,
+        "predicted": "2943.11",
+        "expected": "3174.41",
+        "latency_ms": 894.59,
+        "output_tokens": 8,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0003",
+        "correct": false,
+        "predicted": "341.13",
+        "expected": "340.74",
+        "latency_ms": 1220.866,
+        "output_tokens": 7,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0004",
+        "correct": true,
+        "predicted": "2695.06",
+        "expected": "2695.06",
+        "latency_ms": 2607.419,
+        "output_tokens": 113,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0005",
+        "correct": false,
+        "predicted": "517.47",
+        "expected": "521.32",
+        "latency_ms": 2696.234,
+        "output_tokens": 7,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0006",
+        "correct": true,
+        "predicted": "17076640",
+        "expected": "17076640",
+        "latency_ms": 7057.071,
+        "output_tokens": 563,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0007",
+        "correct": true,
+        "predicted": "32424418",
+        "expected": "32424418",
+        "latency_ms": 16927.089,
+        "output_tokens": 1139,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0008",
+        "correct": true,
+        "predicted": "38284752",
+        "expected": "38284752",
+        "latency_ms": 20071.33,
+        "output_tokens": 532,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0009",
+        "correct": true,
+        "predicted": "82528030",
+        "expected": "82528030",
+        "latency_ms": 23801.886,
+        "output_tokens": 506,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0010",
+        "correct": true,
+        "predicted": "37048469",
+        "expected": "37048469",
+        "latency_ms": 26988.721,
+        "output_tokens": 891,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0011",
+        "correct": true,
+        "predicted": "331",
+        "expected": "331",
+        "latency_ms": 24629.574,
+        "output_tokens": 822,
+        "category": "arithmetic",
+        "difficulty": "easy"
+      },
+      {
+        "id": "math2-0012",
+        "correct": true,
+        "predicted": "49",
+        "expected": "49",
+        "latency_ms": 25129.436,
+        "output_tokens": 484,
+        "category": "arithmetic",
+        "difficulty": "easy"
+      },
+      {
+        "id": "math2-0013",
+        "correct": true,
+        "predicted": "442",
+        "expected": "442",
+        "latency_ms": 27027.986,
+        "output_tokens": 637,
+        "category": "arithmetic",
+        "difficulty": "easy"
+      },
+      {
+        "id": "math2-0014",
+        "correct": true,
+        "predicted": "236",
+        "expected": "236",
+        "latency_ms": 25106.945,
+        "output_tokens": 652,
+        "category": "arithmetic",
+        "difficulty": "easy"
+      },
+      {
+        "id": "math2-0015",
+        "correct": true,
+        "predicted": "86",
+        "expected": "86",
+        "latency_ms": 22324.219,
+        "output_tokens": 602,
+        "category": "arithmetic",
+        "difficulty": "easy"
+      },
+      {
+        "id": "math2-0016",
+        "correct": true,
+        "predicted": "0.112875",
+        "expected": "0.112875",
+        "latency_ms": 23859.763,
+        "output_tokens": 751,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0017",
+        "correct": true,
+        "predicted": "-0.40625",
+        "expected": "-0.40625",
+        "latency_ms": 21131.849,
+        "output_tokens": 347,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0018",
+        "correct": true,
+        "predicted": "-0.196875",
+        "expected": "-0.196875",
+        "latency_ms": 19261.723,
+        "output_tokens": 477,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0019",
+        "correct": true,
+        "predicted": "-0.09",
+        "expected": "-0.09",
+        "latency_ms": 16084.176,
+        "output_tokens": 164,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0020",
+        "correct": true,
+        "predicted": "0.42735",
+        "expected": "0.42735",
+        "latency_ms": 15508.207,
+        "output_tokens": 704,
+        "category": "arithmetic",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0021",
+        "correct": true,
+        "predicted": "7",
+        "expected": "7",
+        "latency_ms": 17905.404,
+        "output_tokens": 632,
+        "category": "algebra",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0022",
+        "correct": true,
+        "predicted": "-5",
+        "expected": "-5",
+        "latency_ms": 18444.917,
+        "output_tokens": 586,
+        "category": "algebra",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0023",
+        "correct": true,
+        "predicted": "-8",
+        "expected": "-8",
+        "latency_ms": 23211.314,
+        "output_tokens": 737,
+        "category": "algebra",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0024",
+        "correct": true,
+        "predicted": "-1",
+        "expected": "-1",
+        "latency_ms": 23647.326,
+        "output_tokens": 667,
+        "category": "algebra",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0025",
+        "correct": true,
+        "predicted": "12",
+        "expected": "12",
+        "latency_ms": 24648.763,
+        "output_tokens": 750,
+        "category": "algebra",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0026",
+        "correct": true,
+        "predicted": "-5",
+        "expected": "-5",
+        "latency_ms": 27515.774,
+        "output_tokens": 871,
+        "category": "algebra",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0027",
+        "correct": true,
+        "predicted": "9",
+        "expected": "9",
+        "latency_ms": 23122.97,
+        "output_tokens": 243,
+        "category": "algebra",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0028",
+        "correct": true,
+        "predicted": "35",
+        "expected": "35",
+        "latency_ms": 19245.583,
+        "output_tokens": 269,
+        "category": "algebra",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0029",
+        "correct": true,
+        "predicted": "-23",
+        "expected": "-23",
+        "latency_ms": 15020.053,
+        "output_tokens": 265,
+        "category": "algebra",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0030",
+        "correct": true,
+        "predicted": "-1",
+        "expected": "-1",
+        "latency_ms": 9973.115,
+        "output_tokens": 237,
+        "category": "algebra",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0031",
+        "correct": true,
+        "predicted": "109",
+        "expected": "109",
+        "latency_ms": 10154.767,
+        "output_tokens": 262,
+        "category": "algebra",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0032",
+        "correct": false,
+        "predicted": "11",
+        "expected": "6619",
+        "latency_ms": 7906.446,
+        "output_tokens": 3,
+        "category": "algebra",
+        "difficulty": "easy"
+      },
+      {
+        "id": "math2-0033",
+        "correct": false,
+        "predicted": "-14",
+        "expected": "26",
+        "latency_ms": 5573.737,
+        "output_tokens": 4,
+        "category": "algebra",
+        "difficulty": "easy"
+      },
+      {
+        "id": "math2-0034",
+        "correct": false,
+        "predicted": "13",
+        "expected": "32344",
+        "latency_ms": 3205.884,
+        "output_tokens": 3,
+        "category": "algebra",
+        "difficulty": "easy"
+      },
+      {
+        "id": "math2-0035",
+        "correct": false,
+        "predicted": "-11",
+        "expected": "16977",
+        "latency_ms": 1059.933,
+        "output_tokens": 4,
+        "category": "algebra",
+        "difficulty": "easy"
+      },
+      {
+        "id": "math2-0036",
+        "correct": false,
+        "predicted": "11",
+        "expected": "6815",
+        "latency_ms": 1045.64,
+        "output_tokens": 3,
+        "category": "algebra",
+        "difficulty": "easy"
+      },
+      {
+        "id": "math2-0037",
+        "correct": false,
+        "predicted": "11",
+        "expected": "3",
+        "latency_ms": 1079.232,
+        "output_tokens": 3,
+        "category": "algebra",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0038",
+        "correct": true,
+        "predicted": "13",
+        "expected": "13",
+        "latency_ms": 1062.652,
+        "output_tokens": 3,
+        "category": "algebra",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0039",
+        "correct": false,
+        "predicted": "14",
+        "expected": "9",
+        "latency_ms": 1042.792,
+        "output_tokens": 3,
+        "category": "algebra",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0040",
+        "correct": false,
+        "predicted": "14",
+        "expected": "3",
+        "latency_ms": 1028.497,
+        "output_tokens": 3,
+        "category": "algebra",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0041",
+        "correct": true,
+        "predicted": "411",
+        "expected": "411",
+        "latency_ms": 9539.484,
+        "output_tokens": 1017,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0042",
+        "correct": true,
+        "predicted": "856",
+        "expected": "856",
+        "latency_ms": 22227.876,
+        "output_tokens": 1512,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0043",
+        "correct": true,
+        "predicted": "92",
+        "expected": "92",
+        "latency_ms": 32460.116,
+        "output_tokens": 1251,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0044",
+        "correct": true,
+        "predicted": "1941",
+        "expected": "1941",
+        "latency_ms": 39008.461,
+        "output_tokens": 828,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0045",
+        "correct": true,
+        "predicted": "259",
+        "expected": "259",
+        "latency_ms": 39188.509,
+        "output_tokens": 1014,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0046",
+        "correct": true,
+        "predicted": "61",
+        "expected": "61",
+        "latency_ms": 34700.888,
+        "output_tokens": 1004,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0047",
+        "correct": true,
+        "predicted": "256",
+        "expected": "256",
+        "latency_ms": 28842.403,
+        "output_tokens": 528,
+        "category": "number_theory",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0048",
+        "correct": true,
+        "predicted": "128",
+        "expected": "128",
+        "latency_ms": 25492.976,
+        "output_tokens": 390,
+        "category": "number_theory",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0049",
+        "correct": true,
+        "predicted": "584",
+        "expected": "584",
+        "latency_ms": 23337.184,
+        "output_tokens": 738,
+        "category": "number_theory",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0050",
+        "correct": true,
+        "predicted": "640",
+        "expected": "640",
+        "latency_ms": 20980.505,
+        "output_tokens": 678,
+        "category": "number_theory",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0051",
+        "correct": true,
+        "predicted": "2250",
+        "expected": "2250",
+        "latency_ms": 20228.537,
+        "output_tokens": 448,
+        "category": "number_theory",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0052",
+        "correct": true,
+        "predicted": "992",
+        "expected": "992",
+        "latency_ms": 21460.524,
+        "output_tokens": 498,
+        "category": "number_theory",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0053",
+        "correct": true,
+        "predicted": "1344",
+        "expected": "1344",
+        "latency_ms": 19076.827,
+        "output_tokens": 510,
+        "category": "number_theory",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0054",
+        "correct": true,
+        "predicted": "1216",
+        "expected": "1216",
+        "latency_ms": 17686.087,
+        "output_tokens": 519,
+        "category": "number_theory",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0055",
+        "correct": true,
+        "predicted": "76",
+        "expected": "76",
+        "latency_ms": 16585.725,
+        "output_tokens": 257,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0056",
+        "correct": true,
+        "predicted": "56",
+        "expected": "56",
+        "latency_ms": 18081.148,
+        "output_tokens": 721,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0057",
+        "correct": true,
+        "predicted": "25",
+        "expected": "25",
+        "latency_ms": 17827.266,
+        "output_tokens": 432,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0058",
+        "correct": true,
+        "predicted": "76",
+        "expected": "76",
+        "latency_ms": 17415.286,
+        "output_tokens": 452,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0059",
+        "correct": true,
+        "predicted": "35",
+        "expected": "35",
+        "latency_ms": 27409.947,
+        "output_tokens": 1452,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0060",
+        "correct": true,
+        "predicted": "7",
+        "expected": "7",
+        "latency_ms": 28325.117,
+        "output_tokens": 686,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0061",
+        "correct": true,
+        "predicted": "9",
+        "expected": "9",
+        "latency_ms": 29507.525,
+        "output_tokens": 533,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0062",
+        "correct": true,
+        "predicted": "18",
+        "expected": "18",
+        "latency_ms": 39001.239,
+        "output_tokens": 1390,
+        "category": "number_theory",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0063",
+        "correct": true,
+        "predicted": "3.1",
+        "expected": "3.1",
+        "latency_ms": 28329.483,
+        "output_tokens": 193,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0064",
+        "correct": true,
+        "predicted": "2.35",
+        "expected": "2.35",
+        "latency_ms": 23614.571,
+        "output_tokens": 254,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0065",
+        "correct": true,
+        "predicted": "1.81",
+        "expected": "1.82",
+        "latency_ms": 18578.65,
+        "output_tokens": 5,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0066",
+        "correct": false,
+        "predicted": "2.71",
+        "expected": "1.98",
+        "latency_ms": 5209.887,
+        "output_tokens": 5,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0067",
+        "correct": false,
+        "predicted": "3.1",
+        "expected": "2.14",
+        "latency_ms": 3419.464,
+        "output_tokens": 5,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0068",
+        "correct": false,
+        "predicted": "12",
+        "expected": "14.4",
+        "latency_ms": 1415.583,
+        "output_tokens": 6,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0069",
+        "correct": false,
+        "predicted": "16",
+        "expected": "18",
+        "latency_ms": 1481.408,
+        "output_tokens": 6,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0070",
+        "correct": false,
+        "predicted": "12.67",
+        "expected": "13.25",
+        "latency_ms": 1486.792,
+        "output_tokens": 6,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0071",
+        "correct": false,
+        "predicted": "10.17",
+        "expected": "9.07",
+        "latency_ms": 1492.652,
+        "output_tokens": 6,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0072",
+        "correct": true,
+        "predicted": "30.75",
+        "expected": "30.75",
+        "latency_ms": 2171.541,
+        "output_tokens": 98,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0073",
+        "correct": true,
+        "predicted": "19",
+        "expected": "19",
+        "latency_ms": 6863.048,
+        "output_tokens": 510,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0074",
+        "correct": true,
+        "predicted": "27",
+        "expected": "27",
+        "latency_ms": 11712.369,
+        "output_tokens": 538,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0075",
+        "correct": true,
+        "predicted": "26",
+        "expected": "26",
+        "latency_ms": 15837.924,
+        "output_tokens": 485,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0076",
+        "correct": true,
+        "predicted": "9",
+        "expected": "9",
+        "latency_ms": 20324.742,
+        "output_tokens": 569,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0077",
+        "correct": true,
+        "predicted": "28",
+        "expected": "28",
+        "latency_ms": 19550.691,
+        "output_tokens": 434,
+        "category": "word_problems",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0078",
+        "correct": true,
+        "predicted": "16",
+        "expected": "16",
+        "latency_ms": 16987.404,
+        "output_tokens": 276,
+        "category": "word_problems",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0079",
+        "correct": true,
+        "predicted": "20",
+        "expected": "20",
+        "latency_ms": 14684.374,
+        "output_tokens": 221,
+        "category": "word_problems",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0080",
+        "correct": true,
+        "predicted": "19",
+        "expected": "19",
+        "latency_ms": 11291.572,
+        "output_tokens": 238,
+        "category": "word_problems",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0081",
+        "correct": true,
+        "predicted": "38",
+        "expected": "38",
+        "latency_ms": 9817.452,
+        "output_tokens": 291,
+        "category": "word_problems",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0082",
+        "correct": true,
+        "predicted": "58",
+        "expected": "58",
+        "latency_ms": 10212.844,
+        "output_tokens": 306,
+        "category": "word_problems",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0083",
+        "correct": true,
+        "predicted": "0.4444",
+        "expected": "0.4444",
+        "latency_ms": 11246.274,
+        "output_tokens": 348,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0084",
+        "correct": true,
+        "predicted": "0.125",
+        "expected": "0.125",
+        "latency_ms": 16478.328,
+        "output_tokens": 924,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0085",
+        "correct": true,
+        "predicted": "0.1157",
+        "expected": "0.1157",
+        "latency_ms": 21617.568,
+        "output_tokens": 940,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0086",
+        "correct": true,
+        "predicted": "0.125",
+        "expected": "0.125",
+        "latency_ms": 25132.645,
+        "output_tokens": 767,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0087",
+        "correct": false,
+        "predicted": "0.5",
+        "expected": "0.4213",
+        "latency_ms": 26836.7,
+        "output_tokens": 396,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0088",
+        "correct": true,
+        "predicted": "0.2426",
+        "expected": "0.2426",
+        "latency_ms": 23472.258,
+        "output_tokens": 438,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0089",
+        "correct": true,
+        "predicted": "0.6333",
+        "expected": "0.6333",
+        "latency_ms": 22744.747,
+        "output_tokens": 770,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0090",
+        "correct": true,
+        "predicted": "0.2571",
+        "expected": "0.2571",
+        "latency_ms": 19632.986,
+        "output_tokens": 417,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0091",
+        "correct": true,
+        "predicted": "0.1538",
+        "expected": "0.1538",
+        "latency_ms": 18635.019,
+        "output_tokens": 438,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0092",
+        "correct": true,
+        "predicted": "0.5091",
+        "expected": "0.5091",
+        "latency_ms": 18046.732,
+        "output_tokens": 378,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0093",
+        "correct": true,
+        "predicted": "1401",
+        "expected": "1401",
+        "latency_ms": 17305.535,
+        "output_tokens": 698,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0094",
+        "correct": true,
+        "predicted": "1617",
+        "expected": "1617",
+        "latency_ms": 25790.999,
+        "output_tokens": 1270,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0095",
+        "correct": true,
+        "predicted": "512",
+        "expected": "512",
+        "latency_ms": 26639.312,
+        "output_tokens": 535,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0096",
+        "correct": true,
+        "predicted": "15301",
+        "expected": "15301",
+        "latency_ms": 28694.078,
+        "output_tokens": 597,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0097",
+        "correct": true,
+        "predicted": "8250",
+        "expected": "8250",
+        "latency_ms": 27499.755,
+        "output_tokens": 478,
+        "category": "combinatorics_probability",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0098",
+        "correct": true,
+        "predicted": "110",
+        "expected": "110",
+        "latency_ms": 21145.14,
+        "output_tokens": 541,
+        "category": "combinatorics_probability",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0099",
+        "correct": true,
+        "predicted": "11208",
+        "expected": "11208",
+        "latency_ms": 23265.638,
+        "output_tokens": 682,
+        "category": "combinatorics_probability",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0100",
+        "correct": true,
+        "predicted": "1358",
+        "expected": "1358",
+        "latency_ms": 21861.456,
+        "output_tokens": 495,
+        "category": "combinatorics_probability",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0101",
+        "correct": true,
+        "predicted": "4396",
+        "expected": "4396",
+        "latency_ms": 22935.022,
+        "output_tokens": 602,
+        "category": "combinatorics_probability",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0102",
+        "correct": true,
+        "predicted": "10816",
+        "expected": "10816",
+        "latency_ms": 27148.603,
+        "output_tokens": 1133,
+        "category": "combinatorics_probability",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0103",
+        "correct": true,
+        "predicted": "158240",
+        "expected": "158240",
+        "latency_ms": 26289.14,
+        "output_tokens": 800,
+        "category": "sequences",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0104",
+        "correct": true,
+        "predicted": "21523358",
+        "expected": "21523358",
+        "latency_ms": 31326.551,
+        "output_tokens": 1150,
+        "category": "sequences",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0105",
+        "correct": true,
+        "predicted": "10053005",
+        "expected": "10053005",
+        "latency_ms": 31166.506,
+        "output_tokens": 839,
+        "category": "sequences",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0106",
+        "correct": true,
+        "predicted": "531438",
+        "expected": "531438",
+        "latency_ms": 27371.96,
+        "output_tokens": 811,
+        "category": "sequences",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0107",
+        "correct": true,
+        "predicted": "1416933",
+        "expected": "1416933",
+        "latency_ms": 28218.585,
+        "output_tokens": 924,
+        "category": "sequences",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0108",
+        "correct": true,
+        "predicted": "16387",
+        "expected": "16387",
+        "latency_ms": 23108.703,
+        "output_tokens": 486,
+        "category": "sequences",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0109",
+        "correct": true,
+        "predicted": "2391483",
+        "expected": "2391483",
+        "latency_ms": 20974.327,
+        "output_tokens": 492,
+        "category": "sequences",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0110",
+        "correct": true,
+        "predicted": "442865",
+        "expected": "442865",
+        "latency_ms": 18830.916,
+        "output_tokens": 471,
+        "category": "sequences",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0111",
+        "correct": true,
+        "predicted": "20475",
+        "expected": "20475",
+        "latency_ms": 15152.322,
+        "output_tokens": 370,
+        "category": "sequences",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0112",
+        "correct": true,
+        "predicted": "57337",
+        "expected": "57337",
+        "latency_ms": 14449.816,
+        "output_tokens": 391,
+        "category": "sequences",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0113",
+        "correct": true,
+        "predicted": "2125760",
+        "expected": "2125760",
+        "latency_ms": 15130.535,
+        "output_tokens": 565,
+        "category": "sequences",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0114",
+        "correct": true,
+        "predicted": "354292",
+        "expected": "354292",
+        "latency_ms": 14924.979,
+        "output_tokens": 466,
+        "category": "sequences",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0115",
+        "correct": true,
+        "predicted": "88",
+        "expected": "88",
+        "latency_ms": 16213.735,
+        "output_tokens": 559,
+        "category": "sequences",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0116",
+        "correct": true,
+        "predicted": "191",
+        "expected": "191",
+        "latency_ms": 19549.078,
+        "output_tokens": 888,
+        "category": "sequences",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0117",
+        "correct": true,
+        "predicted": "137",
+        "expected": "137",
+        "latency_ms": 21401.877,
+        "output_tokens": 878,
+        "category": "sequences",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0118",
+        "correct": true,
+        "predicted": "148",
+        "expected": "148",
+        "latency_ms": 22967.118,
+        "output_tokens": 681,
+        "category": "sequences",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0119",
+        "correct": true,
+        "predicted": "137",
+        "expected": "137",
+        "latency_ms": 24655.904,
+        "output_tokens": 813,
+        "category": "sequences",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0120",
+        "correct": true,
+        "predicted": "191",
+        "expected": "191",
+        "latency_ms": 24210.384,
+        "output_tokens": 835,
+        "category": "sequences",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0121",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 17837.525,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0122",
+        "correct": true,
+        "predicted": "40",
+        "expected": "40",
+        "latency_ms": 30346.123,
+        "output_tokens": 1645,
+        "category": "claims",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0123",
+        "correct": false,
+        "predicted": "A",
+        "expected": "B",
+        "latency_ms": 24451.613,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0124",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 18479.335,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0125",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 18481.661,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0126",
+        "correct": true,
+        "predicted": "11",
+        "expected": "11",
+        "latency_ms": 5877.149,
+        "output_tokens": 546,
+        "category": "claims",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0127",
+        "correct": false,
+        "predicted": "B",
+        "expected": "A",
+        "latency_ms": 5881.098,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0128",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 5894.433,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0129",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 5902.888,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0130",
+        "correct": true,
+        "predicted": "5777",
+        "expected": "5777",
+        "latency_ms": 20652.068,
+        "output_tokens": 1717,
+        "category": "claims",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0131",
+        "correct": false,
+        "predicted": "A",
+        "expected": "B",
+        "latency_ms": 20663.892,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0132",
+        "correct": false,
+        "predicted": "B",
+        "expected": "A",
+        "latency_ms": 20648.345,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0133",
+        "correct": true,
+        "predicted": "16",
+        "expected": "16",
+        "latency_ms": 32592.534,
+        "output_tokens": 1095,
+        "category": "claims",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0134",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 12942.88,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0135",
+        "correct": false,
+        "predicted": "B",
+        "expected": "A",
+        "latency_ms": 12914.218,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0136",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 12911.496,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0137",
+        "correct": true,
+        "predicted": "24",
+        "expected": "24",
+        "latency_ms": 9557.478,
+        "output_tokens": 929,
+        "category": "claims",
+        "difficulty": "hard"
+      },
+      {
+        "id": "math2-0138",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 9553.926,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0139",
+        "correct": false,
+        "predicted": "B",
+        "expected": "A",
+        "latency_ms": 9560.585,
+        "output_tokens": 2,
+        "category": "claims",
+        "difficulty": "medium"
+      },
+      {
+        "id": "math2-0140",
+        "correct": true,
+        "predicted": "128",
+        "expected": "128",
+        "latency_ms": 21474.009,
+        "output_tokens": 1105,
+        "category": "claims",
+        "difficulty": "hard"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "bea2a9dad5ecd496af414fc0d3ada79b87950b0327fed0dc5374ad116b221688",
+    "payload_path": null,
+    "payload": {
+      "scorer": "numeric",
+      "scorers_used": [
+        "mc",
+        "numeric"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "ling-3.0-flash",
+        "advertised_models": [
+          "ling-3.0-flash"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-09-10T00:17:57Z",
+    "finished_at": "2026-09-10T00:28:28Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Served with the ling3-flash-dgx-spark recipe (49b6c9c), PROFILE=humming-dspark, thinking off (server default via --default-chat-template-kwargs): inclusionAI/Ling-3.0-flash-fp4 (MXFP4 routed experts, FP8 attention/shared/router) with --moe-runner-backend humming, online FP8 LM head (SGLANG_ENABLE_FP8_LM_HEAD=1), DSpark speculative decoding with inclusionAI/Ling-3.0-flash-dspark and the KDA ReplaySSM exact fold (--enable-linear-replayssm-spec, ring 32), context 262144 native (no YaRN), mem-fraction 0.75, max-running 1, page 64, decode cuda graph bs 1, prefill cuda graph disabled, FlashInfer autotune off with precompiled CUTLASS MXFP4 kernels. Single request at a time on every row."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-reasoning-v2--8b4083.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-reasoning-v2--8b4083.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -93,7 +93,7 @@
       "items": 140,
       "concurrency": 4,
       "max_output_tokens": 4096,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -106,7 +106,7 @@
     "requests_total": 140,
     "requests_ok": 140,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 196.314,
     "input_tokens_total": 17689,
     "output_tokens_total": 16969,
@@ -125,7 +125,7 @@
     "power_peak_w": 55.5,
     "energy_wh": 2.4989,
     "gpu_util_avg_pct": 95.83,
-    "temp_max_c": 72.0,
+    "temp_max_c": 72,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -133,7 +133,7 @@
     "total": 140,
     "correct": 90,
     "accuracy": 0.642857,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "counting": {
         "total": 20,
@@ -1619,7 +1619,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-10T00:28:29Z",
     "finished_at": "2026-09-10T00:31:45Z",
     "submitted_at": null,

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-reasoning-v2--8b4083.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-reasoning-v2--8b4083.json
@@ -1,0 +1,1637 @@
+{
+  "schema_version": 1,
+  "run_id": "a9e5da49f0c2bba3--eval-reasoning-v2--8b4083",
+  "config_id": "a9e5da49f0c2bba3",
+  "cell_id": "4ab17fea2273",
+  "workload_id": "eval-reasoning-v2",
+  "kind": "eval",
+  "engine": {
+    "id": "sglang",
+    "version": "0.0.0.dev1+g079d40460",
+    "commit": null,
+    "build": "github.com/inclusionAI/sglang@079d404",
+    "container": "lmsysorg/sglang:v0.0.0.dev1+g079d40460-cu126",
+    "install_method": "source"
+  },
+  "model": {
+    "id": "inclusionAI/Ling-3.0-flash",
+    "quant_id": "mxfp4",
+    "hf_id": "inclusionAI/Ling-3.0-flash",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "moe-runner-backend": "humming",
+    "speculative-algorithm": "DSPARK",
+    "speculative-draft-model-path": "inclusionAI/Ling-3.0-flash-dspark",
+    "enable-linear-replayssm-spec": true,
+    "linear-replayssm-cache-len": 32,
+    "mem-fraction-static": 0.75,
+    "max-running-requests": 1,
+    "max-mamba-cache-size": 64,
+    "chunked-prefill-size": 8192,
+    "max-prefill-tokens": 16384,
+    "page-size": 64,
+    "attention-backend": "flashinfer",
+    "fp8-gemm-backend": "cutlass",
+    "flashinfer-mxfp4-moe-precision": "default",
+    "disable-shared-experts-fusion": true,
+    "cuda-graph-backend-decode": "full",
+    "cuda-graph-max-bs-decode": 1,
+    "cuda-graph-backend-prefill": "disabled",
+    "reasoning-parser": "deepseek-r1",
+    "tool-call-parser": "qwen25",
+    "trust-remote-code": true,
+    "fp8-lm-head": "online",
+    "default-chat-template-kwargs": {
+      "enable_thinking": false
+    }
+  },
+  "args_canonical": "@build=github.com/inclusionai/sglang@079d404;@dtype=auto;@quant=mxfp4;attention-backend=flashinfer;chunked-prefill-size=8192;cuda-graph-backend-decode=full;cuda-graph-backend-prefill=disabled;cuda-graph-max-bs-decode=1;default-chat-template-kwargs={\"enable_thinking\":false};disable-shared-experts-fusion=true;enable-linear-replayssm-spec=true;fp8-gemm-backend=cutlass;fp8-lm-head=online;linear-replayssm-cache-len=32;max-mamba-cache-size=64;max-running-requests=1;mem-fraction-static=0.75;moe-runner-backend=humming;page-size=64;reasoning-parser=deepseek-r1;speculative-algorithm=DSPARK;speculative-draft-model-path=inclusionAI/Ling-3.0-flash-dspark;tool-call-parser=qwen25;trust-remote-code=true",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-reasoning-v2",
+    "resolved_params": {
+      "dataset_id": "eval-reasoning-v2",
+      "suite": "reasoning",
+      "scorer": "exact",
+      "items": 140,
+      "concurrency": 4,
+      "max_output_tokens": 4096,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 140,
+    "requests_ok": 140,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 196.314,
+    "input_tokens_total": 17689,
+    "output_tokens_total": 16969,
+    "e2e_ms": {
+      "mean": 5596.36,
+      "p50": 1141.828,
+      "p90": 17949.86,
+      "p95": 23761.012,
+      "p99": 25805.098,
+      "min": 235.153,
+      "max": 27327.543
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 103.871,
+    "power_avg_w": 45.82,
+    "power_peak_w": 55.5,
+    "energy_wh": 2.4989,
+    "gpu_util_avg_pct": 95.83,
+    "temp_max_c": 72.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "reasoning",
+    "total": 140,
+    "correct": 90,
+    "accuracy": 0.642857,
+    "success_rate": 1.0,
+    "by_category": {
+      "counting": {
+        "total": 20,
+        "correct": 20
+      },
+      "datetime": {
+        "total": 20,
+        "correct": 9
+      },
+      "deduction": {
+        "total": 20,
+        "correct": 19
+      },
+      "ordering": {
+        "total": 20,
+        "correct": 7
+      },
+      "spatial": {
+        "total": 20,
+        "correct": 11
+      },
+      "syllogism": {
+        "total": 20,
+        "correct": 18
+      },
+      "truth_liar": {
+        "total": 20,
+        "correct": 6
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 16,
+        "correct": 9
+      },
+      "hard": {
+        "total": 79,
+        "correct": 58
+      },
+      "medium": {
+        "total": 45,
+        "correct": 23
+      }
+    },
+    "avg_output_tokens": 121.21,
+    "avg_latency_ms": 5596.36,
+    "failures": 0,
+    "items": [
+      {
+        "id": "reason2-0001",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 235.153,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0002",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 508.851,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0003",
+        "correct": false,
+        "predicted": "D",
+        "expected": "C",
+        "latency_ms": 782.373,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0004",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1056.417,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0005",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1098.789,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0006",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1103.116,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0007",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1109.949,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0008",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1111.515,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0009",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1110.875,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0010",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1107.054,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0011",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1094.602,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0012",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1099.713,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0013",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1111.663,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0014",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1110.03,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0015",
+        "correct": false,
+        "predicted": "D",
+        "expected": "C",
+        "latency_ms": 1123.511,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0016",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1122.533,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0017",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1103.941,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0018",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1112.504,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0019",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1101.402,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0020",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1099.781,
+        "output_tokens": 2,
+        "category": "syllogism",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0021",
+        "correct": true,
+        "predicted": "Gus",
+        "expected": "Gus",
+        "latency_ms": 1104.894,
+        "output_tokens": 3,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0022",
+        "correct": false,
+        "predicted": "Dita",
+        "expected": "Ada",
+        "latency_ms": 1086.234,
+        "output_tokens": 3,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0023",
+        "correct": false,
+        "predicted": "Bo",
+        "expected": "Juno",
+        "latency_ms": 1083.573,
+        "output_tokens": 2,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0024",
+        "correct": false,
+        "predicted": "Gus",
+        "expected": "Juno",
+        "latency_ms": 1063.559,
+        "output_tokens": 3,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0025",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 1042.848,
+        "output_tokens": 2,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0026",
+        "correct": false,
+        "predicted": "Fenna",
+        "expected": "Juno",
+        "latency_ms": 1049.27,
+        "output_tokens": 3,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0027",
+        "correct": false,
+        "predicted": "Gus",
+        "expected": "Cai",
+        "latency_ms": 1045.047,
+        "output_tokens": 3,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0028",
+        "correct": false,
+        "predicted": "1",
+        "expected": "0",
+        "latency_ms": 1050.784,
+        "output_tokens": 2,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0029",
+        "correct": true,
+        "predicted": "Bo",
+        "expected": "Bo",
+        "latency_ms": 1056.175,
+        "output_tokens": 2,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0030",
+        "correct": false,
+        "predicted": "Fenna",
+        "expected": "Ada",
+        "latency_ms": 1054.33,
+        "output_tokens": 3,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0031",
+        "correct": false,
+        "predicted": "2",
+        "expected": "3",
+        "latency_ms": 1057.825,
+        "output_tokens": 2,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0032",
+        "correct": false,
+        "predicted": "1",
+        "expected": "0",
+        "latency_ms": 1052.46,
+        "output_tokens": 2,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0033",
+        "correct": false,
+        "predicted": "Dita",
+        "expected": "Lars",
+        "latency_ms": 1051.286,
+        "output_tokens": 3,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0034",
+        "correct": false,
+        "predicted": "Lars",
+        "expected": "Juno",
+        "latency_ms": 1053.416,
+        "output_tokens": 3,
+        "category": "ordering",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0035",
+        "correct": false,
+        "predicted": "Bo",
+        "expected": "Ada",
+        "latency_ms": 1044.056,
+        "output_tokens": 2,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0036",
+        "correct": true,
+        "predicted": "Cai",
+        "expected": "Cai",
+        "latency_ms": 1058.392,
+        "output_tokens": 3,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0037",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 1056.27,
+        "output_tokens": 2,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0038",
+        "correct": false,
+        "predicted": "Bo",
+        "expected": "Kira",
+        "latency_ms": 1042.711,
+        "output_tokens": 2,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0039",
+        "correct": true,
+        "predicted": "Hana",
+        "expected": "Hana",
+        "latency_ms": 1041.575,
+        "output_tokens": 3,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0040",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 1030.565,
+        "output_tokens": 2,
+        "category": "ordering",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0041",
+        "correct": false,
+        "predicted": "Fenna, Kira",
+        "expected": "Juno, Kira",
+        "latency_ms": 1088.498,
+        "output_tokens": 6,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0042",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 1080.771,
+        "output_tokens": 2,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0043",
+        "correct": false,
+        "predicted": "1",
+        "expected": "0",
+        "latency_ms": 1058.396,
+        "output_tokens": 2,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0044",
+        "correct": false,
+        "predicted": "1",
+        "expected": "3",
+        "latency_ms": 1049.912,
+        "output_tokens": 2,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0045",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 968.766,
+        "output_tokens": 2,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0046",
+        "correct": false,
+        "predicted": "Ada, Kira",
+        "expected": "Kira",
+        "latency_ms": 981.932,
+        "output_tokens": 6,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0047",
+        "correct": false,
+        "predicted": "Cai, Lars",
+        "expected": "Kira, Lars",
+        "latency_ms": 1008.713,
+        "output_tokens": 5,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0048",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 1008.312,
+        "output_tokens": 2,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0049",
+        "correct": false,
+        "predicted": "Ada, Fenna",
+        "expected": "Ada, Fenna, Hana",
+        "latency_ms": 1091.42,
+        "output_tokens": 6,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0050",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 1078.244,
+        "output_tokens": 2,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0051",
+        "correct": false,
+        "predicted": "Cai, Lars",
+        "expected": "Bo, Cai",
+        "latency_ms": 1130.828,
+        "output_tokens": 5,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0052",
+        "correct": false,
+        "predicted": "1",
+        "expected": "0",
+        "latency_ms": 1133.315,
+        "output_tokens": 2,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0053",
+        "correct": false,
+        "predicted": "2",
+        "expected": "3",
+        "latency_ms": 1065.729,
+        "output_tokens": 2,
+        "category": "truth_liar",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0054",
+        "correct": false,
+        "predicted": "Dita, Fenna",
+        "expected": "Juno, Kira",
+        "latency_ms": 1078.511,
+        "output_tokens": 6,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0055",
+        "correct": false,
+        "predicted": "1",
+        "expected": "3",
+        "latency_ms": 1015.248,
+        "output_tokens": 2,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0056",
+        "correct": false,
+        "predicted": "Bo, Fenna",
+        "expected": "Bo",
+        "latency_ms": 1072.812,
+        "output_tokens": 5,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0057",
+        "correct": false,
+        "predicted": "1",
+        "expected": "0",
+        "latency_ms": 1065.766,
+        "output_tokens": 2,
+        "category": "truth_liar",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0058",
+        "correct": true,
+        "predicted": "Ada, Cai, Juno",
+        "expected": "Ada, Cai, Juno",
+        "latency_ms": 1125.162,
+        "output_tokens": 9,
+        "category": "truth_liar",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0059",
+        "correct": false,
+        "predicted": "2",
+        "expected": "3",
+        "latency_ms": 1138.18,
+        "output_tokens": 2,
+        "category": "truth_liar",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0060",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 1070.595,
+        "output_tokens": 2,
+        "category": "truth_liar",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0061",
+        "correct": true,
+        "predicted": "480",
+        "expected": "480",
+        "latency_ms": 4565.616,
+        "output_tokens": 360,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0062",
+        "correct": true,
+        "predicted": "104",
+        "expected": "104",
+        "latency_ms": 10483.427,
+        "output_tokens": 618,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0063",
+        "correct": true,
+        "predicted": "41",
+        "expected": "41",
+        "latency_ms": 22041.395,
+        "output_tokens": 1089,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0064",
+        "correct": true,
+        "predicted": "3600",
+        "expected": "3600",
+        "latency_ms": 25259.837,
+        "output_tokens": 349,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0065",
+        "correct": true,
+        "predicted": "480",
+        "expected": "480",
+        "latency_ms": 24743.188,
+        "output_tokens": 324,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0066",
+        "correct": true,
+        "predicted": "230",
+        "expected": "230",
+        "latency_ms": 23746.581,
+        "output_tokens": 470,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0067",
+        "correct": true,
+        "predicted": "144",
+        "expected": "144",
+        "latency_ms": 15873.057,
+        "output_tokens": 429,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0068",
+        "correct": true,
+        "predicted": "491",
+        "expected": "491",
+        "latency_ms": 20302.677,
+        "output_tokens": 947,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0069",
+        "correct": true,
+        "predicted": "610",
+        "expected": "610",
+        "latency_ms": 22192.283,
+        "output_tokens": 604,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0070",
+        "correct": true,
+        "predicted": "112",
+        "expected": "112",
+        "latency_ms": 22010.877,
+        "output_tokens": 498,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0071",
+        "correct": true,
+        "predicted": "45",
+        "expected": "45",
+        "latency_ms": 27327.543,
+        "output_tokens": 891,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0072",
+        "correct": true,
+        "predicted": "85",
+        "expected": "85",
+        "latency_ms": 25882.438,
+        "output_tokens": 625,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0073",
+        "correct": true,
+        "predicted": "1401",
+        "expected": "1401",
+        "latency_ms": 25684.131,
+        "output_tokens": 436,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0074",
+        "correct": true,
+        "predicted": "3600",
+        "expected": "3600",
+        "latency_ms": 24035.2,
+        "output_tokens": 315,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0075",
+        "correct": true,
+        "predicted": "14833",
+        "expected": "14833",
+        "latency_ms": 25357.909,
+        "output_tokens": 1240,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0076",
+        "correct": true,
+        "predicted": "166",
+        "expected": "166",
+        "latency_ms": 19172.026,
+        "output_tokens": 4,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0077",
+        "correct": true,
+        "predicted": "43",
+        "expected": "43",
+        "latency_ms": 20732.041,
+        "output_tokens": 757,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0078",
+        "correct": true,
+        "predicted": "63",
+        "expected": "63",
+        "latency_ms": 17585.186,
+        "output_tokens": 3,
+        "category": "counting",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0079",
+        "correct": true,
+        "predicted": "104",
+        "expected": "104",
+        "latency_ms": 12312.452,
+        "output_tokens": 512,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0080",
+        "correct": true,
+        "predicted": "3600",
+        "expected": "3600",
+        "latency_ms": 16175.348,
+        "output_tokens": 366,
+        "category": "counting",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0081",
+        "correct": false,
+        "predicted": "2032-12-10 04:15",
+        "expected": "2032-12-09 22:15",
+        "latency_ms": 10160.273,
+        "output_tokens": 17,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0082",
+        "correct": true,
+        "predicted": "1925-01-28",
+        "expected": "1925-01-28",
+        "latency_ms": 10222.342,
+        "output_tokens": 11,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0083",
+        "correct": true,
+        "predicted": "1929-10-04",
+        "expected": "1929-10-04",
+        "latency_ms": 5177.765,
+        "output_tokens": 11,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0084",
+        "correct": false,
+        "predicted": "2028-06-30 09:10",
+        "expected": "2028-06-30 23:10",
+        "latency_ms": 1460.988,
+        "output_tokens": 17,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0085",
+        "correct": true,
+        "predicted": "07:40",
+        "expected": "07:40",
+        "latency_ms": 1230.612,
+        "output_tokens": 6,
+        "category": "datetime",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0086",
+        "correct": true,
+        "predicted": "2034-11-16",
+        "expected": "2034-11-16",
+        "latency_ms": 1164.241,
+        "output_tokens": 11,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0087",
+        "correct": true,
+        "predicted": "19:35",
+        "expected": "19:35",
+        "latency_ms": 1171.977,
+        "output_tokens": 6,
+        "category": "datetime",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0088",
+        "correct": true,
+        "predicted": "2028-01-10",
+        "expected": "2028-01-10",
+        "latency_ms": 1026.324,
+        "output_tokens": 11,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0089",
+        "correct": false,
+        "predicted": "1995-11-24",
+        "expected": "1995-12-29",
+        "latency_ms": 1174.727,
+        "output_tokens": 11,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0090",
+        "correct": true,
+        "predicted": "1963-01-22",
+        "expected": "1963-01-22",
+        "latency_ms": 1239.338,
+        "output_tokens": 11,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0091",
+        "correct": false,
+        "predicted": "2039-11-16",
+        "expected": "2039-11-02",
+        "latency_ms": 1393.302,
+        "output_tokens": 11,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0092",
+        "correct": false,
+        "predicted": "13:35",
+        "expected": "16:35",
+        "latency_ms": 1427.874,
+        "output_tokens": 6,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0093",
+        "correct": false,
+        "predicted": "2012-05-14 09:40",
+        "expected": "2012-05-13 21:40",
+        "latency_ms": 1401.233,
+        "output_tokens": 17,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0094",
+        "correct": true,
+        "predicted": "3777",
+        "expected": "3777",
+        "latency_ms": 14055.324,
+        "output_tokens": 1332,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0095",
+        "correct": false,
+        "predicted": "Saturday",
+        "expected": "Sunday",
+        "latency_ms": 13836.723,
+        "output_tokens": 2,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0096",
+        "correct": false,
+        "predicted": "11:30",
+        "expected": "10:30",
+        "latency_ms": 13879.996,
+        "output_tokens": 6,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0097",
+        "correct": true,
+        "predicted": "11:05",
+        "expected": "11:05",
+        "latency_ms": 13755.65,
+        "output_tokens": 6,
+        "category": "datetime",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0098",
+        "correct": false,
+        "predicted": "2eville-07-10",
+        "expected": "2023-07-10",
+        "latency_ms": 1230.213,
+        "output_tokens": 9,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0099",
+        "correct": false,
+        "predicted": "2006-02-10 04:10",
+        "expected": "2006-02-10 10:10",
+        "latency_ms": 1370.662,
+        "output_tokens": 17,
+        "category": "datetime",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0100",
+        "correct": false,
+        "predicted": "2008-01-11",
+        "expected": "2007-11-05",
+        "latency_ms": 1355.973,
+        "output_tokens": 11,
+        "category": "datetime",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0101",
+        "correct": true,
+        "predicted": "7",
+        "expected": "7",
+        "latency_ms": 6519.285,
+        "output_tokens": 514,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0102",
+        "correct": false,
+        "predicted": "1",
+        "expected": "2",
+        "latency_ms": 6306.716,
+        "output_tokens": 2,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0103",
+        "correct": false,
+        "predicted": "1",
+        "expected": "4",
+        "latency_ms": 6136.492,
+        "output_tokens": 2,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0104",
+        "correct": true,
+        "predicted": "7",
+        "expected": "7",
+        "latency_ms": 10966.82,
+        "output_tokens": 479,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0105",
+        "correct": true,
+        "predicted": "17",
+        "expected": "17",
+        "latency_ms": 12091.021,
+        "output_tokens": 585,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0106",
+        "correct": true,
+        "predicted": "7",
+        "expected": "7",
+        "latency_ms": 17806.267,
+        "output_tokens": 521,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0107",
+        "correct": false,
+        "predicted": "1",
+        "expected": "6",
+        "latency_ms": 17814.064,
+        "output_tokens": 2,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0108",
+        "correct": false,
+        "predicted": "east",
+        "expected": "north",
+        "latency_ms": 12870.063,
+        "output_tokens": 2,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0109",
+        "correct": true,
+        "predicted": "20",
+        "expected": "20",
+        "latency_ms": 12128.178,
+        "output_tokens": 554,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0110",
+        "correct": false,
+        "predicted": "1",
+        "expected": "6",
+        "latency_ms": 6359.931,
+        "output_tokens": 2,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0111",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 6357.112,
+        "output_tokens": 2,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0112",
+        "correct": true,
+        "predicted": "15",
+        "expected": "15",
+        "latency_ms": 12649.234,
+        "output_tokens": 627,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0113",
+        "correct": true,
+        "predicted": "east",
+        "expected": "east",
+        "latency_ms": 7097.78,
+        "output_tokens": 2,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0114",
+        "correct": false,
+        "predicted": "1",
+        "expected": "3",
+        "latency_ms": 7097.406,
+        "output_tokens": 2,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0115",
+        "correct": true,
+        "predicted": "20",
+        "expected": "20",
+        "latency_ms": 12281.06,
+        "output_tokens": 569,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0116",
+        "correct": false,
+        "predicted": "south",
+        "expected": "north",
+        "latency_ms": 6007.256,
+        "output_tokens": 2,
+        "category": "spatial",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0117",
+        "correct": true,
+        "predicted": "13",
+        "expected": "13",
+        "latency_ms": 11169.016,
+        "output_tokens": 528,
+        "category": "spatial",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0118",
+        "correct": false,
+        "predicted": "north",
+        "expected": "south",
+        "latency_ms": 11216.741,
+        "output_tokens": 2,
+        "category": "spatial",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0119",
+        "correct": true,
+        "predicted": "south",
+        "expected": "south",
+        "latency_ms": 6075.662,
+        "output_tokens": 2,
+        "category": "spatial",
+        "difficulty": "medium"
+      },
+      {
+        "id": "reason2-0120",
+        "correct": false,
+        "predicted": "north",
+        "expected": "west",
+        "latency_ms": 6058.394,
+        "output_tokens": 2,
+        "category": "spatial",
+        "difficulty": "easy"
+      },
+      {
+        "id": "reason2-0121",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 960.044,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0122",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1014.332,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0123",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1066.778,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0124",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1137.011,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0125",
+        "correct": false,
+        "predicted": "B",
+        "expected": "A",
+        "latency_ms": 1147.562,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0126",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1156.531,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0127",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1153.847,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0128",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1157.285,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0129",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1149.136,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0130",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1136.256,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0131",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1139.83,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0132",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1138.986,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0133",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1146.227,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0134",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1142.46,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0135",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1140.867,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0136",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1144.838,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0137",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1141.197,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0138",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1146.248,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0139",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1149.581,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      },
+      {
+        "id": "reason2-0140",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1154.018,
+        "output_tokens": 2,
+        "category": "deduction",
+        "difficulty": "hard"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "fab1929ab353901e5c7f829ecd140c22f2c6e7decc615789296826a20e3e5085",
+    "payload_path": null,
+    "payload": {
+      "scorer": "exact",
+      "scorers_used": [
+        "exact",
+        "mc",
+        "numeric"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "ling-3.0-flash",
+        "advertised_models": [
+          "ling-3.0-flash"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-09-10T00:28:29Z",
+    "finished_at": "2026-09-10T00:31:45Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Served with the ling3-flash-dgx-spark recipe (49b6c9c), PROFILE=humming-dspark, thinking off (server default via --default-chat-template-kwargs): inclusionAI/Ling-3.0-flash-fp4 (MXFP4 routed experts, FP8 attention/shared/router) with --moe-runner-backend humming, online FP8 LM head (SGLANG_ENABLE_FP8_LM_HEAD=1), DSpark speculative decoding with inclusionAI/Ling-3.0-flash-dspark and the KDA ReplaySSM exact fold (--enable-linear-replayssm-spec, ring 32), context 262144 native (no YaRN), mem-fraction 0.75, max-running 1, page 64, decode cuda graph bs 1, prefill cuda graph disabled, FlashInfer autotune off with precompiled CUTLASS MXFP4 kernels. Single request at a time on every row."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-science-v2--35ee73.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-science-v2--35ee73.json
@@ -1,0 +1,1431 @@
+{
+  "schema_version": 1,
+  "run_id": "a9e5da49f0c2bba3--eval-science-v2--35ee73",
+  "config_id": "a9e5da49f0c2bba3",
+  "cell_id": "4ab17fea2273",
+  "workload_id": "eval-science-v2",
+  "kind": "eval",
+  "engine": {
+    "id": "sglang",
+    "version": "0.0.0.dev1+g079d40460",
+    "commit": null,
+    "build": "github.com/inclusionAI/sglang@079d404",
+    "container": "lmsysorg/sglang:v0.0.0.dev1+g079d40460-cu126",
+    "install_method": "source"
+  },
+  "model": {
+    "id": "inclusionAI/Ling-3.0-flash",
+    "quant_id": "mxfp4",
+    "hf_id": "inclusionAI/Ling-3.0-flash",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "moe-runner-backend": "humming",
+    "speculative-algorithm": "DSPARK",
+    "speculative-draft-model-path": "inclusionAI/Ling-3.0-flash-dspark",
+    "enable-linear-replayssm-spec": true,
+    "linear-replayssm-cache-len": 32,
+    "mem-fraction-static": 0.75,
+    "max-running-requests": 1,
+    "max-mamba-cache-size": 64,
+    "chunked-prefill-size": 8192,
+    "max-prefill-tokens": 16384,
+    "page-size": 64,
+    "attention-backend": "flashinfer",
+    "fp8-gemm-backend": "cutlass",
+    "flashinfer-mxfp4-moe-precision": "default",
+    "disable-shared-experts-fusion": true,
+    "cuda-graph-backend-decode": "full",
+    "cuda-graph-max-bs-decode": 1,
+    "cuda-graph-backend-prefill": "disabled",
+    "reasoning-parser": "deepseek-r1",
+    "tool-call-parser": "qwen25",
+    "trust-remote-code": true,
+    "fp8-lm-head": "online",
+    "default-chat-template-kwargs": {
+      "enable_thinking": false
+    }
+  },
+  "args_canonical": "@build=github.com/inclusionai/sglang@079d404;@dtype=auto;@quant=mxfp4;attention-backend=flashinfer;chunked-prefill-size=8192;cuda-graph-backend-decode=full;cuda-graph-backend-prefill=disabled;cuda-graph-max-bs-decode=1;default-chat-template-kwargs={\"enable_thinking\":false};disable-shared-experts-fusion=true;enable-linear-replayssm-spec=true;fp8-gemm-backend=cutlass;fp8-lm-head=online;linear-replayssm-cache-len=32;max-mamba-cache-size=64;max-running-requests=1;mem-fraction-static=0.75;moe-runner-backend=humming;page-size=64;reasoning-parser=deepseek-r1;speculative-algorithm=DSPARK;speculative-draft-model-path=inclusionAI/Ling-3.0-flash-dspark;tool-call-parser=qwen25;trust-remote-code=true",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-science-v2",
+    "resolved_params": {
+      "dataset_id": "eval-science-v2",
+      "suite": "science",
+      "scorer": "numeric",
+      "items": 120,
+      "concurrency": 4,
+      "max_output_tokens": 4096,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 120,
+    "requests_ok": 120,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 275.459,
+    "input_tokens_total": 11465,
+    "output_tokens_total": 27957,
+    "e2e_ms": {
+      "mean": 9171.464,
+      "p50": 8512.868,
+      "p90": 17798.085,
+      "p95": 18468.879,
+      "p99": 19682.001,
+      "min": 198.004,
+      "max": 22131.385
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 103.867,
+    "power_avg_w": 45.31,
+    "power_peak_w": 50.47,
+    "energy_wh": 3.4666,
+    "gpu_util_avg_pct": 95.07,
+    "temp_max_c": 72.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "science",
+    "total": 120,
+    "correct": 114,
+    "accuracy": 0.95,
+    "success_rate": 1.0,
+    "by_category": {
+      "chemistry": {
+        "total": 20,
+        "correct": 19
+      },
+      "electricity": {
+        "total": 20,
+        "correct": 16
+      },
+      "mechanics": {
+        "total": 20,
+        "correct": 20
+      },
+      "radioactivity_units": {
+        "total": 20,
+        "correct": 19
+      },
+      "thermodynamics": {
+        "total": 20,
+        "correct": 20
+      },
+      "waves_optics": {
+        "total": 20,
+        "correct": 20
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 22,
+        "correct": 22
+      },
+      "hard": {
+        "total": 51,
+        "correct": 50
+      },
+      "medium": {
+        "total": 47,
+        "correct": 42
+      }
+    },
+    "avg_output_tokens": 232.97,
+    "avg_latency_ms": 9171.46,
+    "failures": 0,
+    "items": [
+      {
+        "id": "sci-0001",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 198.004,
+        "output_tokens": 2,
+        "category": "mechanics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0002",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 431.55,
+        "output_tokens": 2,
+        "category": "mechanics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0003",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 663.929,
+        "output_tokens": 2,
+        "category": "mechanics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0004",
+        "correct": true,
+        "predicted": "120",
+        "expected": "120",
+        "latency_ms": 4215.217,
+        "output_tokens": 317,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0005",
+        "correct": true,
+        "predicted": "96",
+        "expected": "96",
+        "latency_ms": 6025.005,
+        "output_tokens": 173,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0006",
+        "correct": true,
+        "predicted": "32",
+        "expected": "32",
+        "latency_ms": 9621.415,
+        "output_tokens": 362,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0007",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 15411.312,
+        "output_tokens": 580,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0008",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 16375.209,
+        "output_tokens": 448,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0009",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 19554.426,
+        "output_tokens": 568,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0010",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 22131.385,
+        "output_tokens": 648,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0011",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 19085.375,
+        "output_tokens": 315,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0012",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 18105.141,
+        "output_tokens": 344,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0013",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 16344.6,
+        "output_tokens": 347,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0014",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 13541.242,
+        "output_tokens": 352,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0015",
+        "correct": true,
+        "predicted": "108",
+        "expected": "108",
+        "latency_ms": 10810.054,
+        "output_tokens": 4,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0016",
+        "correct": true,
+        "predicted": "72",
+        "expected": "72",
+        "latency_ms": 7507.278,
+        "output_tokens": 3,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0017",
+        "correct": true,
+        "predicted": "28.8",
+        "expected": "28.8",
+        "latency_ms": 4315.094,
+        "output_tokens": 5,
+        "category": "mechanics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0018",
+        "correct": true,
+        "predicted": "8",
+        "expected": "8",
+        "latency_ms": 3538.761,
+        "output_tokens": 276,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0019",
+        "correct": true,
+        "predicted": "16",
+        "expected": "16",
+        "latency_ms": 6857.486,
+        "output_tokens": 331,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0020",
+        "correct": true,
+        "predicted": "10",
+        "expected": "10",
+        "latency_ms": 11220.92,
+        "output_tokens": 450,
+        "category": "mechanics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0021",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 13095.182,
+        "output_tokens": 181,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0022",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 14526.051,
+        "output_tokens": 491,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0023",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 13186.619,
+        "output_tokens": 192,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0024",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 12999.014,
+        "output_tokens": 497,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0025",
+        "correct": true,
+        "predicted": "1",
+        "expected": "1",
+        "latency_ms": 15067.476,
+        "output_tokens": 500,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0026",
+        "correct": true,
+        "predicted": "72",
+        "expected": "72",
+        "latency_ms": 13030.285,
+        "output_tokens": 198,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0027",
+        "correct": true,
+        "predicted": "27",
+        "expected": "27",
+        "latency_ms": 12965.299,
+        "output_tokens": 182,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0028",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 10636.403,
+        "output_tokens": 152,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0029",
+        "correct": true,
+        "predicted": "27",
+        "expected": "27",
+        "latency_ms": 8915.489,
+        "output_tokens": 193,
+        "category": "electricity",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0030",
+        "correct": false,
+        "predicted": "4.29",
+        "expected": "4.11",
+        "latency_ms": 7039.276,
+        "output_tokens": 5,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0031",
+        "correct": false,
+        "predicted": "13.57",
+        "expected": "4.12",
+        "latency_ms": 5283.552,
+        "output_tokens": 6,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0032",
+        "correct": false,
+        "predicted": "7.2",
+        "expected": "6.86",
+        "latency_ms": 3494.614,
+        "output_tokens": 5,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0033",
+        "correct": false,
+        "predicted": "10.15",
+        "expected": "5.74",
+        "latency_ms": 1328.562,
+        "output_tokens": 6,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0034",
+        "correct": true,
+        "predicted": "14.4",
+        "expected": "14.4",
+        "latency_ms": 2489.536,
+        "output_tokens": 112,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0035",
+        "correct": true,
+        "predicted": "8",
+        "expected": "8",
+        "latency_ms": 5044.665,
+        "output_tokens": 291,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0036",
+        "correct": true,
+        "predicted": "10",
+        "expected": "10",
+        "latency_ms": 7671.816,
+        "output_tokens": 269,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0037",
+        "correct": true,
+        "predicted": "67.5",
+        "expected": "67.5",
+        "latency_ms": 10725.25,
+        "output_tokens": 343,
+        "category": "electricity",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0038",
+        "correct": true,
+        "predicted": "8",
+        "expected": "8",
+        "latency_ms": 9441.737,
+        "output_tokens": 2,
+        "category": "electricity",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0039",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 6703.917,
+        "output_tokens": 2,
+        "category": "electricity",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0040",
+        "correct": true,
+        "predicted": "10",
+        "expected": "10",
+        "latency_ms": 4004.496,
+        "output_tokens": 3,
+        "category": "electricity",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0041",
+        "correct": true,
+        "predicted": "43",
+        "expected": "43",
+        "latency_ms": 4774.992,
+        "output_tokens": 443,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0042",
+        "correct": true,
+        "predicted": "32",
+        "expected": "32",
+        "latency_ms": 8456.552,
+        "output_tokens": 432,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0043",
+        "correct": true,
+        "predicted": "44",
+        "expected": "44",
+        "latency_ms": 12431.515,
+        "output_tokens": 480,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0044",
+        "correct": true,
+        "predicted": "34",
+        "expected": "34",
+        "latency_ms": 16633.804,
+        "output_tokens": 481,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0045",
+        "correct": true,
+        "predicted": "30",
+        "expected": "30",
+        "latency_ms": 17469.148,
+        "output_tokens": 568,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0046",
+        "correct": true,
+        "predicted": "30",
+        "expected": "30",
+        "latency_ms": 18084.561,
+        "output_tokens": 524,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0047",
+        "correct": true,
+        "predicted": "30",
+        "expected": "30",
+        "latency_ms": 18016.904,
+        "output_tokens": 442,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0048",
+        "correct": true,
+        "predicted": "80",
+        "expected": "80",
+        "latency_ms": 18436.431,
+        "output_tokens": 560,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0049",
+        "correct": true,
+        "predicted": "1995",
+        "expected": "1995",
+        "latency_ms": 17773.772,
+        "output_tokens": 521,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0050",
+        "correct": true,
+        "predicted": "2310",
+        "expected": "2310",
+        "latency_ms": 18408.468,
+        "output_tokens": 647,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0051",
+        "correct": true,
+        "predicted": "2835",
+        "expected": "2835",
+        "latency_ms": 19266.271,
+        "output_tokens": 645,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0052",
+        "correct": true,
+        "predicted": "1050",
+        "expected": "1050",
+        "latency_ms": 19255.562,
+        "output_tokens": 628,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0053",
+        "correct": true,
+        "predicted": "0.17",
+        "expected": "0.17",
+        "latency_ms": 19711.927,
+        "output_tokens": 515,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0054",
+        "correct": true,
+        "predicted": "0.55",
+        "expected": "0.55",
+        "latency_ms": 17698.461,
+        "output_tokens": 331,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0055",
+        "correct": true,
+        "predicted": "0.56",
+        "expected": "0.56",
+        "latency_ms": 17620.653,
+        "output_tokens": 560,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0056",
+        "correct": true,
+        "predicted": "1.13",
+        "expected": "1.13",
+        "latency_ms": 17642.026,
+        "output_tokens": 539,
+        "category": "thermodynamics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0057",
+        "correct": true,
+        "predicted": "180",
+        "expected": "180",
+        "latency_ms": 15499.75,
+        "output_tokens": 253,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0058",
+        "correct": true,
+        "predicted": "300",
+        "expected": "300",
+        "latency_ms": 15095.546,
+        "output_tokens": 293,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0059",
+        "correct": true,
+        "predicted": "180",
+        "expected": "180",
+        "latency_ms": 13104.895,
+        "output_tokens": 316,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0060",
+        "correct": true,
+        "predicted": "200",
+        "expected": "200",
+        "latency_ms": 11622.603,
+        "output_tokens": 313,
+        "category": "thermodynamics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0061",
+        "correct": true,
+        "predicted": "36",
+        "expected": "36",
+        "latency_ms": 11547.803,
+        "output_tokens": 232,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0062",
+        "correct": true,
+        "predicted": "72",
+        "expected": "72",
+        "latency_ms": 10804.302,
+        "output_tokens": 177,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0063",
+        "correct": true,
+        "predicted": "72",
+        "expected": "72",
+        "latency_ms": 10318.756,
+        "output_tokens": 227,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0064",
+        "correct": true,
+        "predicted": "36",
+        "expected": "36",
+        "latency_ms": 9233.942,
+        "output_tokens": 224,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0065",
+        "correct": true,
+        "predicted": "85",
+        "expected": "85",
+        "latency_ms": 11023.125,
+        "output_tokens": 553,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0066",
+        "correct": true,
+        "predicted": "51",
+        "expected": "51",
+        "latency_ms": 13192.139,
+        "output_tokens": 491,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0067",
+        "correct": true,
+        "predicted": "102",
+        "expected": "102",
+        "latency_ms": 15060.914,
+        "output_tokens": 537,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0068",
+        "correct": true,
+        "predicted": "51",
+        "expected": "51",
+        "latency_ms": 18033.039,
+        "output_tokens": 640,
+        "category": "chemistry",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0069",
+        "correct": true,
+        "predicted": "0.02",
+        "expected": "0.02",
+        "latency_ms": 15429.138,
+        "output_tokens": 171,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0070",
+        "correct": true,
+        "predicted": "0.005",
+        "expected": "0.005",
+        "latency_ms": 12575.636,
+        "output_tokens": 88,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0071",
+        "correct": true,
+        "predicted": "0.04",
+        "expected": "0.04",
+        "latency_ms": 10018.748,
+        "output_tokens": 172,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0072",
+        "correct": true,
+        "predicted": "0.01",
+        "expected": "0.01",
+        "latency_ms": 6454.364,
+        "output_tokens": 169,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0073",
+        "correct": true,
+        "predicted": "90",
+        "expected": "90",
+        "latency_ms": 4990.032,
+        "output_tokens": 3,
+        "category": "chemistry",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0074",
+        "correct": true,
+        "predicted": "60",
+        "expected": "60",
+        "latency_ms": 3913.828,
+        "output_tokens": 3,
+        "category": "chemistry",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0075",
+        "correct": true,
+        "predicted": "65",
+        "expected": "65",
+        "latency_ms": 2404.05,
+        "output_tokens": 3,
+        "category": "chemistry",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0076",
+        "correct": true,
+        "predicted": "70",
+        "expected": "70",
+        "latency_ms": 946.208,
+        "output_tokens": 3,
+        "category": "chemistry",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0077",
+        "correct": true,
+        "predicted": "24",
+        "expected": "24",
+        "latency_ms": 2831.734,
+        "output_tokens": 219,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0078",
+        "correct": false,
+        "predicted": "4.8",
+        "expected": "120",
+        "latency_ms": 4243.487,
+        "output_tokens": 136,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0079",
+        "correct": true,
+        "predicted": "72",
+        "expected": "72",
+        "latency_ms": 5918.193,
+        "output_tokens": 201,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0080",
+        "correct": true,
+        "predicted": "48",
+        "expected": "48",
+        "latency_ms": 7597.734,
+        "output_tokens": 181,
+        "category": "chemistry",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0081",
+        "correct": true,
+        "predicted": "3",
+        "expected": "3",
+        "latency_ms": 5745.699,
+        "output_tokens": 5,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0082",
+        "correct": true,
+        "predicted": "2",
+        "expected": "2",
+        "latency_ms": 4384.448,
+        "output_tokens": 5,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0083",
+        "correct": true,
+        "predicted": "4",
+        "expected": "4",
+        "latency_ms": 2751.492,
+        "output_tokens": 5,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0084",
+        "correct": true,
+        "predicted": "1.5",
+        "expected": "1.5",
+        "latency_ms": 1065.315,
+        "output_tokens": 4,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0085",
+        "correct": true,
+        "predicted": "50",
+        "expected": "50",
+        "latency_ms": 4646.968,
+        "output_tokens": 378,
+        "category": "waves_optics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0086",
+        "correct": true,
+        "predicted": "120",
+        "expected": "120",
+        "latency_ms": 7001.516,
+        "output_tokens": 275,
+        "category": "waves_optics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0087",
+        "correct": true,
+        "predicted": "120",
+        "expected": "120",
+        "latency_ms": 10134.087,
+        "output_tokens": 371,
+        "category": "waves_optics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0088",
+        "correct": true,
+        "predicted": "60",
+        "expected": "60",
+        "latency_ms": 11929.526,
+        "output_tokens": 217,
+        "category": "waves_optics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0089",
+        "correct": true,
+        "predicted": "0.72",
+        "expected": "0.72",
+        "latency_ms": 8313.495,
+        "output_tokens": 5,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0090",
+        "correct": true,
+        "predicted": "0.38",
+        "expected": "0.38",
+        "latency_ms": 5977.17,
+        "output_tokens": 5,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0091",
+        "correct": true,
+        "predicted": "0.84",
+        "expected": "0.84",
+        "latency_ms": 2812.06,
+        "output_tokens": 5,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0092",
+        "correct": true,
+        "predicted": "0.7",
+        "expected": "0.7",
+        "latency_ms": 1041.688,
+        "output_tokens": 5,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0093",
+        "correct": true,
+        "predicted": "50",
+        "expected": "50",
+        "latency_ms": 1005.925,
+        "output_tokens": 3,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0094",
+        "correct": true,
+        "predicted": "100",
+        "expected": "100",
+        "latency_ms": 920.535,
+        "output_tokens": 4,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0095",
+        "correct": true,
+        "predicted": "25",
+        "expected": "25",
+        "latency_ms": 889.658,
+        "output_tokens": 3,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0096",
+        "correct": true,
+        "predicted": "200",
+        "expected": "200",
+        "latency_ms": 850.377,
+        "output_tokens": 4,
+        "category": "waves_optics",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0097",
+        "correct": true,
+        "predicted": "1020",
+        "expected": "1020",
+        "latency_ms": 2180.506,
+        "output_tokens": 130,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0098",
+        "correct": true,
+        "predicted": "680",
+        "expected": "680",
+        "latency_ms": 3502.98,
+        "output_tokens": 129,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0099",
+        "correct": true,
+        "predicted": "340",
+        "expected": "340",
+        "latency_ms": 5846.572,
+        "output_tokens": 254,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0100",
+        "correct": true,
+        "predicted": "510",
+        "expected": "510",
+        "latency_ms": 8700.769,
+        "output_tokens": 323,
+        "category": "waves_optics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0101",
+        "correct": true,
+        "predicted": "6",
+        "expected": "6",
+        "latency_ms": 8569.183,
+        "output_tokens": 121,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0102",
+        "correct": true,
+        "predicted": "12",
+        "expected": "12",
+        "latency_ms": 8312.791,
+        "output_tokens": 125,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0103",
+        "correct": true,
+        "predicted": "10",
+        "expected": "10",
+        "latency_ms": 7898.049,
+        "output_tokens": 237,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0104",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 6598.244,
+        "output_tokens": 166,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0105",
+        "correct": true,
+        "predicted": "36",
+        "expected": "36",
+        "latency_ms": 8197.785,
+        "output_tokens": 286,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0106",
+        "correct": true,
+        "predicted": "75",
+        "expected": "75",
+        "latency_ms": 9112.61,
+        "output_tokens": 188,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0107",
+        "correct": true,
+        "predicted": "24",
+        "expected": "24",
+        "latency_ms": 10433.132,
+        "output_tokens": 338,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0108",
+        "correct": true,
+        "predicted": "125",
+        "expected": "125",
+        "latency_ms": 11214.214,
+        "output_tokens": 192,
+        "category": "radioactivity_units",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sci-0109",
+        "correct": false,
+        "predicted": "0",
+        "expected": "3600",
+        "latency_ms": 9621.409,
+        "output_tokens": 125,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0110",
+        "correct": true,
+        "predicted": "6000",
+        "expected": "6000",
+        "latency_ms": 8679.748,
+        "output_tokens": 123,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0111",
+        "correct": true,
+        "predicted": "18000",
+        "expected": "18000",
+        "latency_ms": 6460.129,
+        "output_tokens": 130,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0112",
+        "correct": true,
+        "predicted": "30000",
+        "expected": "30000",
+        "latency_ms": 5212.837,
+        "output_tokens": 117,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0113",
+        "correct": true,
+        "predicted": "360",
+        "expected": "360",
+        "latency_ms": 5325.752,
+        "output_tokens": 147,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0114",
+        "correct": true,
+        "predicted": "450",
+        "expected": "450",
+        "latency_ms": 5515.868,
+        "output_tokens": 139,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0115",
+        "correct": true,
+        "predicted": "240",
+        "expected": "240",
+        "latency_ms": 5796.696,
+        "output_tokens": 147,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0116",
+        "correct": true,
+        "predicted": "1000",
+        "expected": "1000",
+        "latency_ms": 5931.794,
+        "output_tokens": 155,
+        "category": "radioactivity_units",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sci-0117",
+        "correct": true,
+        "predicted": "35",
+        "expected": "35",
+        "latency_ms": 4607.363,
+        "output_tokens": 3,
+        "category": "radioactivity_units",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0118",
+        "correct": true,
+        "predicted": "25",
+        "expected": "25",
+        "latency_ms": 3370.521,
+        "output_tokens": 3,
+        "category": "radioactivity_units",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0119",
+        "correct": true,
+        "predicted": "5",
+        "expected": "5",
+        "latency_ms": 2050.059,
+        "output_tokens": 2,
+        "category": "radioactivity_units",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sci-0120",
+        "correct": true,
+        "predicted": "15",
+        "expected": "15",
+        "latency_ms": 823.057,
+        "output_tokens": 3,
+        "category": "radioactivity_units",
+        "difficulty": "easy"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "a31b99c24e94de4c9f2e04edc64d3512c5c6af345973c36613dd66faf68db0e2",
+    "payload_path": null,
+    "payload": {
+      "scorer": "numeric",
+      "scorers_used": [
+        "numeric"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "ling-3.0-flash",
+        "advertised_models": [
+          "ling-3.0-flash"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-09-10T00:32:21Z",
+    "finished_at": "2026-09-10T00:36:57Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Served with the ling3-flash-dgx-spark recipe (49b6c9c), PROFILE=humming-dspark, thinking off (server default via --default-chat-template-kwargs): inclusionAI/Ling-3.0-flash-fp4 (MXFP4 routed experts, FP8 attention/shared/router) with --moe-runner-backend humming, online FP8 LM head (SGLANG_ENABLE_FP8_LM_HEAD=1), DSpark speculative decoding with inclusionAI/Ling-3.0-flash-dspark and the KDA ReplaySSM exact fold (--enable-linear-replayssm-spec, ring 32), context 262144 native (no YaRN), mem-fraction 0.75, max-running 1, page 64, decode cuda graph bs 1, prefill cuda graph disabled, FlashInfer autotune off with precompiled CUTLASS MXFP4 kernels. Single request at a time on every row."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-science-v2--35ee73.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-science-v2--35ee73.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -93,7 +93,7 @@
       "items": 120,
       "concurrency": 4,
       "max_output_tokens": 4096,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -106,7 +106,7 @@
     "requests_total": 120,
     "requests_ok": 120,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 275.459,
     "input_tokens_total": 11465,
     "output_tokens_total": 27957,
@@ -125,7 +125,7 @@
     "power_peak_w": 50.47,
     "energy_wh": 3.4666,
     "gpu_util_avg_pct": 95.07,
-    "temp_max_c": 72.0,
+    "temp_max_c": 72,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -133,7 +133,7 @@
     "total": 120,
     "correct": 114,
     "accuracy": 0.95,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "chemistry": {
         "total": 20,
@@ -1413,7 +1413,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-10T00:32:21Z",
     "finished_at": "2026-09-10T00:36:57Z",
     "submitted_at": null,

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-security-v2--2039ec.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-security-v2--2039ec.json
@@ -42,7 +42,7 @@
         "products": [
           "NVIDIA GB10"
         ],
-        "fb_memory_total_mib": 0.0
+        "fb_memory_total_mib": 0
       },
       "lscpu": {
         "architecture": "aarch64",
@@ -93,7 +93,7 @@
       "items": 111,
       "concurrency": 4,
       "max_output_tokens": 4096,
-      "timeout_s": 300.0,
+      "timeout_s": 300,
       "temperature": 0,
       "reasoning": "default",
       "dataset_categories": null,
@@ -106,7 +106,7 @@
     "requests_total": 111,
     "requests_ok": 111,
     "requests_failed": 0,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "duration_s": 53.992,
     "input_tokens_total": 12963,
     "output_tokens_total": 3112,
@@ -125,7 +125,7 @@
     "power_peak_w": 56.03,
     "energy_wh": 0.7131,
     "gpu_util_avg_pct": 91.61,
-    "temp_max_c": 74.0,
+    "temp_max_c": 74,
     "thermal_throttle_detected": false
   },
   "scores": {
@@ -133,7 +133,7 @@
     "total": 111,
     "correct": 92,
     "accuracy": 0.828829,
-    "success_rate": 1.0,
+    "success_rate": 1,
     "by_category": {
       "concepts": {
         "total": 19,
@@ -1325,7 +1325,7 @@
   },
   "provenance": {
     "github_login": "0xBakeer",
-    "github_user_id": null,
+    "github_user_id": 17404809,
     "started_at": "2026-09-10T00:37:27Z",
     "finished_at": "2026-09-10T00:38:21Z",
     "submitted_at": null,

--- a/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-security-v2--2039ec.json
+++ b/results/sglang/inclusionAI/Ling-3.0-flash/nvidia-gb10-dgx-spark/a9e5da49f0c2bba3--eval-security-v2--2039ec.json
@@ -1,0 +1,1343 @@
+{
+  "schema_version": 1,
+  "run_id": "a9e5da49f0c2bba3--eval-security-v2--2039ec",
+  "config_id": "a9e5da49f0c2bba3",
+  "cell_id": "4ab17fea2273",
+  "workload_id": "eval-security-v2",
+  "kind": "eval",
+  "engine": {
+    "id": "sglang",
+    "version": "0.0.0.dev1+g079d40460",
+    "commit": null,
+    "build": "github.com/inclusionAI/sglang@079d404",
+    "container": "lmsysorg/sglang:v0.0.0.dev1+g079d40460-cu126",
+    "install_method": "source"
+  },
+  "model": {
+    "id": "inclusionAI/Ling-3.0-flash",
+    "quant_id": "mxfp4",
+    "hf_id": "inclusionAI/Ling-3.0-flash",
+    "revision": null,
+    "dtype": "auto",
+    "local_path": null
+  },
+  "hardware": {
+    "id": "nvidia-gb10-dgx-spark",
+    "count": 1,
+    "driver": "580.173.02",
+    "cuda": "13.0",
+    "host": {
+      "cpu": "Cortex-A725",
+      "cpu_cores": 20,
+      "ram_gb": 121.6,
+      "os": "Ubuntu 24.04.4 LTS",
+      "kernel": "6.17.0-1029-nvidia",
+      "arch": "aarch64"
+    },
+    "fingerprint": "sha256:52ea2bdd513719724db88c162b6cc2c9fb4e5b67e02dbe41b9de00687acefb91",
+    "captured": {
+      "nvidia_smi": {
+        "driver": "580.173.02",
+        "cuda": "13.0",
+        "products": [
+          "NVIDIA GB10"
+        ],
+        "fb_memory_total_mib": 0.0
+      },
+      "lscpu": {
+        "architecture": "aarch64",
+        "cpus": "20",
+        "vendor_id": "ARM",
+        "model_name": "Cortex-A725",
+        "cores_per_socket": "10",
+        "sockets": "1",
+        "cpu_max_mhz": "2808.0000"
+      }
+    }
+  },
+  "args": {
+    "moe-runner-backend": "humming",
+    "speculative-algorithm": "DSPARK",
+    "speculative-draft-model-path": "inclusionAI/Ling-3.0-flash-dspark",
+    "enable-linear-replayssm-spec": true,
+    "linear-replayssm-cache-len": 32,
+    "mem-fraction-static": 0.75,
+    "max-running-requests": 1,
+    "max-mamba-cache-size": 64,
+    "chunked-prefill-size": 8192,
+    "max-prefill-tokens": 16384,
+    "page-size": 64,
+    "attention-backend": "flashinfer",
+    "fp8-gemm-backend": "cutlass",
+    "flashinfer-mxfp4-moe-precision": "default",
+    "disable-shared-experts-fusion": true,
+    "cuda-graph-backend-decode": "full",
+    "cuda-graph-max-bs-decode": 1,
+    "cuda-graph-backend-prefill": "disabled",
+    "reasoning-parser": "deepseek-r1",
+    "tool-call-parser": "qwen25",
+    "trust-remote-code": true,
+    "fp8-lm-head": "online",
+    "default-chat-template-kwargs": {
+      "enable_thinking": false
+    }
+  },
+  "args_canonical": "@build=github.com/inclusionai/sglang@079d404;@dtype=auto;@quant=mxfp4;attention-backend=flashinfer;chunked-prefill-size=8192;cuda-graph-backend-decode=full;cuda-graph-backend-prefill=disabled;cuda-graph-max-bs-decode=1;default-chat-template-kwargs={\"enable_thinking\":false};disable-shared-experts-fusion=true;enable-linear-replayssm-spec=true;fp8-gemm-backend=cutlass;fp8-lm-head=online;linear-replayssm-cache-len=32;max-mamba-cache-size=64;max-running-requests=1;mem-fraction-static=0.75;moe-runner-backend=humming;page-size=64;reasoning-parser=deepseek-r1;speculative-algorithm=DSPARK;speculative-draft-model-path=inclusionAI/Ling-3.0-flash-dspark;tool-call-parser=qwen25;trust-remote-code=true",
+  "serve_command": null,
+  "workload": {
+    "id": "eval-security-v2",
+    "resolved_params": {
+      "dataset_id": "eval-security-v2",
+      "suite": "security",
+      "scorer": "mc",
+      "items": 111,
+      "concurrency": 4,
+      "max_output_tokens": 4096,
+      "timeout_s": 300.0,
+      "temperature": 0,
+      "reasoning": "default",
+      "dataset_categories": null,
+      "dataset_target_tokens": null,
+      "pass_threshold": null,
+      "seed": 42
+    }
+  },
+  "metrics": {
+    "requests_total": 111,
+    "requests_ok": 111,
+    "requests_failed": 0,
+    "success_rate": 1.0,
+    "duration_s": 53.992,
+    "input_tokens_total": 12963,
+    "output_tokens_total": 3112,
+    "e2e_ms": {
+      "mean": 1929.432,
+      "p50": 1063.639,
+      "p90": 6060.253,
+      "p95": 6509.546,
+      "p99": 9126.241,
+      "min": 351.028,
+      "max": 9300.171
+    },
+    "vram_peak_gb": null,
+    "ram_peak_gb": 103.857,
+    "power_avg_w": 48.23,
+    "power_peak_w": 56.03,
+    "energy_wh": 0.7131,
+    "gpu_util_avg_pct": 91.61,
+    "temp_max_c": 74.0,
+    "thermal_throttle_detected": false
+  },
+  "scores": {
+    "suite": "security",
+    "total": 111,
+    "correct": 92,
+    "accuracy": 0.828829,
+    "success_rate": 1.0,
+    "by_category": {
+      "concepts": {
+        "total": 19,
+        "correct": 19
+      },
+      "crypto": {
+        "total": 21,
+        "correct": 8
+      },
+      "forensics": {
+        "total": 17,
+        "correct": 11
+      },
+      "incident_judgment": {
+        "total": 12,
+        "correct": 12
+      },
+      "network": {
+        "total": 22,
+        "correct": 22
+      },
+      "web_security": {
+        "total": 20,
+        "correct": 20
+      }
+    },
+    "by_difficulty": {
+      "easy": {
+        "total": 15,
+        "correct": 15
+      },
+      "hard": {
+        "total": 31,
+        "correct": 20
+      },
+      "medium": {
+        "total": 65,
+        "correct": 57
+      }
+    },
+    "avg_output_tokens": 28.04,
+    "avg_latency_ms": 1929.43,
+    "failures": 0,
+    "items": [
+      {
+        "id": "sec2-0001",
+        "correct": false,
+        "predicted": "sancqxo",
+        "expected": "sandbox",
+        "latency_ms": 351.028,
+        "output_tokens": 5,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0002",
+        "correct": false,
+        "predicted": "13",
+        "expected": "142",
+        "latency_ms": 633.645,
+        "output_tokens": 3,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0003",
+        "correct": true,
+        "predicted": "10.45.120.0",
+        "expected": "10.45.120.0",
+        "latency_ms": 907.779,
+        "output_tokens": 12,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0004",
+        "correct": false,
+        "predicted": "10",
+        "expected": "68",
+        "latency_ms": 1119.727,
+        "output_tokens": 3,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0005",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1042.112,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0006",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1001.293,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0007",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 998.982,
+        "output_tokens": 2,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0008",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1042.087,
+        "output_tokens": 2,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0009",
+        "correct": true,
+        "predicted": "10.25.55.255",
+        "expected": "10.25.55.255",
+        "latency_ms": 1116.821,
+        "output_tokens": 13,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0010",
+        "correct": true,
+        "predicted": "11",
+        "expected": "11",
+        "latency_ms": 6127.852,
+        "output_tokens": 589,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0011",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 6091.509,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0012",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 6107.883,
+        "output_tokens": 2,
+        "category": "incident_judgment",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0013",
+        "correct": true,
+        "predicted": "30",
+        "expected": "30",
+        "latency_ms": 5979.943,
+        "output_tokens": 3,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0014",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 989.314,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0015",
+        "correct": false,
+        "predicted": "A",
+        "expected": "D",
+        "latency_ms": 1077.957,
+        "output_tokens": 2,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0016",
+        "correct": true,
+        "predicted": "126",
+        "expected": "126",
+        "latency_ms": 1029.95,
+        "output_tokens": 4,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0017",
+        "correct": false,
+        "predicted": "jihgfedc",
+        "expected": "phishing",
+        "latency_ms": 1244.63,
+        "output_tokens": 6,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0018",
+        "correct": false,
+        "predicted": "10",
+        "expected": "230",
+        "latency_ms": 1184.319,
+        "output_tokens": 3,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0019",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1113.465,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0020",
+        "correct": false,
+        "predicted": "wxyzabcdef",
+        "expected": "firewall",
+        "latency_ms": 1166.467,
+        "output_tokens": 4,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0021",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 989.196,
+        "output_tokens": 2,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0022",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1055.366,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0023",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1030.995,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0024",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 999.792,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0025",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1014.165,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0026",
+        "correct": true,
+        "predicted": "02:37:04",
+        "expected": "02:37:04",
+        "latency_ms": 1184.777,
+        "output_tokens": 9,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0027",
+        "correct": false,
+        "predicted": "2群22-06-28 03:25:38",
+        "expected": "2022-06-28 14:45:38",
+        "latency_ms": 1574.599,
+        "output_tokens": 20,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0028",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1737.513,
+        "output_tokens": 2,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0029",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1731.826,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0030",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1557.267,
+        "output_tokens": 2,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0031",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1182.285,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0032",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1015.786,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0033",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1006.108,
+        "output_tokens": 2,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0034",
+        "correct": false,
+        "predicted": "2023-08-04 14:51:35",
+        "expected": "2023-08-04 10:51:35",
+        "latency_ms": 1371.038,
+        "output_tokens": 20,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0035",
+        "correct": true,
+        "predicted": "235",
+        "expected": "235",
+        "latency_ms": 6420.046,
+        "output_tokens": 606,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0036",
+        "correct": true,
+        "predicted": "02:38:57",
+        "expected": "02:38:57",
+        "latency_ms": 6618.123,
+        "output_tokens": 9,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0037",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 6599.046,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0038",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 6226.608,
+        "output_tokens": 2,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0039",
+        "correct": true,
+        "predicted": "28",
+        "expected": "28",
+        "latency_ms": 1147.411,
+        "output_tokens": 3,
+        "category": "concepts",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0040",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 930.584,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0041",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 939.785,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0042",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 939.653,
+        "output_tokens": 2,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0043",
+        "correct": false,
+        "predicted": "2023-09-13 12:20:36",
+        "expected": "2023-09-14 08:20:36",
+        "latency_ms": 1413.087,
+        "output_tokens": 20,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0044",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1429.582,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0045",
+        "correct": false,
+        "predicted": "11",
+        "expected": "118",
+        "latency_ms": 1387.383,
+        "output_tokens": 3,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0046",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1364.429,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0047",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 935.985,
+        "output_tokens": 2,
+        "category": "crypto",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0048",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 934.248,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0049",
+        "correct": false,
+        "predicted": "foolish",
+        "expected": "firewall",
+        "latency_ms": 1044.058,
+        "output_tokens": 4,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0050",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1040.402,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0051",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1040.842,
+        "output_tokens": 2,
+        "category": "incident_judgment",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0052",
+        "correct": true,
+        "predicted": "352",
+        "expected": "352",
+        "latency_ms": 1097.05,
+        "output_tokens": 4,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0053",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1038.851,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0054",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1060.255,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0055",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1063.639,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0056",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1002.51,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0057",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1000.587,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0058",
+        "correct": false,
+        "predicted": "wxyzab",
+        "expected": "cipher",
+        "latency_ms": 1095.412,
+        "output_tokens": 4,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0059",
+        "correct": true,
+        "predicted": "308915776",
+        "expected": "308915776",
+        "latency_ms": 1254.704,
+        "output_tokens": 12,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0060",
+        "correct": false,
+        "predicted": "C",
+        "expected": "A",
+        "latency_ms": 1343.813,
+        "output_tokens": 2,
+        "category": "forensics",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0061",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1355.021,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0062",
+        "correct": true,
+        "predicted": "1083",
+        "expected": "1083",
+        "latency_ms": 9300.171,
+        "output_tokens": 930,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0063",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 9133.135,
+        "output_tokens": 2,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0064",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 9064.195,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0065",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 9058.343,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0066",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1016.711,
+        "output_tokens": 2,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0067",
+        "correct": false,
+        "predicted": "magnetic",
+        "expected": "malware",
+        "latency_ms": 1026.291,
+        "output_tokens": 3,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0068",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1006.576,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0069",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 999.144,
+        "output_tokens": 2,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0070",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1000.476,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0071",
+        "correct": true,
+        "predicted": "7",
+        "expected": "7",
+        "latency_ms": 6028.55,
+        "output_tokens": 611,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0072",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 6054.166,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0073",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 6060.253,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0074",
+        "correct": true,
+        "predicted": "66",
+        "expected": "66",
+        "latency_ms": 6024.354,
+        "output_tokens": 3,
+        "category": "concepts",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0075",
+        "correct": true,
+        "predicted": "510",
+        "expected": "510",
+        "latency_ms": 995.474,
+        "output_tokens": 4,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0076",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 989.754,
+        "output_tokens": 2,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0077",
+        "correct": false,
+        "predicted": "hello",
+        "expected": "malware",
+        "latency_ms": 961.701,
+        "output_tokens": 2,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0078",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 974.135,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0079",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 934.452,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0080",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 947.173,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0081",
+        "correct": true,
+        "predicted": "105",
+        "expected": "105",
+        "latency_ms": 944.883,
+        "output_tokens": 4,
+        "category": "concepts",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0082",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 972.074,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0083",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1028.344,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0084",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 998.012,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0085",
+        "correct": true,
+        "predicted": "1022",
+        "expected": "1022",
+        "latency_ms": 1040.899,
+        "output_tokens": 5,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0086",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1018.483,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0087",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 962.575,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0088",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 950.105,
+        "output_tokens": 2,
+        "category": "network",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0089",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 923.546,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0090",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 956.951,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0091",
+        "correct": true,
+        "predicted": "10.169.14.0",
+        "expected": "10.169.14.0",
+        "latency_ms": 1028.528,
+        "output_tokens": 12,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0092",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1055.282,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0093",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1072.329,
+        "output_tokens": 2,
+        "category": "incident_judgment",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0094",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1074.742,
+        "output_tokens": 2,
+        "category": "incident_judgment",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0095",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1048.32,
+        "output_tokens": 2,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0096",
+        "correct": false,
+        "predicted": "9",
+        "expected": "8",
+        "latency_ms": 1182.346,
+        "output_tokens": 2,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0097",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1163.631,
+        "output_tokens": 2,
+        "category": "crypto",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0098",
+        "correct": false,
+        "predicted": "1680",
+        "expected": "1656",
+        "latency_ms": 1136.013,
+        "output_tokens": 5,
+        "category": "crypto",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0099",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1129.178,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0100",
+        "correct": true,
+        "predicted": "7",
+        "expected": "7",
+        "latency_ms": 1122.439,
+        "output_tokens": 2,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0101",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1120.917,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0102",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1118.83,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0103",
+        "correct": true,
+        "predicted": "10.7.189.255",
+        "expected": "10.7.189.255",
+        "latency_ms": 1146.193,
+        "output_tokens": 13,
+        "category": "network",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0104",
+        "correct": true,
+        "predicted": "10000",
+        "expected": "10000",
+        "latency_ms": 977.698,
+        "output_tokens": 6,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0105",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 991.598,
+        "output_tokens": 2,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0106",
+        "correct": true,
+        "predicted": "B",
+        "expected": "B",
+        "latency_ms": 1010.008,
+        "output_tokens": 2,
+        "category": "concepts",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0107",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1119.056,
+        "output_tokens": 2,
+        "category": "forensics",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0108",
+        "correct": true,
+        "predicted": "C",
+        "expected": "C",
+        "latency_ms": 1168.336,
+        "output_tokens": 2,
+        "category": "incident_judgment",
+        "difficulty": "easy"
+      },
+      {
+        "id": "sec2-0109",
+        "correct": true,
+        "predicted": "D",
+        "expected": "D",
+        "latency_ms": 1178.455,
+        "output_tokens": 2,
+        "category": "web_security",
+        "difficulty": "medium"
+      },
+      {
+        "id": "sec2-0110",
+        "correct": false,
+        "predicted": "bcdeefts",
+        "expected": "backdoor",
+        "latency_ms": 1298.797,
+        "output_tokens": 5,
+        "category": "crypto",
+        "difficulty": "hard"
+      },
+      {
+        "id": "sec2-0111",
+        "correct": true,
+        "predicted": "A",
+        "expected": "A",
+        "latency_ms": 1152.747,
+        "output_tokens": 2,
+        "category": "incident_judgment",
+        "difficulty": "medium"
+      }
+    ]
+  },
+  "failures": [],
+  "conditions": null,
+  "gotchas": [],
+  "derived": {
+    "cost_per_1m_output_tokens_usd": null,
+    "tokens_per_watt": null,
+    "tok_s_per_gb_bandwidth": null,
+    "bandwidth_efficiency": null,
+    "memory_headroom_gb": null
+  },
+  "raw": {
+    "harness": "atlas-bench",
+    "harness_version": "0.1.0",
+    "sha256": "c890e0f2e3b9c749882d02e5b05b7c253875f4971be90ba5d31132168cfe53be",
+    "payload_path": null,
+    "payload": {
+      "scorer": "mc",
+      "scorers_used": [
+        "exact",
+        "mc",
+        "numeric"
+      ],
+      "engine_endpoint": {
+        "attached": true,
+        "base_url": "http://127.0.0.1:8000/v1",
+        "served_model_id": "ling-3.0-flash",
+        "advertised_models": [
+          "ling-3.0-flash"
+        ]
+      }
+    },
+    "truncated": false
+  },
+  "provenance": {
+    "github_login": "0xBakeer",
+    "github_user_id": null,
+    "started_at": "2026-09-10T00:37:27Z",
+    "finished_at": "2026-09-10T00:38:21Z",
+    "submitted_at": null,
+    "commit": null,
+    "pr": null,
+    "method": "atlas-bench",
+    "agent": null,
+    "notes": "Served with the ling3-flash-dgx-spark recipe (49b6c9c), PROFILE=humming-dspark, thinking off (server default via --default-chat-template-kwargs): inclusionAI/Ling-3.0-flash-fp4 (MXFP4 routed experts, FP8 attention/shared/router) with --moe-runner-backend humming, online FP8 LM head (SGLANG_ENABLE_FP8_LM_HEAD=1), DSpark speculative decoding with inclusionAI/Ling-3.0-flash-dspark and the KDA ReplaySSM exact fold (--enable-linear-replayssm-spec, ring 32), context 262144 native (no YaRN), mem-fraction 0.75, max-running 1, page 64, decode cuda graph bs 1, prefill cuda graph disabled, FlashInfer autotune off with precompiled CUTLASS MXFP4 kernels. Single request at a time on every row."
+  },
+  "verification": {
+    "level": "self-reported",
+    "reproduced_by": [],
+    "flags": []
+  }
+}


### PR DESCRIPTION
The other half of #207: the same six v2 suites on the same server with thinking off, so the cost of the switch is measured rather than assumed. Everything else is identical — same weights, same flags, same box, same session; only `--default-chat-template-kwargs` differs.

| suite | thinking on (`a3b46e9e`) | thinking off (`a9e5da49`) | delta |
|---|---:|---:|---:|
| eval-knowledge-v2 | 1.000 | 1.000 | 0.0 |
| eval-science-v2 | 1.000 | 0.950 | −5.0 |
| eval-math-v2 | 0.993 | 0.821 | −17.2 |
| eval-security-v2 | 0.973 | 0.829 | −14.4 |
| eval-commonsense-v2 | 0.948 | 0.853 | −9.5 |
| eval-reasoning-v2 | 0.950 | 0.643 | **−30.7** |

The interesting part is how misleading the token counts are. This model spends very few tokens thinking — a couple of dozen on an arithmetic prompt — so thinking reads as nearly free and easy to switch off for throughput. It is not: `eval-reasoning-v2` loses thirty points. Only `eval-knowledge-v2`, pure recall, is unaffected, which is the shape you would expect if the reasoning tokens are doing real work rather than padding.

And on this stack thinking-on is also the *faster* config (`serve-single` 61.8 vs 50.6 tok/s), because the DSpark drafter predicts the model's own reasoning style better than it predicts terse answers. So the two axes agree: leave it on, which is the model's default anyway.

This completes a 2 × (7 speed + 6 eval) matrix for the MXFP4 pack on a single DGX Spark.

`validate.ts`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)